### PR TITLE
Save and load project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,7 @@ else (JACK_FOUND)
 endif (JACK_FOUND)
 
 # Boost
-find_package (Boost)
+find_package (Boost COMPONENTS system filesystem REQUIRED)
 if (Boost_FOUND)
     message(STATUS "Found boost headers version " ${Boost_VERSION})
 else (Boost_FOUND)
@@ -458,6 +458,8 @@ set(ExternLibraries
     ${FFTW3F_LIBRARIES}
     ${LIBCAIRO_LIBRARIES}
     ${Readline_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     ncurses
     z
     dl

--- a/src/LV2_Plugin/CMakeLists.txt
+++ b/src/LV2_Plugin/CMakeLists.txt
@@ -127,6 +127,8 @@ target_link_libraries(yoshimi_lv2
                       ${FFTW3F_LIBRARIES}
                       ${LIBCAIRO_LIBRARIES}
                       ${JACK_LIBRARIES}
+                      ${Boost_FILESYSTEM_LIBRARY}
+                      ${Boost_SYSTEM_LIBRARY}
                       z
                       dl
 )

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -307,155 +307,198 @@ mainCreateNewInstance(forceId);}
             xywh {0 0 31 21} labelsize 12
           }
           MenuItem {} {
+            label {&Load project...}
+            callback {//
+            
+                const char *filename;
+                filename = fl_dir_chooser("Load:", NULL, 0);
+                if (filename == NULL)
+                    return;
+				// pgm = -1 here because it's not from a bank
+				
+				size_t found;
+                string tmpStr(filename);
+                found = tmpStr.find_last_of("/\\\\");   // TODO Test on Windows, or just use Boost for this.
+				
+				// Instrument
+				int result = synth->SetProgramToPart(npart, -1, string(filename)+"/"+tmpStr.substr(found+1)+".xiz");
+                npartcounter->do_callback();
+                updatepanel();
+                if (result == 0)
+                    fl_alert("Failed to load instrument file");
+                else if (result == 3)
+                    fl_alert("Instrument is called 'Simple Sound', Yoshimi's basic sound name. You should change this if you wish to re-save.");
+                
+                // Patch Set
+                do_load_master(true, (string(filename)+"/"+tmpStr.substr(found+1)+".xmz").c_str());
+                
+                // Scales
+                string fname = string(filename)+"/"+tmpStr.substr(found+1)+".xsz";
+                do_load_scale(fname);
+                RecentScale->activate();
+                
+                // State
+                laststatefile = string(filename)+"/"+tmpStr.substr(found+1)+".state";
+                synth->getRuntime().loadState(laststatefile);
+                synth->addHistory(laststatefile, 4);
+                RecentState->activate();
+                unsigned int name_start = laststatefile.rfind("/");
+            	unsigned int name_end = laststatefile.rfind(".");
+            	setMasterLabel(laststatefile.substr(name_start + 1, name_end - name_start - 1));
+                refresh_master_ui();
+            }
+           
+            tooltip {Load a Yoshimi project from a folder containing the .x*z and .state files.} xywh {25 25 100 20} labelsize 12
+          }
+          MenuItem {} {
             label {&Save project...}
-            //callback {configui->Show();}
             callback {//
             
             const char *tmp = fl_dir_chooser("Save:", NULL, 0);
             if (tmp == NULL)
                 return;
             
-    bool valid = false;
-    for(int npart = 0; npart < NUM_MIDI_PARTS; npart ++)
-        if (synth->part[npart]->Pname != "Simple Sound")
-        {
-            valid = true;
-            npart = NUM_MIDI_PARTS;
-        }
-    if (valid){
-        const char *file = NULL;
-        const char *fname;
-        bool result = false;
-        if (file == NULL)
-        {
-            size_t found;
-            string tmpStr(tmp);
-            found = tmpStr.find_last_of("/\\\\");
-            
-            boost::filesystem::create_directories(tmp);
-            
-            char buf[FL_PATH_MAX];
-
-            // Instrument
-            for (unsigned int i = 0; i <= strlen(tmp); i++) {
-
-                if (i < strlen(tmp)) {
-                    buf[i] = tmp[i];
-                
-                } else {
-                    buf[i] = 0;
+            bool valid = false;
+            for(int npart = 0; npart < NUM_MIDI_PARTS; npart ++)
+                if (synth->part[npart]->Pname != "Simple Sound")
+                {
+                    valid = true;
+                    npart = NUM_MIDI_PARTS;
                 }
-            }
-            
-            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xiz").c_str());
-            if (isRegFile(string(buf)))
-                if (!fl_choice("The instrument (.xiz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
-                    return;
-            synth->actionLock(lockmute);
-            bool result = synth->part[npart]->saveXML(string(buf));
-            synth->actionLock(unlock);
-            if (!result)
-                fl_alert("Failed to save instrument file");
-            updatepanel();
-        
-            // Patch set
-            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+                if (valid){
+                    const char *file = NULL;
+                    const char *fname;
+                    bool result = false;
+                    if (file == NULL)
+                    {
+                        size_t found;
+                        string tmpStr(tmp);
+                        found = tmpStr.find_last_of("/\\\\");   // TODO Test on Windows, or just use Boost for this.
+                        
+                        boost::filesystem::create_directories(tmp);
+                        
+                        char buf[FL_PATH_MAX];
 
-                if (i < strlen(tmp)) {
-                    buf[i] = tmp[i];
-                
-                } else {
-                    buf[i] = 0;
-                }
-            }
-            
-            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xmz").c_str());
-            
-            fname = buf;
-            result = isRegFile(string(buf));
-            if (result)
-            {
-                result = false;
-                if (!fl_choice("The patch set (.xmz) file exists. Overwrite it?", "No", "Yes", NULL))
-                    return;
-            }
+                        // Instrument
+                        for (unsigned int i = 0; i <= strlen(tmp); i++) {
 
-            result = synth->saveXML(fname);
-            
-            if (!result)
-                fl_alert("Could not save the file.");
-            else
-            {
-                synth->addHistory(fname, 2);
-                RecentParams->activate();
-            }
-            updatepanel();
-            
-            // Scales
-            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+                            if (i < strlen(tmp)) {
+                                buf[i] = tmp[i];
+                            
+                            } else {
+                                buf[i] = 0;
+                            }
+                        }
+                        
+                        fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xiz").c_str());
+                        if (isRegFile(string(buf)))
+                            if (!fl_choice("The instrument (.xiz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                                return;
+                        synth->actionLock(lockmute);
+                        bool result = synth->part[npart]->saveXML(string(buf));
+                        synth->actionLock(unlock);
+                        if (!result)
+                            fl_alert("Failed to save instrument file");
+                        updatepanel();
+                    
+                        // Patch set
+                        for (unsigned int i = 0; i <= strlen(tmp); i++) {
 
-                if (i < strlen(tmp)) {
-                    buf[i] = tmp[i];
-                
-                } else {
-                    buf[i] = 0;
-                }
-            }
-            
-            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xsz").c_str());
-            if (isRegFile(string(buf)))
-                if (!fl_choice("The scale (.xsz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
-                    return;
-            synth->actionLock(lockmute);
-            result = synth->microtonal.saveXML(string(buf));
-            synth->actionLock(unlock);
-            if (!result)
-                fl_alert("Failed to save scale settings");
-            else
-            {
-                synth->addHistory(filename, 3);
-                RecentScale->activate();
-            }
-            updatepanel();
-            
-            
-            // State
-            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+                            if (i < strlen(tmp)) {
+                                buf[i] = tmp[i];
+                            
+                            } else {
+                                buf[i] = 0;
+                            }
+                        }
+                        
+                        fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xmz").c_str());
+                        
+                        fname = buf;
+                        result = isRegFile(string(buf));
+                        if (result)
+                        {
+                            result = false;
+                            if (!fl_choice("The patch set (.xmz) file exists. Overwrite it?", "No", "Yes", NULL))
+                                return;
+                        }
 
-                if (i < strlen(tmp)) {
-                    buf[i] = tmp[i];
-                
-                } else {
-                    buf[i] = 0;
-                }
-            }
-            
-            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".state").c_str());
-            if (isRegFile(string(buf)))
-                if (!fl_choice("The state (.state) file exists. \\nOverwrite it?", "No", "Yes", NULL))
-                    return;
-            laststatefile = string(buf);
-            synth->getRuntime().saveState(laststatefile);
-            synth->addHistory(laststatefile, 4);
-            RecentState->activate();
-        }
-        else {
-            fname = file;
-            result = synth->saveXML(fname);
-            
-            if (!result)
-                fl_alert("Could not save the file.");
-            else
-            {
-                synth->addHistory(fname, 2);
-                RecentParams->activate();
-            }
-            updatepanel();
-        }
-    }
-    }
+                        result = synth->saveXML(fname);
+                        
+                        if (!result)
+                            fl_alert("Could not save the file.");
+                        else
+                        {
+                            synth->addHistory(fname, 2);
+                            RecentParams->activate();
+                        }
+                        updatepanel();
+                        
+                        // Scales
+                        for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                            if (i < strlen(tmp)) {
+                                buf[i] = tmp[i];
+                            
+                            } else {
+                                buf[i] = 0;
+                            }
+                        }
+                        
+                        fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xsz").c_str());
+                        if (isRegFile(string(buf)))
+                            if (!fl_choice("The scale (.xsz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                                return;
+                        synth->actionLock(lockmute);
+                        result = synth->microtonal.saveXML(string(buf));
+                        synth->actionLock(unlock);
+                        if (!result)
+                            fl_alert("Failed to save scale settings");
+                        else
+                        {
+                            synth->addHistory(filename, 3);
+                            RecentScale->activate();
+                        }
+                        updatepanel();
+                        
+                        
+                        // State
+                        for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                            if (i < strlen(tmp)) {
+                                buf[i] = tmp[i];
+                            
+                            } else {
+                                buf[i] = 0;
+                            }
+                        }
+                        
+                        fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".state").c_str());
+                        if (isRegFile(string(buf)))
+                            if (!fl_choice("The state (.state) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                                return;
+                        laststatefile = string(buf);
+                        synth->getRuntime().saveState(laststatefile);
+                        synth->addHistory(laststatefile, 4);
+                        RecentState->activate();
+                    }
+                    else {
+                        fname = file;
+                        result = synth->saveXML(fname);
+                        
+                        if (!result)
+                            fl_alert("Could not save the file.");
+                        else
+                        {
+                            synth->addHistory(fname, 2);
+                            RecentParams->activate();
+                        }
+                        updatepanel();
+                    }
+              }
+          }
            
-            tooltip {Save your current Yoshimi project as an .xpz file} xywh {25 25 100 20} labelsize 12
+            tooltip {Save your current Yoshimi project as a folder containing the .x*z and .state files.} xywh {25 25 100 20} labelsize 12
           }
           MenuItem {} {
             label {S&ettings...}

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -34,6 +34,12 @@ This file is a derivative of the ZynAddSubFX original, modified October 2014
 decl {\#include <string>} {public local
 } 
 
+decl {\#include <boost/filesystem.hpp>} {public local
+}
+
+decl {\#include <FL/filename.H>} {public local
+} 
+
 decl {using namespace std;} {public local
 } 
 
@@ -301,7 +307,158 @@ mainCreateNewInstance(forceId);}
             xywh {0 0 31 21} labelsize 12
           }
           MenuItem {} {
-            label {&Settings...}
+            label {&Save project...}
+            //callback {configui->Show();}
+            callback {//
+            
+            const char *tmp = fl_dir_chooser("Save:", NULL, 0);
+            if (tmp == NULL)
+                return;
+            
+    bool valid = false;
+    for(int npart = 0; npart < NUM_MIDI_PARTS; npart ++)
+        if (synth->part[npart]->Pname != "Simple Sound")
+        {
+            valid = true;
+            npart = NUM_MIDI_PARTS;
+        }
+    if (valid){
+        const char *file = NULL;
+        const char *fname;
+        bool result = false;
+        if (file == NULL)
+        {
+            size_t found;
+            string tmpStr(tmp);
+            found = tmpStr.find_last_of("/\\\\");
+            
+            boost::filesystem::create_directories(tmp);
+            
+            char buf[FL_PATH_MAX];
+
+            // Instrument
+            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                if (i < strlen(tmp)) {
+                    buf[i] = tmp[i];
+                
+                } else {
+                    buf[i] = 0;
+                }
+            }
+            
+            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xiz").c_str());
+            if (isRegFile(string(buf)))
+                if (!fl_choice("The instrument (.xiz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                    return;
+            synth->actionLock(lockmute);
+            bool result = synth->part[npart]->saveXML(string(buf));
+            synth->actionLock(unlock);
+            if (!result)
+                fl_alert("Failed to save instrument file");
+            updatepanel();
+        
+            // Patch set
+            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                if (i < strlen(tmp)) {
+                    buf[i] = tmp[i];
+                
+                } else {
+                    buf[i] = 0;
+                }
+            }
+            
+            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xmz").c_str());
+            
+            fname = buf;
+            result = isRegFile(string(buf));
+            if (result)
+            {
+                result = false;
+                if (!fl_choice("The patch set (.xmz) file exists. Overwrite it?", "No", "Yes", NULL))
+                    return;
+            }
+
+            result = synth->saveXML(fname);
+            
+            if (!result)
+                fl_alert("Could not save the file.");
+            else
+            {
+                synth->addHistory(fname, 2);
+                RecentParams->activate();
+            }
+            updatepanel();
+            
+            // Scales
+            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                if (i < strlen(tmp)) {
+                    buf[i] = tmp[i];
+                
+                } else {
+                    buf[i] = 0;
+                }
+            }
+            
+            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".xsz").c_str());
+            if (isRegFile(string(buf)))
+                if (!fl_choice("The scale (.xsz) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                    return;
+            synth->actionLock(lockmute);
+            result = synth->microtonal.saveXML(string(buf));
+            synth->actionLock(unlock);
+            if (!result)
+                fl_alert("Failed to save scale settings");
+            else
+            {
+                synth->addHistory(filename, 3);
+                RecentScale->activate();
+            }
+            updatepanel();
+            
+            
+            // State
+            for (unsigned int i = 0; i <= strlen(tmp); i++) {
+
+                if (i < strlen(tmp)) {
+                    buf[i] = tmp[i];
+                
+                } else {
+                    buf[i] = 0;
+                }
+            }
+            
+            fl_filename_setext(buf, sizeof(buf), (string("/")+tmpStr.substr(found+1)+".state").c_str());
+            if (isRegFile(string(buf)))
+                if (!fl_choice("The state (.state) file exists. \\nOverwrite it?", "No", "Yes", NULL))
+                    return;
+            laststatefile = string(buf);
+            synth->getRuntime().saveState(laststatefile);
+            synth->addHistory(laststatefile, 4);
+            RecentState->activate();
+        }
+        else {
+            fname = file;
+            result = synth->saveXML(fname);
+            
+            if (!result)
+                fl_alert("Could not save the file.");
+            else
+            {
+                synth->addHistory(fname, 2);
+                RecentParams->activate();
+            }
+            updatepanel();
+        }
+    }
+    }
+           
+            tooltip {Save your current Yoshimi project as an .xpz file} xywh {25 25 100 20} labelsize 12
+          }
+          MenuItem {} {
+            label {S&ettings...}
             callback {configui->Show();}
             tooltip {View, change, save settings} xywh {25 25 100 20} labelsize 12
           }


### PR DESCRIPTION
I have added "Load project..." and "Save project..." menu options to the Yoshimi menu, because it takes too long to load and save the 4 different yoshimi files every time.

These new menu options open a directory chooser. 

To save your yoshimi project, you specify a folder, and it will save the 4 files into that folder, creating the folder if it doesn't exist.

To load your yoshimi project, you specify a folder which contains the 4 files, and it loads them.

The reason I implemented these features, is because I use Yoshimi LV2 plugin in Ardour, and I've noticed that the plugin doesn't save and restore the yoshimi settings. And anyway, it's nice to be able to save and load the 4 files (.xiz, .xmz, .xsz, and .state) in one go.

Feel free to modify the code I added as you see fit, but I would really like this feature in Yoshimi, regardless of how it's implemented. Note that it has introduced a dependency on Boost Filesystem library.

Let me know what you think of it, I've never worked with FLTK before.
