### PR TITLE
fix crash due to the max memory lock

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -47,7 +47,13 @@ using namespace std;
 #include "MasterUI.h"
 
 InterChange::InterChange(SynthEngine *_synth) :
-    synth(_synth)
+    synth(_synth),
+    fromCLI(NULL),
+    toCLI(NULL),
+    fromGUI(NULL),
+    toGUI(NULL),
+    fromMIDI(NULL),
+    returnsLoopback(NULL)
 {
     ;
 }
@@ -63,7 +69,7 @@ bool InterChange::Init(SynthEngine *_synth)
     }
     if (jack_ringbuffer_mlock(fromCLI))
     {
-        synth->getRuntime().Log("Failed to lock fromCLI memory");
+        synth->getRuntime().LogError("Failed to lock fromCLI memory");
         goto bail_out;
     }
     jack_ringbuffer_reset(fromCLI);

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -338,7 +338,10 @@ bool YoshimiLV2Plugin::init()
     if (!prepBuffers())
         return false;
 
-    _synth->Init(_sampleRate, _bufferSize);
+    if(!_synth->Init(_sampleRate, _bufferSize)) {
+        synth->getRuntime().LogError("Can't init synth engine");
+	return false;
+    }
 
     _synth->getRuntime().showGui = false;
 
@@ -367,8 +370,10 @@ LV2_Handle	YoshimiLV2Plugin::instantiate (const struct _LV2_Descriptor *desc, do
     YoshimiLV2Plugin *inst = new YoshimiLV2Plugin(synth, sample_rate, bundle_path, features, desc);
     if (inst->init())
         return static_cast<LV2_Handle>(inst);
-    else
+    else {
+        synth->getRuntime().LogError("Failed to create Yoshimi LV2 plugin");
         delete inst;
+    }
     return NULL;
 }
 

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -771,7 +771,7 @@ end_game:
 }
 
 
-void Config::Log(string msg, char tostderr)
+void Config::Log(const string &msg, char tostderr)
 {
     if ((tostderr & 2) && hideErrors)
         return;
@@ -784,6 +784,10 @@ void Config::Log(string msg, char tostderr)
         cerr << msg << endl; // error log
 }
 
+void Config::LogError(const string &msg)
+{
+    Log("[ERROR] " + msg, 3);
+}
 
 #ifndef YOSHIMI_LV2_PLUGIN
 void Config::StartupReport(MusicClient *musicClient)

--- a/src/Misc/Config.h
+++ b/src/Misc/Config.h
@@ -55,7 +55,8 @@ class Config : public MiscFuncs
 #endif
         void Announce(void);
         void Usage(void);
-        void Log(string msg, char tostderr = 0); // 1 = cli only ored 2 = hideable
+        void Log(const string &msg, char tostderr = 0); // 1 = cli only ored 2 = hideable
+	void LogError(const string &msg);
         void flushLog(void);
 
         void clearPresetsDirlist(void);

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -209,8 +209,10 @@ bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
     ControlStep = (127.0f / samplerate) * 5.0f; // 200mS for 0 to 127
     int found = 0;
 
-    if (!interchange.Init(this))
+    if (!interchange.Init(this)) {
+        Runtime.LogError("interChange init failed");
         goto bail_out;
+    }
 
     if (!pthread_mutex_init(&processMutex, NULL))
         processLock = &processMutex;


### PR DESCRIPTION
Yoshimi LV2 plugin crashed if there is not enough memory to lock. Since the pointers were not set to NULL in the constructor, sometimes there will be an attempt to free an invalid memory. Also if the synth init fails, there is a still attempt to use the engine.