### PR TITLE
Formant filter UI: graphical editing + tooltips [FIXED]

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,17 @@
 yoshimi 1.5.2 M
 
+2017-7-25 Jesper
+* Bugfix: Fixed segfault from edge cases when float->int
+  conversion was very close to zero in formant filter
+  transition calculations.
+* New formant filter editing tools - visual parameter
+  manipulation on the frequency graph, primarily
+  mouse-driven.
+* New tooltips for the formant filter control knobs and
+  amended related tooltips in filter envelopes/LFO's
+  to show the differences between formant filters and
+  the other types.
+
 2017-7-24 Will
 * Started refining loads and saves (state first).
 

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -97,7 +97,7 @@ void FormantFilter::setpos(float input)
 {
     int p1, p2;
 
-    if (firsttime != 0)
+    if (firsttime)
         slowinput = input;
     else
         slowinput = slowinput * (1.0f - formantslowness) + input * formantslowness;
@@ -111,26 +111,23 @@ void FormantFilter::setpos(float input)
     } else
         oldinput = input;
 
-    float pos = fmodf(input * sequencestretch, 1.0f);
-    if (pos < 0.0f)
-        pos += 1.0f;
+    float pos = input * sequencestretch;
+    pos -= floorf(pos);
 
-    p2 = float2int(pos * sequencesize);
+    p2 = (int)(pos * sequencesize);
     p1 = p2 - 1;
     if (p1 < 0)
         p1 += sequencesize;
 
-    pos = fmodf(pos * sequencesize, 1.0f);
-    if (pos < 0.0f)
-        pos = 0.0f;
-    else if (pos > 1.0f)
-        pos = 1.0f;
+    pos = pos * sequencesize;
+    pos -= floorf(pos);
+
     pos = (atanf((pos * 2.0f - 1.0f) * vowelclearness) / atanf(vowelclearness) + 1.0f) * 0.5f;
 
     p1 = sequence[p1].nvowel;
     p2 = sequence[p2].nvowel;
 
