### PR TITLE
Fix crash on preexisting connections when autoconnecting audio (JACK)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,8 @@
 yoshimi 1.5.3 rc1
+
+2017-8-17 Jesper
+* Don't crash when autoconnect "fails" due to preexisting connections.
+
 2017-8-16 Will.
 * Doc updates.
 * Set Version 1.5.3 rc1.

--- a/src/MusicIO/JackEngine.cpp
+++ b/src/MusicIO/JackEngine.cpp
@@ -317,10 +317,19 @@ bool JackEngine::connectJackPorts(void)
         const char *port_name = jack_port_name(audio.ports[port + NUM_MIDI_PARTS * 2]);
         if ((ret = jack_connect(jackClient, port_name, playback_ports[port])))
         {
+            if(ret == EEXIST)
+            {
+            synth->getRuntime().Log(string(port_name)
+                        + " is already connected to jack port " + string(playback_ports[port])
+                        + ", status " + asString(ret));
+            }
+            else
+            {
             synth->getRuntime().Log("Cannot connect " + string(port_name)
                         + " to jack port " + string(playback_ports[port])
                         + ", status " + asString(ret));
             return false;
+            }
         }
     }
     return true;


### PR DESCRIPTION
Fixes bailout in cases where another client, e.g. a patchbay connection manages to connect the audio channels before Yoshimi tries to.