### PR TITLE
Add checkbutton to double range of filter frequency tracking

### DIFF
--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -27,7 +27,7 @@
 #include "Effects/DynamicFilter.h"
 
 DynamicFilter::DynamicFilter(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64, _synth), 0),
+    Effect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64, 0, _synth), 0),
     lfo(_synth),
     Pvolume(110),
     Pdepth(0),

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -4541,6 +4541,12 @@ void InterChange::filterReadWrite(CommandBlock *getData, FilterParams *pars, uns
             else
                 val = pars->Ptype;;
             break;
+        case 10:
+            if (write)
+                pars->Pdoublefreqtrack = (val != 0);
+            else
+                val = pars->Pdoublefreqtrack;
+            break;
 
         case 16:
             if (write)

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -50,7 +50,7 @@ ADnoteParameters::ADnoteParameters(FFTwrapper *fft_, SynthEngine *_synth) :
     GlobalPar.AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     GlobalPar.AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1, synth);
 
-    GlobalPar.GlobalFilter = new FilterParams(2, 94, 40, synth);
+    GlobalPar.GlobalFilter = new FilterParams(2, 94, 40, 0, synth);
     GlobalPar.FilterEnvelope = new EnvelopeParams(0, 1, synth);
     GlobalPar.FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     GlobalPar.FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2, synth);
@@ -189,7 +189,7 @@ void ADnoteParameters::enableVoice(int nvoice)
     VoicePar[nvoice].FreqEnvelope->ASRinit(30, 40, 64, 60);
     VoicePar[nvoice].FreqLfo = new LFOParams(50, 40, 0, 0, 0, 0, 0, 0, synth);
 
-    VoicePar[nvoice].VoiceFilter = new FilterParams(2, 50, 60, synth);
+    VoicePar[nvoice].VoiceFilter = new FilterParams(2, 50, 60, 0, synth);
     VoicePar[nvoice].FilterEnvelope = new EnvelopeParams(0, 0, synth);
     VoicePar[nvoice].FilterEnvelope->ADSRinit_filter(90, 70, 40, 70, 10, 40);
     VoicePar[nvoice].FilterLfo = new LFOParams(50, 20, 64, 0, 0, 0, 0, 2, synth);

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -30,12 +30,13 @@ using namespace std;
 #include "Misc/SynthEngine.h"
 #include "Params/FilterParams.h"
 
-FilterParams::FilterParams(unsigned char Ptype_, unsigned char Pfreq_, unsigned  char Pq_, SynthEngine *_synth) :
+FilterParams::FilterParams(unsigned char Ptype_, unsigned char Pfreq_, unsigned  char Pq_, unsigned char Pdoublefreqtrack_, SynthEngine *_synth) :
     Presets(_synth),
     changed(false),
     Dtype(Ptype_),
     Dfreq(Pfreq_),
-    Dq(Pq_)
+    Dq(Pq_),
+    Ddoublefreqtrack(Pdoublefreqtrack_)
 {
     setpresettype("Pfilter");
     defaults();
@@ -50,6 +51,7 @@ void FilterParams::defaults(void)
 
     Pstages = 0;
     Pfreqtrack = 64;
+    Pdoublefreqtrack = Ddoublefreqtrack;
     Pgain = 64;
     Pcategory = 0;
 
@@ -137,7 +139,11 @@ float FilterParams::getq(void)
 
 float FilterParams::getfreqtracking(float notefreq)
 {
-    return logf(notefreq / 440.0f) * (Pfreqtrack - 64.0f) / (64.0f * LOG_2);
+    if (Pdoublefreqtrack != 0) {
+        return logf(notefreq / 440.0f) * (Pfreqtrack - 64.0f) / (32.0f * LOG_2);
+    } else {
+        return logf(notefreq / 440.0f) * (Pfreqtrack - 64.0f) / (64.0f * LOG_2);
+    }
 }
 
 
@@ -278,6 +284,7 @@ void FilterParams::add2XML(XMLwrapper *xml)
     xml->addpar("q",Pq);
     xml->addpar("stages",Pstages);
     xml->addpar("freq_track",Pfreqtrack);
+    xml->addparbool("doublefreqtrack",Pdoublefreqtrack);
     xml->addpar("gain",Pgain);
 
     //formant filter parameters
@@ -336,6 +343,7 @@ void FilterParams::getfromXML(XMLwrapper *xml)
     Pq = xml->getpar127("q",Pq);
     Pstages = xml->getpar127("stages",Pstages);
     Pfreqtrack = xml->getpar127("freq_track",Pfreqtrack);
+    Pdoublefreqtrack = xml->getparbool("doublefreqtrack", Pdoublefreqtrack);
     Pgain = xml->getpar127("gain",Pgain);
 
     // formant filter parameters

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -139,9 +139,17 @@ float FilterParams::getq(void)
 
 float FilterParams::getfreqtracking(float notefreq)
 {
-    if (Pdoublefreqtrack != 0) {
-        return logf(notefreq / 440.0f) * (Pfreqtrack - 64.0f) / (32.0f * LOG_2);
-    } else {
+    if (Pdoublefreqtrack != 0)
+    {
+        // In this setting freq.tracking's range is: 0% to 198%
+        // 100% for value 64
+        return logf(notefreq / 440.0f) * Pfreqtrack / (64.0f * LOG_2);
+    }
+    else
+    {
+        // In this original setting freq.tracking's range is: -100% to +98%
+        // It does not reach up to 100% because the maximum value of
+        // Pfreqtrack is 127. Pfreqtrack==128 would give 100%
         return logf(notefreq / 440.0f) * (Pfreqtrack - 64.0f) / (64.0f * LOG_2);
     }
 }

--- a/src/Params/FilterParams.h
+++ b/src/Params/FilterParams.h
@@ -35,7 +35,7 @@ class SynthEngine;
 class FilterParams : public Presets, private MiscFuncs
 {
     public:
-        FilterParams(unsigned char Ptype_, unsigned char Pfreq, unsigned char Pq_, SynthEngine *_synth);
+        FilterParams(unsigned char Ptype_, unsigned char Pfreq, unsigned char Pq_, unsigned char Pdoublefreqtrack_, SynthEngine *_synth);
         ~FilterParams() { }
 
         void add2XML(XMLwrapper *xml);
@@ -73,6 +73,7 @@ class FilterParams : public Presets, private MiscFuncs
         unsigned char Pstages;    // filter stages+1
         unsigned char Pfreqtrack; // how the filter frequency is changing
                                   // according the note frequency
+        unsigned char Pdoublefreqtrack;  // double range for freq tracking
         unsigned char Pgain;      // filter's output gain
 
         // Formant filter parameters
@@ -107,6 +108,7 @@ class FilterParams : public Presets, private MiscFuncs
         unsigned char Dtype;
         unsigned char Dfreq;
         unsigned char Dq;
+        unsigned char Ddoublefreqtrack;
 };
 
 #endif

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -54,7 +54,7 @@ PADnoteParameters::PADnoteParameters(FFTwrapper *fft_, SynthEngine *_synth) : Pr
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1, synth);
 
-    GlobalFilter = new FilterParams(2, 94, 40, synth);
+    GlobalFilter = new FilterParams(2, 94, 40, 0, synth);
     FilterEnvelope = new EnvelopeParams(0, 1, synth);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2, synth);