-    if (firsttime != 0)
+    if (firsttime)
     {
         for (int i = 0; i < numformants; ++i)
         {

--- a/src/DSP/FormantFilter.h
+++ b/src/DSP/FormantFilter.h
@@ -26,7 +26,6 @@
 #define FORMANT_FILTER_H
 
 #include "Misc/MiscFuncs.h"
-#include "Misc/Float2Int.h"
 #include "Misc/SynthHelper.h"
 #include "DSP/Filter_.h"
 #include "DSP/AnalogFilter.h"
@@ -34,7 +33,7 @@
 
 class SynthEngine;
 
-class FormantFilter : public Filter_, private MiscFuncs, private SynthHelper, private Float2Int
+class FormantFilter : public Filter_, private MiscFuncs, private SynthHelper
 {
     public:
         FormantFilter(FilterParams *pars, SynthEngine *_synth);

--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -196,11 +196,11 @@ else
    fl_color(255,0,0);
    time=env->getdt(currentpoint);
 };
-char tmpstr[20];
+char tmpstr[40];
 if (time<1000.0)
-    snprintf((char *)&tmpstr,20,"%.1fms",time);
+    snprintf((char *)&tmpstr,40,"%.1fms",time);
 else
-    snprintf((char *)&tmpstr,20,"%.2fs",time/1000.0);
+    snprintf((char *)&tmpstr,40,"%.2fs",time/1000.0);
 fl_draw(tmpstr,ox+lx-20,oy+ly-10,20,10,FL_ALIGN_RIGHT,NULL,0);
 
 //Draw formatted point value in the top right corner when dragging points
@@ -231,7 +231,7 @@ if(currentpoint >= 0){
 
    strcpy(tmpstr, valDesc.c_str());
    fl_color(FL_CYAN);
-   fl_draw(tmpstr,ox+lx-20,oy,20,10,FL_ALIGN_RIGHT,NULL,0);
+   fl_draw(tmpstr,ox+lx-30,oy,30,25,FL_ALIGN_RIGHT,NULL,0);
 }} {}
   }
   Function {handle(int event)} {return_type int

--- a/src/UI/FilterUI.fl
+++ b/src/UI/FilterUI.fl
@@ -62,26 +62,31 @@ decl {\#include "Params/FilterParams.h"} {public local
 decl {\#include "Misc/MiscFuncs.h"} {public local
 }
 
+decl {\#include <FL/Fl.H>} {private global
+}
+
+decl {\#include <FL/names.h>} {private global
+}
+
 decl {\#include "MasterUI.h"} {private global
 }
 
 decl {\#include "Misc/SynthEngine.h"} {public global
 }
 
+decl {class FilterUI;} {public global
+}
+
 class FormantFilterGraph {: {public Fl_Box, MiscFuncs}
 } {
-  Function {FormantFilterGraph(int x,int y, int w, int h, const char *label=0):Fl_Box(x,y,w,h,label)} {} {
-    code {pars = NULL;
-        nvowel = NULL;
-        nformant = NULL;
-        graphpoints = NULL;} {}
-  }
-  Function {init(FilterParams *pars_,int *nvowel_,int *nformant_)} {} {
-    code {pars = pars_;
-        nvowel = nvowel_;
-        nformant = nformant_;
-        oldx = -1;
-        graphpoints = new float [w()];} {}
+  Function {FormantFilterGraph(int x, int y, int w, int h, FilterUI& parent_,
+            FilterParams *pars_, int *nvowel_, int *nformant_):
+      Fl_Box(x,y,w,h), parent(parent_), pars(pars_), nvowel(nvowel_), nformant(nformant_)} {}
+  {code {//
+        selectedFormant = -1;
+        hoverFormant = -1;
+        qMode = false;
+        graphpoints = new float [w];} {}
   }
   Function {draw_freq_line(float freq,int type)} {} {
     code {float freqx = pars->getfreqpos(freq);
@@ -111,9 +116,7 @@ class FormantFilterGraph {: {public Fl_Box, MiscFuncs}
 
         //draw the lines
         fl_color(FL_GRAY);
-
         fl_line_style(FL_SOLID);
-        //fl_line(ox+2,oy+ly/2,ox+lx-2,oy+ly/2);
 
         freqx = pars->getfreqpos(1000.0);
         if (freqx > 0.0 && freqx < 1.0)
@@ -168,6 +171,12 @@ class FormantFilterGraph {: {public Fl_Box, MiscFuncs}
             fl_draw(tmpstr.c_str(), ox + 1, oy + 15, 40, 12, FL_ALIGN_LEFT, NULL, 0);
         }
 
+        if(hoverFormant >= 0 && hoverFormant != *nformant)
+        {
+            fl_color(fl_darker(FL_YELLOW));
+            draw_freq_line(pars->getformantfreq(pars->Pvowels[*nvowel].formants[hoverFormant].freq), 0);
+        }
+
         // draw the data
         fl_color(FL_RED);
         fl_line_style(FL_SOLID);
@@ -186,13 +195,167 @@ class FormantFilterGraph {: {public Fl_Box, MiscFuncs}
   Function {~FormantFilterGraph()} {} {
     code {delete [] graphpoints;} {}
   }
+  decl {FilterUI& parent;} {private local
+  }
   decl {FilterParams *pars;} {private local
   }
-  decl {int oldx,oldy;} {private local
-  }
-  decl {int *nvowel,*nformant;} {private local
+  decl {int const *nvowel, *nformant;} {private local
   }
   decl {float *graphpoints;} {private local
+  }
+  decl {int selectedFormant, hoverFormant, yRef, xRef, qRef, ampRef, freqRef, cFreqRef;} {private local
+  }
+  decl {bool qMode;} {private local
+  }
+  Function {handle(int event)} {return_type int
+  } {
+    code {//
+
+switch(event)
+{
+  case FL_ENTER: // enable keyboard and drag events
+      Fl::focus(this);
+      Fl::belowmouse(this);
+      fl_cursor(FL_CURSOR_HAND);
+      return 1;
+  case FL_MOVE: // find formant closest to cursor
+  {
+      int minDiff = INT_MAX;
+      int relPos = (int)(127.0f * ((float) Fl::event_x() / w()));
+      for(int i = 0; i < pars->Pnumformants; ++i)
+      {
+          int diff = abs(pars->Pvowels[*nvowel].formants[i].freq - relPos);
+          if(diff < minDiff)
+          {
+              minDiff = diff;
+              hoverFormant = i;
+          }
+      }
+      redraw();
+      return 1;
+  }
+  case FL_PUSH:
+      if(Fl::event_key() > FL_Button + FL_RIGHT_MOUSE)
+      {
+          handle(FL_KEYDOWN); // Non-LMB/MMB/RMB button - check for forward/backward
+          return 0;
+      }
+
+      Fl::pushed(this);
+
+       // select formant closest to cursor
+      if(selectedFormant < 0 && Fl::event_button() != FL_MIDDLE_MOUSE)
+      {
+          selectedFormant = hoverFormant;
+          delegate(parent.formantnumber, hoverFormant);
+          hoverFormant = -1;
+      }
+
+      //Activate w. RMB, retain state when using MMB
+      qMode = Fl::event_button() == FL_RIGHT_MOUSE
+          || (Fl::event_button() == FL_MIDDLE_MOUSE && qMode);
+
+      update_refs();
+
+      return 1;
+  case FL_DRAG: // change frequency/amplitude/q for selected formant
+  {
+
+      int hDiff = 127 * (xRef - Fl::event_x()) / w();
+      int vDiff = 127 * (yRef - Fl::event_y()) / h();
+
+      if(Fl::event_button2()) // Always prioritize center frequency changes
+      {
+          fl_cursor(FL_CURSOR_WE);
+          delegate(parent.cfknob, limit(cFreqRef + hDiff, 0, 127));
+      }
+      else
+      {
+         fl_cursor(FL_CURSOR_MOVE);  
+          delegate(parent.formant_freq_dial, limit(freqRef - hDiff, 0, 127));
+
+          if(qMode)
+              delegate(parent.formant_q_dial, limit(qRef + vDiff, 0, 127));
+          else
+              delegate(parent.formant_amp_dial, limit(ampRef + vDiff, 0, 127));
+      }
+      return 1;
+  }
+  case FL_KEYDOWN: // changes active vowel with left/right , x/z, or forward/back mouse buttons
+
+      if(Fl::event_key(FL_Left) || Fl::event_key(122) || Fl::event_key() == FL_Button + 8)
+      {
+          delegate(parent.vowelnumber, (FF_MAX_VOWELS + ((*nvowel) - 1)) % FF_MAX_VOWELS);
+          hoverFormant = -1;
+      }
+      else if(Fl::event_key(FL_Right) || Fl::event_key(120) || Fl::event_key() == FL_Button + 9)
+      {
+          delegate(parent.vowelnumber, ((*nvowel) + 1) % FF_MAX_VOWELS);
+          hoverFormant = -1;
+      }
+      return 1;
+  case FL_MOUSEWHEEL:
+  {
+      int offset = Fl::event_dy() * (Fl::event_ctrl() ? 1 : 4);
+      if(Fl::event_shift())
+          delegate(parent.cfknob, limit(pars->Pcenterfreq + offset, 0, 127));
+      else
+          delegate(parent.octknob, limit(pars->Poctavesfreq + offset, 0, 127));
+      return 1;
+  }
+  case FL_RELEASE:
+
+      if(Fl::event_inside(this))
+          fl_cursor(FL_CURSOR_HAND);
+
+      if(Fl::event_button() == FL_RIGHT_MOUSE)
+          qMode = false;
+      else if(Fl::event_button() == FL_LEFT_MOUSE)
+          qMode = true;
+
+      if(!Fl::event_button1() && !Fl::event_button3())
+      {
+          selectedFormant = -1;
+          return 1;
+      }
+      else
+      {
+          update_refs();
+      }
+      Fl::pushed(this);
+      return 1;
+  case FL_LEAVE:
+      if(!Fl::event_inside(this)) // Cover for some strange events when clicking
+      {
+          hoverFormant = -1;
+          qMode = false;
+          redraw();
+          fl_cursor(FL_CURSOR_DEFAULT);
+      }
+      return 1;
+}
+
+return Fl_Box::handle(event);} {}
+  }
+  Function {delegate(Fl_Valuator* w, int value)} {private return_type void
+  } {
+    code {// If widget value has changed, update and perform manual callback
+
+        if(w->value() != value)
+        {
+            w->value(value);
+            w->do_callback();
+        }} {}
+  }
+  Function {update_refs()} {private return_type {inline void}
+  } {
+    code {//
+        yRef = Fl::event_y();
+        xRef = Fl::event_x();
+        ampRef = pars->Pvowels[*nvowel].formants[selectedFormant].amp;
+        freqRef = pars->Pvowels[*nvowel].formants[selectedFormant].freq;
+        qRef = pars->Pvowels[*nvowel].formants[selectedFormant].q;
+        cFreqRef = pars->Pcenterfreq;} {}
   }
 }
 
@@ -487,7 +650,7 @@ update_formant_window();
 pars->changed = true;
 send_data(35, o->value(), 0xc0);}
           xywh {595 62 55 20} type Simple labelfont 1 labelsize 10 align 5 minimum 0 maximum 127 step 1 textfont 1 textsize 11
-          code0 {o->bounds(1,FF_MAX_SEQUENCE-1);}
+          code0 {o->bounds(1,FF_MAX_SEQUENCE);}
           code1 {o->value(pars->Psequencesize);}
         }
         Fl_Counter seqpos {
@@ -497,7 +660,7 @@ update_formant_window();
 pars->changed=true;
 send_data(36, o->value(), 0xc0);}
           tooltip {Current position from the sequence} xywh {595 97 40 15} type Simple labelfont 1 labelsize 10 align 9 minimum 0 maximum 127 step 1 textsize 10
-          code0 {o->bounds(0,FF_MAX_SEQUENCE-2);}
+          code0 {o->bounds(0,FF_MAX_SEQUENCE-1);}
           code1 {o->value(nseqpos);}
         }
         Fl_Counter vowel_counter {
@@ -524,6 +687,7 @@ send_data(21, o->value(), 0xc8);}
           tooltip {Sequence Stretch} xywh {595 130 25 25} box ROUND_UP_BOX labelsize 10 align 1 maximum 127 step 1
           code0 {o->init(40);}
           code1 {o->value(pars->Psequencestretch);}
+          code2 {o->setValueType(VC_FormFilterStretch);}
           class WidgetPDial
         }
       }
@@ -545,6 +709,7 @@ send_data(16, o->value(), 0xc8);}
         tooltip {Formant's Slowness (Morphing)} xywh {565 15 25 25} box ROUND_UP_BOX labelfont 1 labelsize 10 align 1 maximum 127 step 1
         code0 {o->init(64);}
         code1 {o->value(pars->Pformantslowness);}
+        code2 {o->setValueType(VC_FormFilterSlowness);}
         class WidgetPDial
       }
       Fl_Value_Output centerfreqvo {
@@ -588,18 +753,15 @@ send_data(23, o->value(), 0xc8);}
         code0 {o->value(pars->Poctavesfreq);}
         class mwheel_slider_rev
       }
-      Fl_Box formantfiltergraph {
-        xywh {5 5 475 195} box BORDER_BOX
-        code0 {o->init(pars,&nvowel,&nformant);}
-        class FormantFilterGraph
-      }
       Fl_Dial wvknob {
         label {Vw.Cl.}
         callback {pars->Pvowelclearness=(int) o->value();pars->changed = true;
 send_data(17, o->value(), 0xc8);}
-        tooltip {Vowel "clearness" (how the mixed vowels are avoided)} xywh {600 15 25 25} box ROUND_UP_BOX labelfont 1 labelsize 10 align 1 maximum 127 step 1
+        tooltip {Vowel "clearness" (transition between vowels)} xywh {600 15 25 25} box ROUND_UP_BOX labelfont 1 labelsize 10 align 1 maximum 127 step 1
         code0 {o->init(64);}
         code1 {o->value(pars->Pvowelclearness);}
+        code2 {o->setValueType(VC_FormFilterClearness);}
+        code3 {o->setGraphicsType(VC_FormFilterClearness);}
         class WidgetPDial
       }
       Fl_Button {} {
@@ -622,9 +784,15 @@ send_data(17, o->value(), 0xc8);}
         xywh {635 10 55 15}
       }
     }
