### PR TITLE
Amplitude envelope tooltip fix + envelope freemode values

### DIFF
--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -201,7 +201,38 @@ if (time<1000.0)
     snprintf((char *)&tmpstr,20,"%.1fms",time);
 else
     snprintf((char *)&tmpstr,20,"%.2fs",time/1000.0);
-fl_draw(tmpstr,ox+lx-20,oy+ly-10,20,10,FL_ALIGN_RIGHT,NULL,0);} {}
+fl_draw(tmpstr,ox+lx-20,oy+ly-10,20,10,FL_ALIGN_RIGHT,NULL,0);
+
+//Draw formatted point value in the top right corner when dragging points
+if(currentpoint >= 0){
+
+  string valDesc;
+  float val = (float) env->Penvval[currentpoint];
+   switch(env->Envmode){
+     case 1: //linear amplitude
+     case 2: //db amplitude
+         if(env->Plinearenvelope)
+             valDesc=convert_value(VC_EnvelopeLinAmpSusVal, val);
+         else
+             valDesc=convert_value(VC_EnvelopeAmpSusVal, val);
+         break;
+     case 3: //frequency offset
+         valDesc=convert_value(VC_EnvelopeFreqVal, val);
+         break;
+     case 4: //filter frequency offset
+         valDesc=convert_value(VC_EnvelopeFilterVal, val);
+         break;
+     case 5: //bandwidth offset (unformatted)
+         valDesc=std::to_string((int)val - 64);
+         break;
+     default:
+         valDesc = "unknown env. type";
+   }
+
+   strcpy(tmpstr, valDesc.c_str());
+   fl_color(FL_CYAN);
+   fl_draw(tmpstr,ox+lx-20,oy,20,10,FL_ALIGN_RIGHT,NULL,0);
+}} {}
   }
   Function {handle(int event)} {return_type int
   } {
@@ -424,8 +455,7 @@ send_data(group, 35, o->value(), 0xc0);}
       }
     }
   }
-  Function {make_ADSR_window()} {selected
-  } {
+  Function {make_ADSR_window()} {} {
     Fl_Window envADSR {
       xywh {1185 87 205 70} type Double color 50 labelfont 1 hide
       class Fl_Group
@@ -504,7 +534,8 @@ send_data(group, 24, o->value(), 0xc0);}
         Fl_Check_Button e1linearenvelope {
           label L
           callback {env->Plinearenvelope=(int)o->value();
-send_data(group, 17, o->value(), 0xc0);}
+setAmpSusVType((int)o->value());
+send_data(group, 17, o->value(), 0xc0);} selected
           tooltip {The envelope is linear} xywh {180 20 15 15} down_box DOWN_BOX labelsize 10 align 4
           code0 {o->value(env->Plinearenvelope);}
         }
@@ -1130,6 +1161,7 @@ if (env->Pfreemode==0)
 		e1adt->value(env->PA_dt);
 		e1ddt->value(env->PD_dt);
 		e1sval->value(env->PS_val);
+		setAmpSusVType(env->Plinearenvelope);
 		e1rdt->value(env->PR_dt);
 		e1envstretch->value(env->Penvstretch);
 		e1linearenvelope->value(env->Plinearenvelope);
@@ -1206,6 +1238,14 @@ else
 envwindow->resize(this->x(),this->y(),this->w(),this->h());
 
 envwindow->show();} {}
+  }
+  Function {setAmpSusVType(bool linear)} {return_type void
+  } {
+    code {//
+if(linear)
+    e1sval->setValueType(VC_EnvelopeLinAmpSusVal);
+else
+    e1sval->setValueType(VC_EnvelopeAmpSusVal);} {}
   }
   decl {EnvelopeParams *env;} {private local
   }

