### PR TITLE
Dynamic tooltip delay behaviour

### DIFF
--- a/src/UI/DynamicTooltip.h
+++ b/src/UI/DynamicTooltip.h
@@ -41,7 +41,7 @@ class DynTooltip : private Fl_Menu_Window {
 
  public:
   DynTooltip();
-
+  ~DynTooltip();
   void setValue(float);
   void setValueType(ValueType vt);
   void setGraphicsType(ValueType gv_);
@@ -49,10 +49,12 @@ class DynTooltip : private Fl_Menu_Window {
   void setOnlyValue(bool onlyval);
 
   void hide();
-  void show();
+  void show(float timeout=0);
 
   void setOffset(int x, int y);
   void draw();
+
+  void tipHandle(int event);
 
  private:
   void reposition();
@@ -74,32 +76,8 @@ class DynTooltip : private Fl_Menu_Window {
 
   /* relative tooltip position */
   int xoffs, yoffs;
+
+  //  static bool _recent;
 };
-
-/*
-  Interface to allow for shared behaviour when handling
-  events of dynamic tooltips.
-*/
-class DynTipped {
- public:
-
-  /* Set whether tooltip is visible or not */
-  virtual void tipShow(bool) = 0;
-
-  /* Set whether or not to show only value, or description + value */
-  virtual void tipOnlyValue(bool) = 0;
-
-  /* Set ValueType used to format the value */
-  virtual void setValueType(ValueType vt) = 0;
-
-  /* Set the type for supplementary graphics, when applicable */
-  virtual void setGraphicsType(ValueType vt) = 0;
-};
-
-
-/*
-  Standard behaviour for showing/hiding/switching dynamic tooltips
-*/
-void stdDynTipHandle(DynTipped*,int event);
 
 #endif

--- a/src/UI/WidgetMWSlider.cpp
+++ b/src/UI/WidgetMWSlider.cpp
@@ -46,19 +46,6 @@ mwheel_val_slider::~mwheel_val_slider()
 
 /* Support for the dynamic tooltip interface */
 
-void mwheel_val_slider::tipShow(bool show)
-{
-    if(show)
-        dyntip->show();
-    else
-        dyntip->hide();
-}
-
-void mwheel_val_slider::tipOnlyValue(bool ov)
-{
-    dyntip->setOnlyValue(ov);
-}
-
 void mwheel_val_slider::setValueType(ValueType vt)
 {
     dyntip->setValueType(vt);
@@ -148,7 +135,7 @@ int mwheel_val_slider::_handle(int res, int event)
     if(customTip)
     {
         dyntip->setValue(value());
-        stdDynTipHandle(this, event);
+        dyntip->tipHandle(event);
     }
 
     return res;

--- a/src/UI/WidgetMWSlider.h
+++ b/src/UI/WidgetMWSlider.h
@@ -28,7 +28,7 @@
 #include <FL/Fl_Value_Slider.H>
 #include "UI/DynamicTooltip.h"
 
-class mwheel_val_slider : public Fl_Value_Slider, public DynTipped {
+class mwheel_val_slider : public Fl_Value_Slider {
  public:
   mwheel_val_slider(int x, int y, int w, int h, const char *l=0) ;
   ~mwheel_val_slider();
@@ -36,8 +36,6 @@ class mwheel_val_slider : public Fl_Value_Slider, public DynTipped {
   void useCustomTip(bool);
 
   /* DynTipped methods */
-  void tipShow(bool);
-  void tipOnlyValue(bool);
   void setValueType(ValueType vt);
   void setGraphicsType(ValueType vt);
 

--- a/src/UI/WidgetPDial.cpp
+++ b/src/UI/WidgetPDial.cpp
@@ -52,19 +52,6 @@ void WidgetPDial::init(float home_ )
     home = home_;
 }
 
-void WidgetPDial::tipShow(bool show)
-{
-    if(show)
-        dyntip->show();
-    else
-        dyntip->hide();
-}
-
-void WidgetPDial::tipOnlyValue(bool ov)
-{
-    dyntip->setOnlyValue(ov);
-}
-
 void WidgetPDial::setValueType(ValueType type_)
 {
     dyntip->setValueType(type_);
@@ -174,7 +161,7 @@ int WidgetPDial::handle(int event)
     }
 
     dyntip->setValue(value());
-    stdDynTipHandle(this, event);
+    dyntip->tipHandle(event);
     return res;
 }
 

--- a/src/UI/WidgetPDial.h
+++ b/src/UI/WidgetPDial.h
@@ -38,15 +38,13 @@
   Dial widget with custom drawing and input handling.
   Supports dynamic tooltips and adjustable default values.
 */
-class WidgetPDial : public Fl_Dial, public DynTipped {
+class WidgetPDial : public Fl_Dial {
  public:
   WidgetPDial(int x,int y, int w, int h, const char *label=0);
   ~WidgetPDial();
 
   void init(float home_ = -1); /*Set optional default value */
 
-  void tipShow(bool);
-  void tipOnlyValue(bool);
   void setValueType(ValueType type_);
   void setGraphicsType(ValueType type_);
 


### PR DESCRIPTION
Adds delay mechanism to dynamic tooltips reflecting that of regular ones. This fixes the (slightly annoying) flickering of tooltips when moving the cursor across multiple controls.

New behaviour:
When hovering, wait for a set amount of time until the tip is shown, delay time depending on whether another tooltip was shown recently. However, show the (formatted) tooltip immediately when changing the value (i.e, pressing, dragging, using the mousewheel).

The conditional delay mechanism does not work between regular and dynamic tooltips, meaning that a regular tooltip having been shown does not affect the delay time for a dynamic tooltip, and vice versa.

It's possible that this patch should wait until after the release, although it technically doesn't add or remove any features.