### PR TITLE
Fix build of Yoshimi 1.5.11.2 on FreeBSD

### DIFF
--- a/src/Interface/RingBuffer.h
+++ b/src/Interface/RingBuffer.h
@@ -23,6 +23,7 @@
 #ifndef RINGBUFF_H
 #define RINGBUFF_H
 
+#include <sys/types.h>
 #include <atomic>
 #include <stdlib.h>
 


### PR DESCRIPTION
Yoshimi 1.5.11.2 fails to build on FreeBSD:
```
In file included from src/Interface/RingBuffer.cpp:27:
src/Interface/RingBuffer.h:34:22: fatal error: use of undeclared identifier 'uint'; did you mean 'int'?
        std::atomic <uint> readPoint{0};
                     ^~~~
                     int
1 error generated.
```
This is a similar error as #50 just in a different place.