### PR TITLE
Menu bar fixes, visual and functional

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,11 @@
 yoshimi 1.5.1 rc3
 
+2017-3-22 Jesper
+* Master window: Added subclassed Fl_Menu_Bar which only draws the bottom border.
+  Now it is not necessary to use negative coordinates to hide the edges.
+* VUMeter no longer swallows all shortcut/keyboard events.
+* Added missing hotkeys/mnemonics and fixed conflicting ones.
+
 2017-3-21 Will
 * Added correction for startup part connection status from Rob.
 * Set master as 1.5.1 rc3

--- a/src/UI/MasterMiscUI.fl
+++ b/src/UI/MasterMiscUI.fl
@@ -89,6 +89,12 @@ decl {\#include "Misc/SynthEngine.h"} {public local
 decl {\#include "Misc/MiscFuncs.h"} {public local
 }
 
+decl {\#include <FL/Fl_Menu_Bar.H>} {public global
+}
+
+decl {\#include <FL/fl_draw.H>} {private global
+}
+
 decl {\#define MIN_DB -48.0} {public local
 }
 
@@ -317,10 +323,10 @@ class VUMeter {: {public Fl_Box, private MiscFuncs}
     {
         case FL_SHOW:
             tick(this);
-            break;
+            return 1;
         case FL_HIDE:
             Fl::remove_timeout(tick, this);
-            break;
+            return 1;
         case FL_PUSH:
             if (npart < 0)
             {
@@ -331,9 +337,9 @@ class VUMeter {: {public Fl_Box, private MiscFuncs}
                	if(masterUI)
                     masterUI->resetPartsClip();
             }
-            break;
+            return 1;
     }
-    return 1;} {}
+    return 0;} {}
   }
   decl {int npart;} {private local
   }
@@ -659,5 +665,27 @@ Right mouse button: Instrument edit} xywh {12 247 40 20} box PLASTIC_UP_BOX labe
   decl {SynthEngine *synth;} {private local
   }
   decl {int *plgroup;} {public local
+  }
+}
+
+class ClearMenuBar {: {public Fl_Menu_Bar}
+} {
+  Function {ClearMenuBar(int x, int y, int w, int h) : Fl_Menu_Bar(x,y,w,h)} {
+    comment {Menu bar drawing only the bottom border}
+  } {
+    code {} {}
+  }
+  Function {draw()} {return_type void
+  } {
+    code {//
+    int m = 10; //margin larger than border in any style
+    fl_push_clip(x(),y(),w(),h());
+    fl_draw_box(box(), x() - m, y() - m, w() + 2 * m, h() + m, color());
+    fl_pop_clip();
+    Fl_Boxtype _box = box();
+    //Draw menu like normal, but without a box
+    box(FL_NO_BOX);
+    Fl_Menu_Bar::draw();
+    box(_box);} {}
   }
 }

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -280,10 +280,11 @@ class MasterUI {selected : {private MiscFuncs}
         xywh {279 28 103 85} box ENGRAVED_FRAME
       }
       Fl_Menu_Bar mastermenu {
-        xywh {-11 0 405 25} labelsize 12 textsize 12
+        xywh {0 0 385 25} labelsize 12 textsize 12
+        class ClearMenuBar
       } {
         Submenu {} {
-          label { &Yoshimi}
+          label {&Yoshimi}
           xywh {0 0 96 20} labelsize 12
         } {
           MenuItem {} {
@@ -297,7 +298,7 @@ class MasterUI {selected : {private MiscFuncs}
             xywh {0 0 100 20} labelsize 12
           }
           MenuItem newinstanceid {
-            label {New instance with id...}
+            label {New instance with &id...}
             callback {if(synth->getIsLV2Plugin())
 {
 	return;
@@ -334,7 +335,7 @@ mainCreateNewInstance(forceId);}
           xywh {0 0 100 20} labelsize 12
         } {
           MenuItem {} {
-            label {&Show Stored...}
+            label {S&how Stored...}
             callback {bankui->Show();}
             xywh {20 20 100 20} labelsize 12
           }
@@ -387,7 +388,7 @@ mainCreateNewInstance(forceId);}
           code2 {if (listType.size() == 0) RecentParams->deactivate(); else RecentParams->activate();}
         } {
           MenuItem {} {
-            label {&Show Patch Banks...}
+            label {S&how Patch Banks...}
             callback {bankui->bankuiwindow->show();}
             xywh {30 30 100 20} labelsize 12
           }
@@ -443,7 +444,7 @@ paramsui->Show(2);}
           code2 {if (listType.size() == 0) RecentScale->deactivate(); else RecentScale->activate();}
         } {
           MenuItem {} {
-            label {&Show Settings...}
+            label {S&how Settings...}
             callback {microtonalui->Show();}
             xywh {20 20 100 20} labelsize 12
           }
@@ -514,7 +515,7 @@ paramsui->Show(3);}
           code2 {if (listType.size() == 0) RecentState->deactivate(); else RecentState->activate();}
         } {
           MenuItem loadState {
-            label {Load...}
+            label {&Load...}
             callback {// for Alessandro
     char *fle = fl_file_chooser("Load:", "({*.state})", laststatefile.c_str(), 0);
     if (fle)
@@ -532,7 +533,7 @@ paramsui->Show(3);}
             tooltip {Load session state} xywh {0 0 34 21} labelsize 12
           }
           MenuItem saveState {
-            label {Save...}
+            label {&Save...}
             callback {// for Alessandro
 
                 char *fle = fl_file_chooser("Save:", "({*.state})",


### PR DESCRIPTION
Details in message/changelog. This approach fixes the first submenu being drawn to the left of the window when selected. To draw the top border as well as bottom, just remove the offsets from the y,h parameters in the draw_box call.