--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -223,7 +223,7 @@ if(currentpoint >= 0){
          valDesc=convert_value(VC_EnvelopeFilterVal, val);
          break;
      case 5: //bandwidth offset (unformatted)
-         valDesc=std::to_string((int)val - 64);
+         valDesc=convert_value(VC_EnvelopeBandwidthVal, val);
          break;
      default:
          valDesc = "unknown env. type";
@@ -766,9 +766,10 @@ send_data(group, 24, o->value(), 0xc0);}
           callback {env->PA_val=(int)o->value();
 freeedit->redraw();
 send_data(group, 0, o->value(), 0xc8);}
-          tooltip {Starting value} xywh {5 20 30 30} box ROUND_UP_BOX labelsize 10 maximum 127 step 1
+          tooltip {Bandwidth multiplier, start} xywh {5 20 30 30} box ROUND_UP_BOX labelsize 10 maximum 127 step 1
           code0 {o->value(env->PA_val);}
           code1 {o->init(100);}
+          code2 {o->setValueType(VC_EnvelopeBandwidthVal);}
           class WidgetPDial
         }
         Fl_Dial e4adt {
@@ -787,9 +788,10 @@ send_data(group, 1, o->value(), 0xc8);}
           callback {env->PR_val=(int)o->value();
 freeedit->redraw();
 send_data(group, 6, o->value(), 0xc8);}
-          tooltip {Release value} xywh {110 20 30 30} box ROUND_UP_BOX labelsize 10 maximum 127 step 1
+          tooltip {Bandwidth multiplier, release} xywh {110 20 30 30} box ROUND_UP_BOX labelsize 10 maximum 127 step 1
           code0 {o->value(env->PR_val);}
           code1 {o->init(64);}
+          code2 {o->setValueType(VC_EnvelopeBandwidthVal);}
           class WidgetPDial
         }
         Fl_Dial e4rdt {

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -507,6 +507,17 @@ string convert_value(ValueType type, float val)
             else
                return(custom_value_units(f, "dB", 1));
 
+        case VC_EnvelopeBandwidthVal:
+	    f = powf(2.0f, 10.0f * ((int)val - 64) / 64.0f);
+            if(f > 100)
+                return(custom_value_units(f, "x", 1));
+            else if(f > 10)
+                return(custom_value_units(f, "x", 2));
+            else if(f > 0.01)
+                return(custom_value_units(f, "x", 3));
+            else
+                return(custom_value_units(f, "x", 4));
+
         case VC_FilterFreq0: // AnalogFilter
             f=powf(2.0f, (val / 64.0f - 1.0f) * 5.0f + 9.96578428f);
             if (f < 100.0f)

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -500,6 +500,13 @@ string convert_value(ValueType type, float val)
             return(custom_value_units((1.0f - (int)val / 127.0f)
                                       * MIN_ENVELOPE_DB, "dB", 1));
 
+        case VC_EnvelopeLinAmpSusVal:
+            f = 20.0f * log10f((int)val / 127.0f);
+            if(f > -10)
+               return(custom_value_units(f, "dB", 2));
+            else
+               return(custom_value_units(f, "dB", 1));
+
         case VC_FilterFreq0: // AnalogFilter
             f=powf(2.0f, (val / 64.0f - 1.0f) * 5.0f + 9.96578428f);
             if (f < 100.0f)

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -43,6 +43,7 @@ enum ValueType {
     VC_EnvelopeFilterVal,
     VC_EnvelopeAmpSusVal,
     VC_EnvelopeLinAmpSusVal,
+    VC_EnvelopeBandwidthVal,
     VC_FilterFreq0,
     VC_FilterFreq1,
     VC_FilterFreq2,

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -42,6 +42,7 @@ enum ValueType {
     VC_EnvelopeFreqVal,
     VC_EnvelopeFilterVal,
     VC_EnvelopeAmpSusVal,
+    VC_EnvelopeLinAmpSusVal,
     VC_FilterFreq0,
     VC_FilterFreq1,
     VC_FilterFreq2,


### PR DESCRIPTION
Amended conversion function to show the correct amplitude values (sustain volume) when linear interpolation is enabled.

Added conditional drawing of envelope point values in the freemode editor. Shows formatted values in the top right corner when dragging a point.
