### PR TITLE
Fix build on FreeBSD with GCC

### DIFF
--- a/src/Misc/RandomGen.h
+++ b/src/Misc/RandomGen.h
@@ -26,6 +26,7 @@
 #ifndef RANDOMGEN_H
 #define RANDOMGEN_H
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Include `sys/types.h` for uint definition

On FreeBSD/powerpc64 yoshimi fails to build with GCC otherwise:
```
/usr/local/bin/g++8  -DDEFAULT_AUDIO=jack_audio -DDEFAULT_MIDI=jack_midi -DGUI_FLTK -DJACK_LATENCY -DJACK_SESSION -DMIN_CONFIG_MAJOR=1 -DMIN_CONFIG_MINOR=5 -DYOSHIMI=\"yoshimi\" -DYOSHI_FIFO_DIR=\"\" -I. -I/wrkdirs/usr/ports/audio/yoshimi/work/yoshimi-1.5.10.2/src -I/usr/local/include/freetype2 -I/usr/local/include/cairo -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/pixman-1 -I/usr/local/include/libdrm -I/usr/local/include/libpng16 -ffast-math -fomit-frame-pointer -O2 -pipe  -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc8  -Wl,-rpath=/usr/local/lib/gcc8 -O3   -std=gnu++11 -Wall -D'YOSHIMI_VERSION="1.5.10.2"' -D'BASE_INSTALL_DIR="/usr/local"' -L/usr/local/lib -ljack -pthread -std=gnu++11 -MD -MT CMakeFiles/yoshimi.dir/Params/PADnoteParameters.cpp.o -MF CMakeFiles/yoshimi.dir/Params/PADnoteParameters.cpp.o.d -o CMakeFiles/yoshimi.dir/Params/PADnoteParameters.cpp.o -c /wrkdirs/usr/ports/audio/yoshimi/work/yoshimi-1.5.10.2/src/Params/PADnoteParameters.cpp
In file included from /wrkdirs/usr/ports/audio/yoshimi/work/yoshimi-1.5.10.2/src/Synth/OscilGen.h:33,
                 from /wrkdirs/usr/ports/audio/yoshimi/work/yoshimi-1.5.10.2/src/Params/PADnoteParameters.cpp:35:
/wrkdirs/usr/ports/audio/yoshimi/work/yoshimi-1.5.10.2/src/Misc/RandomGen.h:190:34: error: 'uint' has not been declared
         uint32_t rot(uint32_t x, uint k) { return (x << k)|(x >> (32-k)); }
                                  ^~~~
```
Downstream bug report: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=237797