--- a/src/Params/SUBnoteParameters.cpp
+++ b/src/Params/SUBnoteParameters.cpp
@@ -34,7 +34,7 @@ SUBnoteParameters::SUBnoteParameters(SynthEngine *_synth) : Presets(_synth)
     BandWidthEnvelope = new EnvelopeParams(64, 0, synth);
     BandWidthEnvelope->ASRinit_bw(100, 70, 64, 60);
 
-    GlobalFilter = new FilterParams(2, 80, 40, synth);
+    GlobalFilter = new FilterParams(2, 80, 40, 0, synth);
     GlobalFilterEnvelope = new EnvelopeParams(0, 1, synth);
     GlobalFilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     defaults();

--- a/src/UI/FilterUI.fl
+++ b/src/UI/FilterUI.fl
@@ -395,10 +395,10 @@ send_data(6, o->value(), 0xc0);}
         xywh {203 5 15 15} box THIN_UP_BOX color 179 labelfont 1 labelsize 10 labelcolor 7
       }
       Fl_Check_Button doublefreqtrack {
-        label x2
+        label {0/+}
         callback {pars->Pdoublefreqtrack=(int)o->value();
 send_data(10, o->value(), 0xc0);}
-        tooltip {Set frequency tracking range to 200%} xywh {244 20 15 15} down_box DOWN_BOX labelsize 10
+        tooltip {Set frequency tracking range to 0%-200%} xywh {244 20 15 15} down_box DOWN_BOX labelsize 9
       }
     }
   }

--- a/src/UI/FilterUI.fl
+++ b/src/UI/FilterUI.fl
@@ -394,6 +394,12 @@ send_data(6, o->value(), 0xc0);}
         callback {synth->getGuiMaster()->getPresetsUi()->paste(pars,this);}
         xywh {203 5 15 15} box THIN_UP_BOX color 179 labelfont 1 labelsize 10 labelcolor 7
       }
+      Fl_Check_Button doublefreqtrack {
+        label x2
+        callback {pars->Pdoublefreqtrack=(int)o->value();
+send_data(10, o->value(), 0xc0);}
+        tooltip {Set frequency tracking range to 200%} xywh {244 20 15 15} down_box DOWN_BOX labelsize 10
+      }
     }
   }
   Function {make_formant_window()} {} {
@@ -632,6 +638,7 @@ send_data(17, o->value(), 0xc8);}
 
         filtertype->value(pars->Pcategory);
         cfreqdial->value(pars->Pfreq);
+        doublefreqtrack->value(pars->Pdoublefreqtrack);
         qdial->value(pars->Pq);
         freqtrdial->value(pars->Pfreqtrack);
         gaindial->value(pars->Pgain);
@@ -745,6 +752,10 @@ collect_data(synth, value, (Fl::event_button() | type), control, npart, kititem,
     	case 9:
     	    svfiltertypechoice->value((int)value);
     	    break;
+
+        case 10:
+            doublefreqtrack->value(value != 0);
+            break;
 
     	case 16:
     	    frsldial->value(value);


### PR DESCRIPTION
This allows using values beyond 100% and the exact value of +100% which was not possible.

The PR adds a "x2" checkbox. Will's suggestion on the mailing list was "x1.5", but to me it seemed like  there's hardly enough space in the UI to name it "x1.5" and I thought, there are other synths that go up to 200%, so why not? However, if you don't like this range or anything else in this PR, I can change it.

Anyway, I'd be happy to hear comments.

![yoshimidft](https://cloud.githubusercontent.com/assets/2162327/20628014/023942ae-b324-11e6-9ee7-a7864d10c15b.png)