+    code {// Formant graph
+{ FormantFilterGraph* o = formantfiltergraph = new FormantFilterGraph(5, 5, 475, 195, *this, pars, &nvowel, &nformant);
+      formantfiltergraph->box(FL_BORDER_BOX);
+      formantparswindow->add(o);
+    } // FormantFilterGraph* formantfiltergraph} {}
   }
   Function {update_formant_window()} {} {
-    code {formant_freq_dial->value(pars->Pvowels[nvowel].formants[nformant].freq);
+    code {//
+        formant_freq_dial->value(pars->Pvowels[nvowel].formants[nformant].freq);
         formant_q_dial->value(pars->Pvowels[nvowel].formants[nformant].q);
         formant_amp_dial->value(pars->Pvowels[nvowel].formants[nformant].amp);
         if (nformant < pars->Pnumformants)
@@ -640,7 +808,8 @@ send_data(17, o->value(), 0xc8);}
         vowel_counter->value(pars->Psequence[nseqpos].nvowel);} {}
   }
   Function {refresh()} {} {
-    code {update_formant_window();
+    code {//
+        update_formant_window();
         formantfiltergraph->redraw();
 
         if (pars->Pcategory == 0)
@@ -709,7 +878,7 @@ collect_data(synth, value, (Fl::event_button() | type), control, npart, kititem,
 
     if (part != npart || ((eng >= 128 && eng != 136) && eng != engine))
         return;
-    
+
     switch(control)
     {
     	case 0:
@@ -906,6 +1075,8 @@ collect_data(synth, value, (Fl::event_button() | type), control, npart, kititem,
           case 2:
              qdial->setValueType(VC_FilterQ);
        }} {}
+  }
+  decl {FormantFilterGraph *formantfiltergraph;} {public local
   }
   decl {FilterParams *pars;} {private local
   }

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -455,8 +455,10 @@ string convert_value(ValueType type, float val)
             return(custom_value_units(val / 127.0f * 200.0f,"%",1));
 
         case VC_LFOdepthFilter: // filter LFO
-            f=(int)val / 127.0f * 4800.0f; // 4 octaves
-            return variable_prec_units(f, "cents", 2);
+            val = (int)val / 127.0f * 4.0f; // 4 octaves
+            f = val * 1200.0f; // cents
+            return variable_prec_units(f, "cents", 2) + "\n("
+                + custom_value_units(val, "base pos. offset)", 2);
 
         case VC_LFOdelay:
             f = ((int)val) / 127.0f * 4.0f + 0.005f;
@@ -483,8 +485,10 @@ string convert_value(ValueType type, float val)
             return variable_prec_units(f, "cents", 2);
 
         case VC_EnvelopeFilterVal:
-            f=((int)val - 64.0f) / 64.0f * 7200.0f; // 6 octaves
-            return variable_prec_units(f, "cents", 2);
+            val = ((int)val - 64.0f) / 64.0f;
+            f = val * 7200.0f; // 6 octaves
+            return variable_prec_units(f, "cents", 2) + "\n("
+                + custom_value_units(val * 6.0f,"base pos. offset)",2);
 
         case VC_EnvelopeAmpSusVal:
             return(custom_value_units((1.0f - (int)val / 127.0f)
@@ -520,8 +524,8 @@ string convert_value(ValueType type, float val)
             else
                 return variable_prec_units(f, "Hz", 2);
 
-        case VC_FilterFreq1: // ToDo
-            return(custom_value_units(val,""));
+        case VC_FilterFreq1: // Formant filter - base position in vowel sequence
+            return(custom_value_units((val / 64.0f - 1.0f) * 5.0f,"x stretch (modulo 1)",2));
 
         case VC_FilterQ:
         case VC_FilterQAnalogUnused:
@@ -534,10 +538,11 @@ string convert_value(ValueType type, float val)
             return(s);
 
         case VC_FilterVelocityAmp:
-            f = (int)val / 127.0 * -6.0;
-            f = powf(2.0f,f + log(1000.0f)/log(2.0f)); // getrealfreq
+            val = (int)val / 127.0 * -6.0; // formant offset value
+            f = powf(2.0f,val + log(1000.0f)/log(2.0f)); // getrealfreq
             f = log(f/1000.0f)/log(powf(2.0f,1.0f/12.0f))*100.0f; // in cents
-            return(custom_value_units(f-0.5, "cents"));
+            return custom_value_units(f-0.5, "cents") +
+                   "\n(Formant offset: " + custom_value_units(val, "x stretch)",2);
 
         case VC_FilterFreqTrack0:
             s.clear();
@@ -552,6 +557,18 @@ string convert_value(ValueType type, float val)
             f = val /64.0f * 100.0f;
             s += custom_value_units(f, "%", 1);
             return(s);
+
+        case VC_FormFilterClearness:
+            f = powf(10.0f, (val - 32.0f) / 48.0f);
+            return custom_value_units(f, " switch rate",2);
+
+        case VC_FormFilterSlowness:
+            f = powf(1.0f - (val / 128.0f), 3.0f);
+            return custom_value_units(f, " morph rate",4);
+
+        case VC_FormFilterStretch:
+            f = powf(0.1f, (val - 32.0f) / 48.0f);
+            return custom_value_units(f, " seq. scale factor",3);
 
         case VC_InstrumentVolume:
             return(custom_value_units(-60.0f*(1.0f-(int)val/96.0f),"dB",1));
@@ -936,10 +953,32 @@ void custom_graph_dimensions(ValueType vt, int& w, int& h)
         w = 256;
         h = 128;
         break;
+    case VC_FormFilterClearness:
+        w = 128;
+        h = 128;
+        break;
     default:
         w = 0;
         h = 0;
     }
+}
+
+inline void grid(int x, int y, int w, int h, int sections)
+{
+        fl_color(FL_GRAY);
+
+        int j = 1;
+        int gDist = h / sections;
+        for(; j < sections; j++) /* Vertical */
+        {
+            fl_line(x, y - gDist * j, x + w, y - gDist * j);
+        }
+
+        gDist = w / sections;
+        for(j = 1; j < sections; j++) /* Horizontal */
+        {
+            fl_line(x + gDist * j, y, x + gDist * j, y - h);
+        }
 }
 
 void custom_graphics(ValueType vt, float val,int W,int H)
@@ -958,21 +997,7 @@ void custom_graphics(ValueType vt, float val,int W,int H)
         p = powf(8.0f,(64.0f-(int)val)/64.0f);
 
         /* Grid */
-        fl_color(FL_GRAY);
-
-        int j = 1;
-        int gDist = _h / 4;
-        for(; j < 4; j++) /* Vertical */
-        {
-            fl_line(x0, y0 - gDist * j, x0 + _w, y0 - gDist * j);
-        }
-
-        gDist = _w / 4;
-        for(j = 1; j < 4; j++) /* Horizontal */
-        {
-            fl_line(x0 + gDist * j, y0, x0 + gDist * j, y0 - _h);
-        }
-
+        grid(x0,y0,_w,_h, 4);
         /*Function curve*/
         fl_color(FL_BLUE);
         if ((int)val == 127)
@@ -991,6 +1016,23 @@ void custom_graphics(ValueType vt, float val,int W,int H)
             }
             fl_end_line();
         }
+        break;
+    }
+    case VC_FormFilterClearness:
+    {
+        p = powf(10.0f, (val - 32.0f) / 48.0f); //clearness param
+        grid(x0,y0,_w,_h,10);
+        fl_color(FL_BLUE);
+        fl_begin_line();
+        x = 0;
+        float frac = 1.0f / (float)_w;
+        for(i = 0; i < _w; i++)
+        {
+            y = (atanf((x * 2.0f - 1.0f) * p) / atanf(p) + 1.0f) * 0.5f * _h;
+            fl_vertex((float)x0 + i, (float)y0 - y);
+            x += frac;
+        }
+        fl_end_line();
         break;
     }
     case VC_SubBandwidthScale:

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -44,14 +44,17 @@ enum ValueType {
     VC_EnvelopeAmpSusVal,
     VC_EnvelopeLinAmpSusVal,
     VC_EnvelopeBandwidthVal,
-    VC_FilterFreq0,
-    VC_FilterFreq1,
-    VC_FilterFreq2,
+    VC_FilterFreq0, // Analog
+    VC_FilterFreq1, // Formant
+    VC_FilterFreq2, // StateVar
     VC_FilterFreqTrack0,
     VC_FilterFreqTrack1,
     VC_FilterQ,
     VC_FilterVelocityAmp,
     VC_FilterVelocitySense,
+    VC_FormFilterClearness,
+    VC_FormFilterSlowness,
+    VC_FormFilterStretch,
     VC_InstrumentVolume,
     VC_ADDVoiceVolume,
     VC_ADDVoiceDelay,


### PR DESCRIPTION
Semantically identical to #32 w.t. exception of a previously omitted crucial whitespace character, which lead to a silent code generation error (and subsequent compilation mayhem).

Changes are now also tested against libfltk1.3.0 