### PR TITLE
Fix build on systems using the musl libc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,22 @@ else (PKG_CONFIG_FOUND)
     message(FATAL_ERROR "pkg-config required but not found")
 endif (PKG_CONFIG_FOUND)
 
+include (CheckFunctionExists)
+check_function_exists(random_r HAVE_RANDOM_R)
+
+# musl systems don’t have random_r() and also need argp-standalone
+if (HAVE_RANDOM_R)
+    add_definitions(-DHAVE_RANDOM_R=1)
+else(HAVE_RANDOM_R)
+    add_definitions(-DHAVE_RANDOM_R=0)
+    find_library (ARGP_LIB argp REQUIRED)
+    if (ARGP_LIB)
+        message(STATUS "Found argp")
+    else(ARGP_LIB)
+        message(FATAL_ERROR "argp required but not found")
+    endif(ARGP_LIB)
+endif(HAVE_RANDOM_R)
+
 # libz
 set (CMAKE_REQUIRED_LIBRARIES z)
 check_c_source_compiles (
@@ -496,6 +512,10 @@ set(ExternLibraries
 add_executable (yoshimi ${ProgSources} main.cpp)
 
 target_link_libraries (yoshimi ${ExternLibraries})
+
+if (NOT HAVE_RANDOM_R)
+    target_link_libraries (yoshimi ${ARGP_LIB})
+endif(NOT HAVE_RANDOM_R)
 
 install (TARGETS yoshimi RUNTIME DESTINATION bin)
 

--- a/src/Misc/MiscFuncs.cpp
+++ b/src/Misc/MiscFuncs.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <string.h>
 #include <mutex>
+#include <limits.h>
 
 using namespace std;
 

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -229,11 +229,16 @@ bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
     }
 
     memset(random_state, 0, sizeof(random_state));
+#if (HAVE_RANDOM_R)
     memset(&random_buf, 0, sizeof(random_buf));
 
     if (initstate_r(samplerate + buffersize + oscilsize, random_state,
                     sizeof(random_state), &random_buf))
         Runtime.Log("SynthEngine Init failed on general randomness");
+#else
+    if (!initstate(samplerate + buffersize + oscilsize, random_state, sizeof(random_state)))
+        Runtime.Log("SynthEngine Init failed on general randomness");
+#endif
 
     if (oscilsize < (buffersize / 2))
     {

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -950,10 +950,16 @@ void OscilGen::prepare(void)
     //int i, j, k;
     float a, b, c, d, hmagnew;
     memset(random_state, 0, sizeof(random_state));
+#if (HAVE_RANDOM_R)
     memset(&random_buf, 0, sizeof(random_buf));
-    if (initstate_r(synth->random(), random_state,
+    if (initstate_r(synth->randomSE(), random_state,
                     sizeof(random_state), &random_buf))
         synth->getRuntime().Log("OscilGen failed to init general randomness");
+#else
+    if (!initstate(synth->randomSE(), random_state, sizeof(random_state)))
+        synth->getRuntime().Log("OscilGen failed to init general randomness");
+#endif
+
     if (oldbasepar != Pbasefuncpar
         || oldbasefunc != Pcurrentbasefunc
         || oldbasefuncmodulation != Pbasefuncmodulation
@@ -1292,10 +1298,16 @@ int OscilGen::get(float *smps, float freqHz, int resonance)
         // unsigned int realrnd = random();
 //        srandom_r(randseed, &harmonic_random_buf);
         memset(harmonic_random_state, 0, sizeof(harmonic_random_state));
+#if (HAVE_RANDOM_R)
         memset(&harmonic_random_buf, 0, sizeof(harmonic_random_buf));
         if (initstate_r(randseed, harmonic_random_state,
                     sizeof(harmonic_random_state), &harmonic_random_buf))
             synth->getRuntime().Log("OscilGen failed to init harmonic amplitude amplitude randomness");
+#else
+	if (!initstate(randseed, harmonic_random_state, sizeof(harmonic_random_state)))
+            synth->getRuntime().Log("OscilGen failed to init harmonic amplitude amplitude randomness");
+#endif
+
         float power = Pamprandpower / 127.0f;
         float normalize = 1.0f / (1.2f - power);
         switch (Pamprandtype)


### PR DESCRIPTION
On musl systems there is no `random_r` function so my suggestion is to replace it with the `random` function in those cases. But I’m wondering if `random_r` could be replaced in general by `random`?

Additionally musl also doesn’t have argp, but there is a [argp-standalone](https://www.freshports.org/devel/argp-standalone/) which would have to be added to the build dependencies.

And last `PATH_MAX` is defined in `limits.h` so I added this include to src/Misc/MiscFuncs.cpp.