### PR TITLE
Fix GUI on musl systems / better check for argp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,7 +105,7 @@ set (BuildOptionsThisCPU
 
 set (BuildOptionsBasic
     "-O3 -msse -msse2 -mfpmath=sse -ffast-math -fomit-frame-pointer"
-    CACHE STRING "basic X86 complier options"
+    CACHE STRING "basic X86 compilier options"
 )
 
 set (BuildOptionsDebug
@@ -119,20 +119,32 @@ else (PKG_CONFIG_FOUND)
 endif (PKG_CONFIG_FOUND)
 
 include (CheckFunctionExists)
+# musl systems don’t have random_r() and also need argp-standalone
 check_function_exists(random_r randomR)
 
-# musl systems don’t have random_r() and also need argp-standalone
 if (randomR)
     add_definitions(-DHAVE_RANDOM_R)
-    message(STATUS "Found random_r")
-else(randomR)
+endif(randomR)
+
+check_c_source_compiles (
+    "#include <argp.h>
+     int main () {
+         int argc=1;
+         char *argv[]={\"test\"};
+         argp_parse(0,argc,argv,0,0,0);
+         return 0;
+     }" LIBC_HAS_ARGP
+)
+
+if (NOT LIBC_HAS_ARGP)
+    message(STATUS "libc does not have argp")
     find_library (ARGP_LIB argp REQUIRED)
     if (ARGP_LIB)
-        message(STATUS "Found argp")
+        message(STATUS "Found libargp")
     else(ARGP_LIB)
-        message(FATAL_ERROR "argp required but not found")
+        message(FATAL_ERROR "libargp required but not found")
     endif(ARGP_LIB)
-endif(randomR)
+endif(NOT LIBC_HAS_ARGP)
 
 # libz
 set (CMAKE_REQUIRED_LIBRARIES z)
@@ -513,9 +525,9 @@ add_executable (yoshimi ${ProgSources} main.cpp)
 
 target_link_libraries (yoshimi ${ExternLibraries})
 
-if (NOT HAVE_RANDOM_R)
+if (ARGP_LIB)
     target_link_libraries (yoshimi ${ARGP_LIB})
-endif(NOT HAVE_RANDOM_R)
+endif(ARGP_LIB)
 
 install (TARGETS yoshimi RUNTIME DESTINATION bin)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,8 @@ void splashTimeout(void *splashWin)
 
 static void *mainGuiThread(void *arg)
 {
+    Fl::lock();
+
     sem_post((sem_t *)arg);
 
     map<SynthEngine *, MusicClient *>::iterator it;
@@ -333,9 +335,6 @@ int main(int argc, char *argv[])
 
     int minVmajor = 1; // need to improve this idea
     int minVminor = 5;
-
-    // moved from mainGuiThread() to prevent leaking from early GuiThreadMessage
-    Fl::lock();
 
     if (!mainCreateNewInstance(0))
     {


### PR DESCRIPTION
This PR reverts commit 426c65f to prevent a GUI crash on musl systems. It puts `Fl::lock()` back into the main GUI thread as it is stated in [fltk’s documentation](http://www.fltk.org/doc-1.3/group__fl__multithread.html).

Furthermore I detachted the check for argp from the check for random_r() because they’re two separate things. E.g. what if another libc has random_r() but not argp? The argp check is also more elaborate (taken from elfutils’ configure script).

This time the builds for glibc and musl are really working.