### PR TITLE
Buffer-branch: use pull processing instead of changing the buffersize dynamically

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,12 @@
 yoshimi 1.5.11 M
 
+2019-6-6 Hermann
+* Buffer-handling: use pull processing for sound output,
+  and let the SynthEngine always operate with a fixed,
+  configured calcualtion buffer size. This avoids sonic
+  changes due to dynamic buffer size changes, as could
+  happen with LV2, esp. with the Carla plugin host.
+
 2019-6-4 Will
 * Completed CLI bank slot deletions.
   Also integrated GUI controls.

--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -4,6 +4,7 @@
     Original ZynAddSubFX author Nasca Octavian Paul
     Copyright (C) 2002-2009 Nasca Octavian Paul
     Copyright 2009-2011, Alan Calvert
+    Copyright 2019 Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -19,7 +20,8 @@
     yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-    This file is a derivative of a ZynAddSubFX original, modified April 2011
+    This file is a derivative of a ZynAddSubFX original.
+    Modified March 2019
 */
 
 #include <cstring>
@@ -431,7 +433,7 @@ void AnalogFilter::filterout(float *smp)
     {
         for (int i = 0; i < synth->sent_buffersize; ++i)
         {
-            float x = (float)i / synth->sent_buffersize_f;
+            float x = (float)i / float(synth->buffersize_f);
             smp[i] = tmpismp[i] * (1.0f - x) + smp[i] * x;
         }
         needsinterpolation = false;

--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -394,7 +394,7 @@ void AnalogFilter::singlefilterout(float *smp, fstage &x, fstage &y, float *c, f
     float y0;
     if (order == 1)
     {   // First order filter
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             y0 = smp[i] * c[0] + x.c1 * c[1] + y.c1 * d[1];
             y.c1 = y0;
@@ -404,7 +404,7 @@ void AnalogFilter::singlefilterout(float *smp, fstage &x, fstage &y, float *c, f
     }
     if (order == 2)
     { // Second order filter
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             y0 = smp[i] * c[0] + x.c1 * c[1] + x.c2 * c[2] + y.c1 * d[1] + y.c2 * d[2];
             y.c2 = y.c1;
@@ -421,7 +421,7 @@ void AnalogFilter::filterout(float *smp)
 {
     if (needsinterpolation)
     {
-        memcpy(tmpismp, smp, synth->sent_bufferbytes);
+        memcpy(tmpismp, smp, synth->bufferbytes);
         for (int i = 0; i < stages + 1; ++i)
             singlefilterout(tmpismp, oldx[i], oldy[i], oldc, oldd);
     }
@@ -431,7 +431,7 @@ void AnalogFilter::filterout(float *smp)
 
     if (needsinterpolation)
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float x = (float)i / float(synth->buffersize_f);
             smp[i] = tmpismp[i] * (1.0f - x) + smp[i] * x;
@@ -439,7 +439,7 @@ void AnalogFilter::filterout(float *smp)
         needsinterpolation = false;
     }
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
         smp[i] *= outgain;
 }
 

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -5,6 +5,7 @@
     Copyright (C) 2002-2009 Nasca Octavian Paul
     Copyright 2009, James Morris
     Copyright 2009-2011, Alan Calvert
+    Copyright 2019 Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -20,7 +21,8 @@
     yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-    This file is derivative of ZynAddSubFX original code, modified March 2011
+    This file is derivative of ZynAddSubFX original code.
+    Modified March 2019
 */
 
 #include <fftw3.h>
@@ -206,7 +208,7 @@ void FormantFilter::filterout(float *smp)
                 smp[i] += tmpbuf[i]
                           * interpolateAmplitude(oldformantamp[j],
                                                   currentformants[j].amp, i,
-                                                  synth->sent_buffersize);
+                                                  synth->buffersize);
         else
             for (int i = 0; i < synth->sent_buffersize; ++i)
                 smp[i] += tmpbuf[i] * currentformants[j].amp;

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -194,23 +194,23 @@ void FormantFilter::setfreq_and_q(float frequency, float q_)
 
 void FormantFilter::filterout(float *smp)
 {
-    memcpy(inbuffer, smp, synth->sent_bufferbytes);
-    memset(smp, 0, synth->sent_bufferbytes);
+    memcpy(inbuffer, smp, synth->bufferbytes);
+    memset(smp, 0, synth->bufferbytes);
 
     for (int j = 0; j < numformants; ++j)
     {
-        for (int k = 0; k < synth->sent_buffersize; ++k)
+        for (int k = 0; k < synth->buffersize; ++k)
             tmpbuf[k] = inbuffer[k] * outgain;
         formant[j]->filterout(tmpbuf);
 
         if (aboveAmplitudeThreshold(oldformantamp[j], currentformants[j].amp))
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 smp[i] += tmpbuf[i]
                           * interpolateAmplitude(oldformantamp[j],
                                                   currentformants[j].amp, i,
                                                   synth->buffersize);
         else
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 smp[i] += tmpbuf[i] * currentformants[j].amp;
         oldformantamp[j] = currentformants[j].amp;
     }

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -4,6 +4,7 @@
     Original ZynAddSubFX author Nasca Octavian Paul
     Copyright (C) 2002-2009 Nasca Octavian Paul
     Copyright 2009-2011, Alan Calvert
+    Copyright 2019 Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -19,7 +20,8 @@
     yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-    This file is derivative of ZynAddSubFX original code, modified April 2011
+    This file is derivative of ZynAddSubFX original code.
+    Modified March 2019
 */
 
 #include <cstring>
@@ -185,7 +187,7 @@ void SVFilter::filterout(float *smp)
     {
         for (int i = 0; i < synth->sent_buffersize; ++i)
         {
-            float x = (float)i / synth->sent_buffersize_f;
+            float x = (float)i / synth->buffersize_f;
             smp[i] = tmpismp[i] * (1.0f - x) + smp[i] * x;
         }
         needsinterpolation = 0;

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -160,7 +160,7 @@ void SVFilter::singlefilterout(float *smp, fstage &x, parameters &par)
             break;
     }
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         x.low = x.low + par.f * x.band;
         x.high = par.q_sqrt * smp[i] - x.low - par.q * x.band;
@@ -175,7 +175,7 @@ void SVFilter::filterout(float *smp)
 {
     if (needsinterpolation)
     {
-        memcpy(tmpismp, smp, synth->sent_bufferbytes);
+        memcpy(tmpismp, smp, synth->bufferbytes);
         for (int i = 0; i < stages + 1; ++i)
             singlefilterout(tmpismp, st[i],ipar);
     }
@@ -185,13 +185,13 @@ void SVFilter::filterout(float *smp)
 
     if (needsinterpolation)
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float x = (float)i / synth->buffersize_f;
             smp[i] = tmpismp[i] * (1.0f - x) + smp[i] * x;
         }
         needsinterpolation = 0;
     }
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
         smp[i] *= outgain;
 }

--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -81,7 +81,7 @@ void Alienwah::out(float *smpsl, float *smpsr)
 
     for (int i = 0; i < synth->sent_buffersize; ++i)
     {
-        float x = (float)i / synth->sent_buffersize_f;
+        float x = (float)i / synth->sent_buffersize;
         float x1 = 1.0f - x;
         // left
         tmp = clfol * x + oldclfol * x1;

--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -79,9 +79,9 @@ void Alienwah::out(float *smpsl, float *smpsr)
     clfol = complex<float>(cosf(lfol + phase) * fb, sinf(lfol + phase) * fb); //rework
     clfor = complex<float>(cosf(lfor + phase) * fb, sinf(lfor + phase) * fb); //rework
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
-        float x = (float)i / synth->sent_buffersize;
+        float x = (float)i / synth->buffersize;
         float x1 = 1.0f - x;
         // left
         tmp = clfol * x + oldclfol * x1;

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -115,7 +115,7 @@ void Chorus::out(float *smpsl, float *smpsr)
         // Left channel
 
         // compute the delay in samples using linear interpolation between the lfo delays
-        mdel = (dl1 * (synth->sent_buffersize - i) + dl2 * i) / synth->sent_buffersize_f;
+        mdel = (dl1 * (synth->buffersize - i) + dl2 * i) / float(synth->buffersize);
         if (++dlk >= maxdelay)
             dlk = 0;
         tmp = dlk - mdel + maxdelay * 2.0f; // where should I get the sample from
@@ -130,7 +130,7 @@ void Chorus::out(float *smpsl, float *smpsr)
         // Right channel
 
         // compute the delay in samples using linear interpolation between the lfo delays
-        mdel = (dr1 * (synth->sent_buffersize - i) + dr2 * i) / synth->sent_buffersize_f;
+        mdel = (dr1 * (synth->buffersize - i) + dr2 * i) / float(synth->buffersize);
         if (++drk >= maxdelay)
             drk = 0;
         tmp = drk * 1.0f - mdel + maxdelay * 2.0f; // where should I get the sample from

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -103,7 +103,7 @@ void Chorus::out(float *smpsl, float *smpsr)
     dr2 = getdelay(lfor);
 
     float inL, inR, tmpL, tmpR, tmp;
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         tmpL = smpsl[i];
         tmpR = smpsr[i];
@@ -145,13 +145,13 @@ void Chorus::out(float *smpsl, float *smpsr)
     }
 
     if (Poutsub)
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             efxoutl[i] *= -1.0f;
             efxoutr[i] *= -1.0f;
         }
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         efxoutl[i] *= pangainL.getAndAdvanceValue();
         efxoutr[i] *= pangainR.getAndAdvanceValue();

--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -127,14 +127,14 @@ void Distorsion::out(float *smpsl, float *smpsr)
 
     if (Pstereo) // Stereo
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             efxoutl[i] = smpsl[i] * inputdrive * pangainL.getAndAdvanceValue();
             efxoutr[i] = smpsr[i] * inputdrive * pangainR.getAndAdvanceValue();
         }
     }
     else // Mono
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
             efxoutl[i] = inputdrive * (smpsl[i] * pangainL.getAndAdvanceValue()
                                        + smpsr[i]* pangainR.getAndAdvanceValue())
                 * 0.7f;
@@ -149,9 +149,9 @@ void Distorsion::out(float *smpsl, float *smpsr)
     if (!Pprefiltering)
         applyfilters(efxoutl, efxoutr);
     if (!Pstereo)
-        memcpy(efxoutr, efxoutl, synth->sent_bufferbytes);
+        memcpy(efxoutr, efxoutl, synth->bufferbytes);
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         float lvl = dB2rap(60.0f * level.getAndAdvanceValue() - 40.0f);
         float lout = efxoutl[i];

--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -95,7 +95,7 @@ void Distorsion::applyfilters(float *efxoutl, float *efxoutr)
     float fr;
 
     fr = lpffr.getValue();
-    lpffr.advanceValue(synth->sent_buffersize);
+    lpffr.advanceValue(synth->buffersize);
     if (fr != lpffr.getValue()) {
         lpfl->interpolatenextbuffer();
         lpfl->setfreq(lpffr.getValue());
@@ -106,7 +106,7 @@ void Distorsion::applyfilters(float *efxoutl, float *efxoutr)
     lpfr->filterout(efxoutr);
 
     fr = hpffr.getValue();
-    hpffr.advanceValue(synth->sent_buffersize);
+    hpffr.advanceValue(synth->buffersize);
     if (fr != hpffr.getValue()) {
         hpfl->interpolatenextbuffer();
         hpfl->setfreq(hpffr.getValue());
@@ -142,9 +142,9 @@ void Distorsion::out(float *smpsl, float *smpsr)
     if (Pprefiltering)
         applyfilters(efxoutl, efxoutr);
 
-    waveShapeSmps(synth->sent_buffersize, efxoutl, Ptype + 1, Pdrive);
+    waveShapeSmps(synth->buffersize, efxoutl, Ptype + 1, Pdrive);
     if (Pstereo)
-        waveShapeSmps(synth->sent_buffersize, efxoutr, Ptype + 1, Pdrive);
+        waveShapeSmps(synth->buffersize, efxoutr, Ptype + 1, Pdrive);
 
     if (!Pprefiltering)
         applyfilters(efxoutl, efxoutr);

--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -86,10 +86,10 @@ void DynamicFilter::out(float *smpsl, float *smpsr)
     float freq = filterpars->getfreq();
     float q = filterpars->getq();
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
-        memcpy(efxoutl, smpsl, synth->sent_bufferbytes);
-        memcpy(efxoutr, smpsr, synth->sent_bufferbytes);
+        memcpy(efxoutl, smpsl, synth->bufferbytes);
+        memcpy(efxoutr, smpsr, synth->bufferbytes);
         float x = (fabsf(smpsl[i]) + fabsf(smpsr[i])) * 0.5f;
         ms1 = ms1 * (1.0f - ampsmooth) + x * ampsmooth + 1e-10f;
     }
@@ -110,7 +110,7 @@ void DynamicFilter::out(float *smpsl, float *smpsr)
     filterr->filterout(efxoutr);
 
     // panning
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         efxoutl[i] *= pangainL.getAndAdvanceValue();
         efxoutr[i] *= pangainR.getAndAdvanceValue();

--- a/src/Effects/EQ.cpp
+++ b/src/Effects/EQ.cpp
@@ -65,9 +65,9 @@ void EQ::cleanup(void)
 // Effect output
 void EQ::out(float *smpsl, float *smpsr)
 {
-    memcpy(efxoutl, smpsl, synth->sent_bufferbytes);
-    memcpy(efxoutr, smpsr, synth->sent_bufferbytes);
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    memcpy(efxoutl, smpsl, synth->bufferbytes);
+    memcpy(efxoutr, smpsr, synth->bufferbytes);
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         efxoutl[i] *= volume.getValue();
         efxoutr[i] *= volume.getValue();

--- a/src/Effects/EQ.cpp
+++ b/src/Effects/EQ.cpp
@@ -79,7 +79,7 @@ void EQ::out(float *smpsl, float *smpsr)
             continue;
 
         float oldval = filter[i].freq.getValue();
-        filter[i].freq.advanceValue(synth->sent_buffersize);
+        filter[i].freq.advanceValue(synth->buffersize);
         float newval = filter[i].freq.getValue();
         if (oldval != newval) {
             filter[i].l->interpolatenextbuffer();
@@ -89,7 +89,7 @@ void EQ::out(float *smpsl, float *smpsr)
         }
 
         oldval = filter[i].gain.getValue();
-        filter[i].gain.advanceValue(synth->sent_buffersize);
+        filter[i].gain.advanceValue(synth->buffersize);
         newval = filter[i].gain.getValue();
         if (oldval != newval) {
             filter[i].l->interpolatenextbuffer();
@@ -99,7 +99,7 @@ void EQ::out(float *smpsl, float *smpsr)
         }
 
         oldval = filter[i].q.getValue();
-        filter[i].q.advanceValue(synth->sent_buffersize);
+        filter[i].q.advanceValue(synth->buffersize);
         newval = filter[i].q.getValue();
         if (oldval != newval) {
             filter[i].l->interpolatenextbuffer();

--- a/src/Effects/Echo.cpp
+++ b/src/Effects/Echo.cpp
@@ -106,7 +106,7 @@ void Echo::out(float* smpsl, float* smpsr)
     float l, r;
     float ldl = ldelay[kl];
     float rdl = rdelay[kr];
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         ldl = ldelay[kl];
         rdl = rdelay[kr];

--- a/src/Effects/EffectLFO.cpp
+++ b/src/Effects/EffectLFO.cpp
@@ -57,7 +57,7 @@ EffectLFO::~EffectLFO()
 void EffectLFO::updateparams(void)
 {
     float lfofreq = (powf(2.0f, Pfreq / 127.0f * 10.0f) - 1.0f) * 0.03f;
-    incx = fabsf(lfofreq) * synth->sent_buffersize_f / synth->samplerate_f;
+    incx = fabsf(lfofreq) * synth->buffersize_f / synth->samplerate_f;
     if (incx > 0.49999999f)
         incx = 0.499999999f; // Limit the Frequency
 

--- a/src/Effects/EffectLFO.cpp
+++ b/src/Effects/EffectLFO.cpp
@@ -4,6 +4,7 @@
     Original ZynAddSubFX author Nasca Octavian Paul
     Copyright (C) 2002-2005 Nasca Octavian Paul
     Copyright 2009-2011, Alan Calvert
+    Copyright 2019 Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -19,7 +20,8 @@
     yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-    This file is derivative of ZynAddSubFX original code, modified March 2011
+    This file is derivative of ZynAddSubFX original code.
+    Modified March 2019
 */
 
 #include <cstdlib>
@@ -55,7 +57,7 @@ EffectLFO::~EffectLFO()
 void EffectLFO::updateparams(void)
 {
     float lfofreq = (powf(2.0f, Pfreq / 127.0f * 10.0f) - 1.0f) * 0.03f;
-    incx = fabsf(lfofreq) * synth->sent_all_buffersize_f / synth->samplerate_f;
+    incx = fabsf(lfofreq) * synth->sent_buffersize_f / synth->samplerate_f;
     if (incx > 0.49999999f)
         incx = 0.499999999f; // Limit the Frequency
 

--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -184,28 +184,28 @@ void EffectMgr::out(float *smpsl, float *smpsr)
     {
         if (!insertion)
         {
-            memset(smpsl, 0, synth->sent_bufferbytes);
-            memset(smpsr, 0, synth->sent_bufferbytes);
-            memset(efxoutl, 0, synth->sent_bufferbytes);
-            memset(efxoutr, 0, synth->sent_bufferbytes);
+            memset(smpsl, 0, synth->bufferbytes);
+            memset(smpsr, 0, synth->bufferbytes);
+            memset(efxoutl, 0, synth->bufferbytes);
+            memset(efxoutr, 0, synth->bufferbytes);
         }
         return;
     }
-    memset(efxoutl, 0, synth->sent_bufferbytes);
-    memset(efxoutr, 0, synth->sent_bufferbytes);
+    memset(efxoutl, 0, synth->bufferbytes);
+    memset(efxoutr, 0, synth->bufferbytes);
     efx->out(smpsl, smpsr);
 
     if (nefx == 7)
     {   // this is need only for the EQ effect
-        memcpy(smpsl, efxoutl, synth->sent_bufferbytes);
-        memcpy(smpsr, efxoutr, synth->sent_bufferbytes);
+        memcpy(smpsl, efxoutl, synth->bufferbytes);
+        memcpy(smpsr, efxoutr, synth->bufferbytes);
         return;
     }
 
     // Insertion effect
     if (insertion != 0)
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float volume = efx->volume.getAndAdvanceValue();
             float v1, v2;
@@ -234,7 +234,7 @@ void EffectMgr::out(float *smpsl, float *smpsr)
             }
         }
     } else { // System effect
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float volume = efx->volume.getAndAdvanceValue();
             efxoutl[i] *= 2.0f * volume;

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -97,7 +97,7 @@ void Phaser::analog_setup()
     Rconst    = 1.0f + Rmx; // Handle parallel resistor relationship
     C         = 0.00000005f; // 50 nF
     CFs       = 2.0f * synth->samplerate_f * C;
-    invperiod = 1.0f / synth->sent_buffersize_f;
+    invperiod = 1.0f / synth->buffersize_f;
 }
 
 
@@ -168,7 +168,7 @@ void Phaser::AnalogPhase(float *smpsl, float *smpsr)
     oldlgain = modl;
     oldrgain = modr;
 
-   for(int i = 0; i < synth->sent_buffersize; ++i)
+   for(int i = 0; i < synth->buffersize; ++i)
    {
         gl += diffl; // Linear interpolation between LFO samples
         gr += diffr;
@@ -194,8 +194,8 @@ void Phaser::AnalogPhase(float *smpsl, float *smpsr)
 
     if(Poutsub)
     {
-        invSignal(efxoutl, synth->sent_buffersize);
-        invSignal(efxoutr, synth->sent_buffersize);
+        invSignal(efxoutl, synth->buffersize);
+        invSignal(efxoutr, synth->buffersize);
     }
 }
 
@@ -248,9 +248,9 @@ void Phaser::NormalPhase(float *smpsl, float *smpsr)
     rgain = 1.0f - phase * (1.0f - depth) - (1.0f - phase) * rgain * depth;
     rgain = limit(rgain,ZERO_,ONE_);//(rgain > 1.0f) ? 1.0f : rgain;
 
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
-        float x = (float)i / synth->sent_buffersize_f;
+        float x = (float)i / synth->buffersize_f;
         float x1 = 1.0f - x;
         float gl = lgain * x + oldlgain * x1;
         float gr = rgain * x + oldrgain * x1;
@@ -284,7 +284,7 @@ void Phaser::NormalPhase(float *smpsl, float *smpsr)
     oldlgain = lgain;
     oldrgain = rgain;
     if (Poutsub)
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             efxoutl[i] *= -1.0f;
             efxoutr[i] *= -1.0f;

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -97,7 +97,7 @@ void Phaser::analog_setup()
     Rconst    = 1.0f + Rmx; // Handle parallel resistor relationship
     C         = 0.00000005f; // 50 nF
     CFs       = 2.0f * synth->samplerate_f * C;
-    invperiod = 1.0f / synth->sent_all_buffersize_f;
+    invperiod = 1.0f / synth->sent_buffersize_f;
 }
 
 

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -171,7 +171,7 @@ void Reverb::processmono(int ch, float *output)
         int comblength = comblen[j];
         float lpcombj = lpcomb[j];
 
-        for (i = 0; i < synth->sent_buffersize; ++i)
+        for (i = 0; i < synth->buffersize; ++i)
         {
             fbout = comb[j][ck] * combfb[j];
             fbout = fbout * (1.0f - lohifb) + lpcombj * lohifb;
@@ -192,7 +192,7 @@ void Reverb::processmono(int ch, float *output)
     {
         int ak = apk[j];
         int aplength = aplen[j];
-        for (i = 0; i < synth->sent_buffersize; ++i)
+        for (i = 0; i < synth->buffersize; ++i)
         {
             tmp = ap[j][ak];
             ap[j][ak] = 0.7f * tmp + output[i];
@@ -211,7 +211,7 @@ void Reverb::out(float *smps_l, float *smps_r)
     if (!Pvolume && insertion)
         return;
     int i;
-    for (i = 0; i < synth->sent_buffersize; ++i)
+    for (i = 0; i < synth->buffersize; ++i)
     {
         inputbuf[i] = (smps_l[i] + smps_r[i]) / 2.0f;
         // Initial delay r
@@ -227,7 +227,7 @@ void Reverb::out(float *smps_l, float *smps_r)
     }
 
     if (bandwidth)
-        bandwidth->process(synth->sent_buffersize, inputbuf);
+        bandwidth->process(synth->buffersize, inputbuf);
 
     if (lpf)
     {
@@ -262,7 +262,7 @@ void Reverb::out(float *smps_l, float *smps_r)
         lvol *= 2.0f;
         rvol *= 2.0f;
     }
-    for (i = 0; i < synth->sent_buffersize; ++i)
+    for (i = 0; i < synth->buffersize; ++i)
     {
         efxoutl[i] *= lvol;
         efxoutr[i] *= rvol;

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -232,7 +232,7 @@ void Reverb::out(float *smps_l, float *smps_r)
     if (lpf)
     {
         float fr = lpffr.getValue();
-        lpffr.advanceValue(synth->sent_buffersize);
+        lpffr.advanceValue(synth->buffersize);
         if (fr != lpffr.getValue())
         {
             lpf->interpolatenextbuffer();
@@ -243,7 +243,7 @@ void Reverb::out(float *smps_l, float *smps_r)
      if (hpf)
     {
         float fr = hpffr.getValue();
-        hpffr.advanceValue(synth->sent_buffersize);
+        hpffr.advanceValue(synth->buffersize);
         if (fr != hpffr.getValue())
         {
             hpf->interpolatenextbuffer();

--- a/src/Interface/CmdInterface.cpp
+++ b/src/Interface/CmdInterface.cpp
@@ -702,7 +702,6 @@ int CmdInterface::effects(unsigned char controlType)
         switch (nFXtype)
         {
             case 1:
-            {
                 selected = stringNumInList(name, effreverb, 1);
                 if (selected != 7) // EQ
                     nFXeqBand = 0;
@@ -719,12 +718,12 @@ int CmdInterface::effects(unsigned char controlType)
                         return value_msg;
                 }
                 break;
-            }
+
             case 2:
                 selected = stringNumInList(name, effecho, 1);
                 break;
+
             case 3:
-            {
                 selected = stringNumInList(name, effchorus, 1);
                 if (selected == 4) // filtershape
                 {
@@ -741,9 +740,8 @@ int CmdInterface::effects(unsigned char controlType)
                     value = (toggle() == 1);
                 }
                 break;
-            }
+
             case 4:
-            {
                 selected = stringNumInList(name, effphaser, 1);
                 if (selected == 4) // filtershape
                 {
@@ -760,9 +758,8 @@ int CmdInterface::effects(unsigned char controlType)
                     value = (toggle() == 1);
                 }
                 break;
-            }
+
             case 5:
-            {
                 selected = stringNumInList(name, effalienwah, 1);
                 if (selected == 3) // filtershape
                 {
@@ -774,9 +771,8 @@ int CmdInterface::effects(unsigned char controlType)
                     else return value_msg;
                 }
                 break;
-            }
+
             case 6:
-            {
                 selected = stringNumInList(name, effdistortion, 1);
                 if (selected == 5) // filtershape
                 {
@@ -792,9 +788,8 @@ int CmdInterface::effects(unsigned char controlType)
                     value = (toggle() == 1);
                 }
                 break;
-            }
+
             case 7: // TODO band and type no GUI update
-            {
                 selected = stringNumInList(name, effeq, 1);
                 if (selected == 1) // band
                 {
@@ -821,9 +816,8 @@ int CmdInterface::effects(unsigned char controlType)
                     selected += 8;
                 }
                 break;
-            }
+
             case 8:
-            {
                 selected = stringNumInList(name, effdynamicfilter, 1);
                 if (selected == 4) // filtershape
                 {
@@ -844,7 +838,7 @@ int CmdInterface::effects(unsigned char controlType)
                     bitSet(context, LEVEL::Filter);
                     return done_msg;
                 }
-            }
+                break;
         }
         if (selected > -1)
         {

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -67,6 +67,9 @@ InterChange::InterChange(SynthEngine *_synth) :
     returnsBuffer(NULL),
     blockRead(0),
     tick(0),
+    flagsValue(0xffffffff),
+    sortResultsThreadHandle(0),
+    showValue(false),
     lockTime(0),
     swapRoot1(UNUSED),
     swapBank1(UNUSED),
@@ -1479,6 +1482,7 @@ std::string InterChange::resolveVector(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     if (control == VECTOR::control::undefined)
@@ -1576,6 +1580,7 @@ std::string InterChange::resolveMicrotonal(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
 
     }
 
@@ -1826,6 +1831,7 @@ std::string InterChange::resolveConfig(CommandBlock *getData)
                     break;
                 default:
                     contstr += "OFF";
+                    break;
             }
             showValue = false;
             break;
@@ -1842,6 +1848,7 @@ std::string InterChange::resolveConfig(CommandBlock *getData)
                     break;
                 default:
                     contstr += "OFF";
+                    break;
             }
             showValue = false;
             break;
@@ -2183,6 +2190,7 @@ std::string InterChange::resolveMain(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Main " + contstr);
@@ -2539,7 +2547,7 @@ std::string InterChange::resolvePart(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
-
+            break;
     }
 
     if (yesno)
@@ -2624,6 +2632,7 @@ std::string InterChange::resolveAdd(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + " AddSynth " + name + contstr);
@@ -2837,6 +2846,7 @@ std::string InterChange::resolveAddVoice(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + " Add Voice " + std::to_string(nvoice + 1) + name + contstr);
@@ -2970,6 +2980,7 @@ std::string InterChange::resolveSub(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + " SubSynth " + name + contstr);
@@ -3146,6 +3157,7 @@ std::string InterChange::resolvePad(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     std::string isPad = "";
@@ -3314,6 +3326,7 @@ std::string InterChange::resolveOscillator(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + eng_name + name + contstr + isPad);
@@ -3388,6 +3401,7 @@ std::string InterChange::resolveResonance(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + name + " Resonance " + contstr + isPad);
@@ -3462,6 +3476,7 @@ std::string InterChange::resolveLFO(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(kititem + 1) + name + lfo + " LFO " + contstr);
@@ -3577,6 +3592,7 @@ std::string InterChange::resolveFilter(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
     std::string extra = "";
     if (control >= FILTERINSERT::control::formantFrequency && control <= FILTERINSERT::control::formantAmplitude)
@@ -3710,6 +3726,7 @@ std::string InterChange::resolveEnvelope(CommandBlock *getData)
         default:
             showValue = false;
             contstr = "Unrecognised";
+            break;
     }
 
     return ("Part " + std::to_string(npart + 1) + " Kit " + std::to_string(int(kititem + 1)) + name  + env + " Env " + contstr);
@@ -3849,6 +3866,7 @@ std::string InterChange::resolveEffects(CommandBlock *getData)
         default:
             showValue = false;
             contstr = " Unrecognised";
+            break;
     }
 
     if (kititem != EFFECT::type::eq && control == EFFECT::control::preset)
@@ -5914,7 +5932,7 @@ void InterChange::commandPart(CommandBlock *getData)
         case PART::control::instrumentName: // done elsewhere
             break;
         case PART::control::defaultInstrumentCopyright: // done elsewhere
-            ;
+            break;
         case PART::control::resetAllControllers:
             if (write)
                 part->SetController(0x79,0);

--- a/src/Interface/InterChange.h
+++ b/src/Interface/InterChange.h
@@ -47,7 +47,6 @@ class InterChange : private MiscFuncs, FileMgr
         ~InterChange();
         bool Init();
 
-        CommandBlock commandData;
 #ifndef YOSHIMI_LV2_PLUGIN
         ringBuff *fromCLI;
 #endif

--- a/src/Interface/MidiLearn.h
+++ b/src/Interface/MidiLearn.h
@@ -45,7 +45,6 @@ class MidiLearn : private MiscFuncs, FileMgr
         bool saveXML(string filename); // true for load ok, otherwise false
         void add2XML(XMLwrapper *xml);
         void getfromXML(XMLwrapper *xml);
-        CommandBlock commandData;
 
         struct Control{
             unsigned char type;

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -140,13 +140,13 @@ void YoshimiLV2Plugin::process(uint32_t sample_count)
                 continue;
             while (processed < next_frame && to_process >= synth->buffersize)
             {
-                _synth->MasterAudio(tmpLeft, tmpRight, synth->buffersize);
+                _synth->MasterAudio(tmpLeft, tmpRight);
                 processed += synth->buffersize;
                 to_process -= synth->buffersize;
             }
-            if (to_process > 0)
+            if (to_process > 0)    ////////////////////////TODO: handle discrepancy between SyntEngine::buffersize and output buffersize
             {
-                _synth->MasterAudio(tmpLeft, tmpRight, to_process);
+                _synth->MasterAudio(tmpLeft, tmpRight); ///TODO  , to_process);
                 processed += to_process;
                 to_process = 0;
             }
@@ -160,7 +160,7 @@ void YoshimiLV2Plugin::process(uint32_t sample_count)
     {
         while (to_process >= synth->buffersize)
         {
-            _synth->MasterAudio(tmpLeft, tmpRight, synth->buffersize);
+            _synth->MasterAudio(tmpLeft, tmpRight);
             for (uint32_t i = 0; i < NUM_MIDI_PARTS + 1; ++i)
             {
                 tmpLeft [i] += synth->buffersize;
@@ -171,7 +171,7 @@ void YoshimiLV2Plugin::process(uint32_t sample_count)
         }
         if (to_process > 0)
         {
-            _synth->MasterAudio(tmpLeft, tmpRight, to_process);
+            _synth->MasterAudio(tmpLeft, tmpRight);////////TODO  , to_process);
             for (uint32_t i = 0; i < NUM_MIDI_PARTS + 1; ++i)
             {
                 tmpLeft [i] += to_process;

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -138,11 +138,11 @@ void YoshimiLV2Plugin::process(uint32_t sample_count)
 
             if (next_frame >= sample_count)
                 continue;
-            while (processed < next_frame && to_process >= ActualBufferSize)
+            while (processed < next_frame && to_process >= synth->buffersize)
             {
-                _synth->MasterAudio(tmpLeft, tmpRight, ActualBufferSize);
-                processed += ActualBufferSize;
-                to_process -= ActualBufferSize;
+                _synth->MasterAudio(tmpLeft, tmpRight, synth->buffersize);
+                processed += synth->buffersize;
+                to_process -= synth->buffersize;
             }
             if (to_process > 0)
             {
@@ -158,16 +158,16 @@ void YoshimiLV2Plugin::process(uint32_t sample_count)
 
     if (to_process > 0)
     {
-        while (to_process >= ActualBufferSize)
+        while (to_process >= synth->buffersize)
         {
-            _synth->MasterAudio(tmpLeft, tmpRight, ActualBufferSize);
+            _synth->MasterAudio(tmpLeft, tmpRight, synth->buffersize);
             for (uint32_t i = 0; i < NUM_MIDI_PARTS + 1; ++i)
             {
-                tmpLeft [i] += ActualBufferSize;
-                tmpRight [i] += ActualBufferSize;
+                tmpLeft [i] += synth->buffersize;
+                tmpRight [i] += synth->buffersize;
             }
-            processed += ActualBufferSize;
-            to_process -= ActualBufferSize;
+            processed += synth->buffersize;
+            to_process -= synth->buffersize;
         }
         if (to_process > 0)
         {

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -54,7 +54,6 @@
 #define YOSHIMI_LV2_STATE__StateChanged      "http://lv2plug.in/ns/ext/state#StateChanged"
 
 extern SynthEngine *firstSynth;
-extern int startInstance;
 
 typedef enum {
     LV2_OPTIONS_INSTANCE,
@@ -451,14 +450,6 @@ void YoshimiLV2Plugin::cleanup(LV2_Handle instance)
 }
 
 
-/*
-LV2_Worker_Interface yoshimi_wrk_iface =
-{
-    YoshimiLV2Plugin::lv2wrk_work,
-    YoshimiLV2Plugin::lv2wrk_response,
-    YoshimiLV2Plugin::lv2_wrk_end_run
-};
-*/
 
 LV2_Programs_Interface yoshimi_prg_iface =
 {
@@ -611,25 +602,6 @@ void YoshimiLV2Plugin::static_SelectProgramNew(LV2_Handle handle, unsigned char 
 }
 
 
-/*
-LV2_Worker_Status YoshimiLV2Plugin::lv2wrk_work(LV2_Handle instance, LV2_Worker_Respond_Function respond, LV2_Worker_Respond_Handle handle, uint32_t size, const void *data)
-{
-
-}
-
-
-LV2_Worker_Status YoshimiLV2Plugin::lv2wrk_response(LV2_Handle instance, uint32_t size, const void *body)
-{
-
-}
-
-
-LV2_Worker_Status YoshimiLV2Plugin::lv2_wrk_end_run(LV2_Handle instance)
-{
-
-}
-
-*/
 
 
 YoshimiLV2PluginUI::YoshimiLV2PluginUI(const char *, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature * const *features)

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -250,7 +250,7 @@ YoshimiLV2Plugin::YoshimiLV2Plugin(SynthEngine *synth, double sampleRate, const 
     MusicIO(synth),
     _synth(synth),
     _sampleRate(static_cast<uint32_t>(sampleRate)),
-    _bufferSize(0),
+    _maxOutputBufferSize(0),
     _bundlePath(bundlePath),
     _midiDataPort(NULL),
     _notifyDataPortOut(NULL),
@@ -299,16 +299,16 @@ YoshimiLV2Plugin::YoshimiLV2Plugin(SynthEngine *synth, double sampleRate, const 
                 if ((options->key == minBufSz || options->key == maxBufSz) && options->type == atomInt)
                 {
                     uint32_t bufSz = *static_cast<const uint32_t *>(options->value);
-                    if (_bufferSize < bufSz)
-                        _bufferSize = bufSz;
+                    if (_maxOutputBufferSize < bufSz)
+                        _maxOutputBufferSize = bufSz;
                 }
             }
             ++options;
         }
     }
 
-    if (_bufferSize == 0)
-        _bufferSize = MAX_BUFFER_SIZE;
+    if (_maxOutputBufferSize == 0)
+        _maxOutputBufferSize = MAX_BUFFER_SIZE;
 }
 
 
@@ -330,7 +330,7 @@ YoshimiLV2Plugin::~YoshimiLV2Plugin()
 
 bool YoshimiLV2Plugin::init()
 {
-    if (_uridMap.map == NULL || _sampleRate == 0 || _bufferSize == 0 || _midi_event_id == 0 || _yoshimi_state_id == 0 || _atom_string_id == 0)
+    if (_uridMap.map == NULL || _sampleRate == 0 || _maxOutputBufferSize == 0 || _midi_event_id == 0 || _yoshimi_state_id == 0 || _atom_string_id == 0)
         return false;
     if (!prepBuffers())
         return false;

--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -48,7 +48,7 @@ class YoshimiLV2Plugin : public MusicIO
 private:
    SynthEngine *_synth;
    uint32_t _sampleRate;
-   uint32_t _bufferSize;
+   uint32_t _maxOutputBufferSize;
    std::string _bundlePath;
    LV2_URID_Map _uridMap;
    LV2_Atom_Sequence *_midiDataPort;
@@ -89,7 +89,7 @@ public:
 
    //virtual methods from MusicIO
    unsigned int getSamplerate(void) {return _sampleRate; }
-   int getBuffersize(void) {return _bufferSize; }
+   int getOutputBufferSize(void) {return _maxOutputBufferSize; }
    bool Start(void) {synth->Unmute(); return true; }
    void Close(void) {synth->Mute();}
 

--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -72,7 +72,6 @@ private:
 
    float *_bFreeWheel;
 
-   jack_ringbuffer_t *_midiRingBuf;
    pthread_t _pIdleThread;
 
    float *lv2Left [NUM_MIDI_PARTS + 1];

--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -73,15 +73,16 @@ private:
    float *_bFreeWheel;
 
    pthread_t _pIdleThread;
+   std::vector <LV2_Program_Descriptor> flatbankprgs;
+   const LV2_Descriptor *_lv2_desc;
 
    float *lv2Left [NUM_MIDI_PARTS + 1];
    float *lv2Right [NUM_MIDI_PARTS + 1];
 
    void process(uint32_t sample_count);
+   void pushAudioOutput(uint32_t offset, uint32_t sample_count) override;
    void processMidiMessage(const uint8_t *msg);
    void *idleThread(void);
-   std::vector <LV2_Program_Descriptor> flatbankprgs;
-   const LV2_Descriptor *_lv2_desc;
 public:
    YoshimiLV2Plugin(SynthEngine *synth, double sampleRate, const char *bundlePath, const LV2_Feature *const *features, const LV2_Descriptor *desc);
    virtual ~YoshimiLV2Plugin();

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -880,12 +880,9 @@ void Config::StartupReport(string clientName)
     Log(report, 2);
     if (fullInfo)
     {
+        Log("Buffsize: " + asString(synth->buffersize), 2);
         Log("Oscilsize: " + asString(synth->oscilsize), 2);
         Log("Samplerate: " + asString(synth->samplerate), 2);
-        if (audioEngine == alsa_audio)
-            Log("Period size: " + asString(Buffersize), 2);
-        //else
-            //Log("Period size: " + asString(synth->buffersize), 2);
     }
 }
 //#endif

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -336,6 +336,7 @@ string Config::testCCvalue(int cc)
 
         default:
             result = masterCCtest(cc);
+            break;
     }
     return result;
 }
@@ -399,7 +400,6 @@ string Config::masterCCtest(int cc)
             break;
 
         default:
-        {
             if (cc < 128) // don't compare with 'disabled' state
             {
                 if (cc == midi_bank_C)
@@ -411,7 +411,7 @@ string Config::masterCCtest(int cc)
                 else if (cc == channelSwitchCC)
                     result = "channel switcher";
             }
-        }
+            break;
     }
     return result;
 }
@@ -855,6 +855,7 @@ void Config::StartupReport(string clientName)
 
         default:
             report += "nada";
+            break;
     }
     report += (" -> '" + audioDevice + "'");
     Log(report, 2);
@@ -871,6 +872,7 @@ void Config::StartupReport(string clientName)
 
         default:
             report += "nada";
+            break;
     }
     if (!midiDevice.size())
         midiDevice = "default";

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -880,7 +880,10 @@ void Config::StartupReport(string clientName)
     {
         Log("Oscilsize: " + asString(synth->oscilsize), 2);
         Log("Samplerate: " + asString(synth->samplerate), 2);
-        Log("Period size: " + asString(synth->buffersize), 2);
+        if (audioEngine == alsa_audio)
+            Log("Period size: " + asString(Buffersize), 2);
+        //else
+            //Log("Period size: " + asString(synth->buffersize), 2);
     }
 }
 //#endif

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -952,8 +952,8 @@ void Part::ComputePartSmps(void)
     tmpoutr = synth->getRuntime().genMixr;
     for (int nefx = 0; nefx < NUM_PART_EFX + 1; ++nefx)
     {
-        memset(partfxinputl[nefx], 0, synth->sent_bufferbytes);
-        memset(partfxinputr[nefx], 0, synth->sent_bufferbytes);
+        memset(partfxinputl[nefx], 0, synth->bufferbytes);
+        memset(partfxinputr[nefx], 0, synth->bufferbytes);
     }
 
     for (k = 0; k < POLIPHONY; ++k)
@@ -976,7 +976,7 @@ void Part::ComputePartSmps(void)
                 if (adnote->ready)
                 {
                     adnote->noteout(tmpoutl, tmpoutr);
-                    for (int i = 0; i < synth->sent_buffersize; ++i)
+                    for (int i = 0; i < synth->buffersize; ++i)
                     {   // add the ADnote to part(mix)
                         partfxinputl[sendcurrenttofx][i] += tmpoutl[i];
                         partfxinputr[sendcurrenttofx][i] += tmpoutr[i];
@@ -995,7 +995,7 @@ void Part::ComputePartSmps(void)
                 if (subnote->ready)
                 {
                     subnote->noteout(tmpoutl, tmpoutr);
-                    for (int i = 0; i < synth->sent_buffersize; ++i)
+                    for (int i = 0; i < synth->buffersize; ++i)
                     {   // add the SUBnote to part(mix)
                         partfxinputl[sendcurrenttofx][i] += tmpoutl[i];
                         partfxinputr[sendcurrenttofx][i] += tmpoutr[i];
@@ -1014,7 +1014,7 @@ void Part::ComputePartSmps(void)
                 if (padnote->ready)
                 {
                     padnote->noteout(tmpoutl, tmpoutr);
-                    for (int i = 0 ; i < synth->sent_buffersize; ++i)
+                    for (int i = 0 ; i < synth->buffersize; ++i)
                     {   // add the PADnote to part(mix)
                         partfxinputl[sendcurrenttofx][i] += tmpoutl[i];
                         partfxinputr[sendcurrenttofx][i] += tmpoutr[i];
@@ -1049,7 +1049,7 @@ void Part::ComputePartSmps(void)
             partefx[nefx]->out(partfxinputl[nefx], partfxinputr[nefx]);
             if (Pefxroute[nefx] == 2)
             {
-                for (int i = 0; i < synth->sent_buffersize; ++i)
+                for (int i = 0; i < synth->buffersize; ++i)
                 {
                     partfxinputl[nefx + 1][i] += partefx[nefx]->efxoutl[i];
                     partfxinputr[nefx + 1][i] += partefx[nefx]->efxoutr[i];
@@ -1057,21 +1057,21 @@ void Part::ComputePartSmps(void)
             }
         }
         int routeto = (Pefxroute[nefx] == 0) ? nefx + 1 : NUM_PART_EFX;
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             partfxinputl[routeto][i] += partfxinputl[nefx][i];
             partfxinputr[routeto][i] += partfxinputr[nefx][i];
         }
     }
-    memcpy(partoutl, partfxinputl[NUM_PART_EFX], synth->sent_bufferbytes);
-    memcpy(partoutr, partfxinputr[NUM_PART_EFX], synth->sent_bufferbytes);
+    memcpy(partoutl, partfxinputl[NUM_PART_EFX], synth->bufferbytes);
+    memcpy(partoutr, partfxinputr[NUM_PART_EFX], synth->bufferbytes);
 
     // Kill All Notes if killallnotes true
     if (killallnotes)
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
-            float tmp = (synth->sent_buffersize - i) / synth->sent_buffersize_f;
+            float tmp = (synth->buffersize - i) / synth->buffersize_f;
             partoutl[i] *= tmp;
             partoutr[i] *= tmp;
         }

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -99,16 +99,20 @@ SynthEngine::SynthEngine(int argc, char **argv, bool _isLV2Plugin, unsigned int 
     interchange(this),
     midilearn(this),
     mididecode(this),
-    //unifiedpresets(this),
+    unifiedpresets(),
     Runtime(this, argc, argv),
     presetsstore(this),
+    legatoPart(0),
+    masterMono(false),
     fadeAll(0),
+    fadeStep(0),
     fadeLevel(0),
     samplerate(48000),
     samplerate_f(samplerate),
     halfsamplerate_f(samplerate / 2),
     buffersize(128),
     buffersize_f(buffersize),
+    bufferbytes(buffersize * sizeof(float)),
     oscilsize(512),
     oscilsize_f(oscilsize),
     halfoscilsize(oscilsize / 2),
@@ -116,11 +120,20 @@ SynthEngine::SynthEngine(int argc, char **argv, bool _isLV2Plugin, unsigned int 
     sent_buffersize(0),
     sent_bufferbytes(0),
     sent_buffersize_f(0),
+    TransVolume(0.0),
+    Pvolume(90),
+    ControlStep(0.0),
+    Pkeyshift(64),
+    syseffnum(0),
+    inseffnum(0),
     ctl(NULL),
     microtonal(this),
     fft(NULL),
+    VUcount(0),
+    VUready(false),
     muted(0),
-    //stateXMLtree(NULL),
+    volume(0.0),
+    keyshift(0),
 #ifdef GUI_FLTK
     guiMaster(NULL),
     guiClosedCallback(NULL),
@@ -1995,8 +2008,8 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
             for (int npart = 0; npart < Runtime.NumAvailableParts; ++npart)
             {
                 if (partLocal[npart]        // it's enabled
-                 && Psysefxvol[nefx][npart]      // it's sending an output
-                 && part[npart]->Paudiodest & 1) // it's connected to the main outs
+                 && Psysefxvol[nefx][npart]        // it's sending an output
+                 && (part[npart]->Paudiodest & 1)) // it's connected to the main outs
                 {
                     // the output volume of each part to system effect
                     float vol = sysefxvol[nefx][npart];
@@ -2281,11 +2294,6 @@ void SynthEngine::setPsysefxsend(int Pefxfrom, int Pefxto, char Pvol)
 {
     Psysefxsend[Pefxfrom][Pefxto] = Pvol;
     sysefxsend[Pefxfrom][Pefxto]  = powf(0.1f, (1.0f - Pvol / 96.0f) * 2.0f);
-}
-
-void SynthEngine::setPaudiodest(int value)
-{
-    Paudiodest = value;
 }
 
 
@@ -3584,6 +3592,7 @@ float SynthEngine::getConfigLimits(CommandBlock *getData)
             break;
         case CONFIG::control::enableNRPNs:
             def = 1;
+            break;
 
         case CONFIG::control::saveCurrentConfig:
             break;

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -107,9 +107,9 @@ SynthEngine::SynthEngine(int argc, char **argv, bool _isLV2Plugin, unsigned int 
     samplerate(48000),
     samplerate_f(samplerate),
     halfsamplerate_f(samplerate / 2),
-    buffersize(512),
+    buffersize(128),
     buffersize_f(buffersize),
-    oscilsize(1024),
+    oscilsize(512),
     oscilsize_f(oscilsize),
     halfoscilsize(oscilsize / 2),
     halfoscilsize_f(halfoscilsize),
@@ -200,13 +200,12 @@ SynthEngine::~SynthEngine()
 }
 
 
-bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
+bool SynthEngine::Init(unsigned int audiosrate)
 {
     samplerate_f = samplerate = audiosrate;
     halfsamplerate_f = samplerate_f / 2;
-    //buffersize = Runtime.Buffersize;
     buffersize = ActualBufferSize;
-    buffersize_f = buffersize;
+    buffersize_f = float(buffersize);
     bufferbytes = buffersize * sizeof(float);
 
     oscilsize_f = oscilsize = Runtime.Oscilsize;

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -217,7 +217,7 @@ bool SynthEngine::Init(unsigned int audiosrate)
 {
     samplerate_f = samplerate = audiosrate;
     halfsamplerate_f = samplerate_f / 2;
-    buffersize = ActualBufferSize;
+    buffersize = Runtime.Buffersize;
     buffersize_f = float(buffersize);
     bufferbytes = buffersize * sizeof(float);
 
@@ -1915,7 +1915,7 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
 
     float *tmpmixl = Runtime.genMixl;
     float *tmpmixr = Runtime.genMixr;
-    sent_buffersize = ActualBufferSize;
+    sent_buffersize = buffersize;
     sent_bufferbytes = bufferbytes;
     sent_buffersize_f = buffersize_f;
     if (to_process < sent_buffersize)

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -204,12 +204,9 @@ bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
 {
     samplerate_f = samplerate = audiosrate;
     halfsamplerate_f = samplerate_f / 2;
-    buffersize_f = buffersize = Runtime.Buffersize;
-    if (buffersize_f > audiobufsize)
-        buffersize_f = audiobufsize;
-     // because its now *groups* of audio buffers.
-    sent_all_buffersize_f = buffersize_f;
-
+    //buffersize = Runtime.Buffersize;
+    buffersize = ActualBufferSize;
+    buffersize_f = buffersize;
     bufferbytes = buffersize * sizeof(float);
 
     oscilsize_f = oscilsize = Runtime.Oscilsize;
@@ -1909,8 +1906,7 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
     sent_buffersize = buffersize;
     sent_bufferbytes = bufferbytes;
     sent_buffersize_f = buffersize_f;
-
-    if ((to_process > 0) && (to_process < buffersize))
+    if (to_process < buffersize)
     {
         sent_buffersize = to_process;
         sent_bufferbytes = sent_buffersize * sizeof(float);

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -1902,17 +1902,16 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
 
     float *tmpmixl = Runtime.genMixl;
     float *tmpmixr = Runtime.genMixr;
-    sent_buffersize = buffersize;
+    sent_buffersize = ActualBufferSize;
     sent_bufferbytes = bufferbytes;
     sent_buffersize_f = buffersize_f;
-    if (to_process < buffersize)
+    if (to_process < ActualBufferSize)
     {
         sent_buffersize = to_process;
         sent_bufferbytes = sent_buffersize * sizeof(float);
         sent_buffersize_f = sent_buffersize;
-        //Runtime.Log("Short Buffer");
+        //cout << "Short Buffer" << endl;;
     }
-
     memset(mainL, 0, sent_bufferbytes);
     memset(mainR, 0, sent_bufferbytes);
 

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -1905,12 +1905,12 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
     sent_buffersize = ActualBufferSize;
     sent_bufferbytes = bufferbytes;
     sent_buffersize_f = buffersize_f;
-    if (to_process < ActualBufferSize)
+    if (to_process < sent_buffersize)
     {
         sent_buffersize = to_process;
         sent_bufferbytes = sent_buffersize * sizeof(float);
         sent_buffersize_f = sent_buffersize;
-        //cout << "Short Buffer" << endl;;
+        //Runtime.Log("Buffer " + to_string(to_process));
     }
     memset(mainL, 0, sent_bufferbytes);
     memset(mainR, 0, sent_bufferbytes);

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -77,7 +77,7 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
     public:
         SynthEngine(int argc, char **argv, bool _isLV2Plugin = false, unsigned int forceId = 0);
         ~SynthEngine();
-        bool Init(unsigned int audiosrate, int audiobufsize);
+        bool Init(unsigned int audiosrate);
 
         bool savePatchesXML(string filename);
         void add2XML(XMLwrapper *xml);

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -185,7 +185,6 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
         float         TransVolume;
         float         Pvolume;
         float         ControlStep;
-        int           Paudiodest;
         int           Pkeyshift;
         unsigned char Psysefxvol[NUM_SYS_EFX][NUM_MIDI_PARTS];
         unsigned char Psysefxsend[NUM_SYS_EFX][NUM_SYS_EFX];
@@ -195,7 +194,6 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
         void setPkeyshift(int Pkeyshift_);
         void setPsysefxvol(int Ppart, int Pefx, char Pvol);
         void setPsysefxsend(int Pefxfrom, int Pefxto, char Pvol);
-        void setPaudiodest(int value);
 
         // effects
         unsigned char  syseffnum;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -141,7 +141,7 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
         void resetAll(bool andML);
         void ShutUp(void);
         void allStop(unsigned int stopType);
-        int MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_MIDI_PARTS + 1], int to_process = 0);
+        int MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_MIDI_PARTS + 1]);
         void partonoffLock(int npart, int what);
         void partonoffWrite(int npart, int what);
         char partonoffRead(int npart);
@@ -179,9 +179,6 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
         int halfoscilsize;
         float halfoscilsize_f;
 
-        int sent_buffersize; //used for variable length runs
-        int sent_bufferbytes; //used for variable length runs
-        float sent_buffersize_f; //used for variable length runs
         float         TransVolume;
         float         Pvolume;
         float         ControlStep;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -182,7 +182,6 @@ class SynthEngine : private SynthHelper, MiscFuncs, FileMgr
         int sent_buffersize; //used for variable length runs
         int sent_bufferbytes; //used for variable length runs
         float sent_buffersize_f; //used for variable length runs
-        float sent_all_buffersize_f; //used for variable length runs (mainly for lv2 - calculate envelopes and lfo)
         float         TransVolume;
         float         Pvolume;
         float         ControlStep;

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -465,11 +465,11 @@ void *AlsaEngine::AudioThread(void)
         {
             int alsa_buff = audio.period_size;//audio.buffer_size;
             int offset = 0;
-            while (alsa_buff - offset >= ActualBufferSize)
+            while (alsa_buff - offset >= synth->buffersize)
             {
-                synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);
-                Interleave(offset, ActualBufferSize);
-                offset += ActualBufferSize;
+                synth->MasterAudio(zynLeft, zynRight, synth->buffersize);
+                Interleave(offset, synth->buffersize);
+                offset += synth->buffersize;
             }
             int remainder = alsa_buff - offset;
             if ( remainder > 0)

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -25,7 +25,6 @@
 #include "Misc/Config.h"
 #include "Misc/SynthEngine.h"
 #include "MusicIO/AlsaEngine.h"
-#include <iostream>
 
 AlsaEngine::AlsaEngine(SynthEngine *_synth) :MusicIO(_synth)
 {
@@ -65,8 +64,8 @@ bool AlsaEngine::openAudio(void)
             {
                 if (prepBuffers())
                 {
-                    int buffersize = getBuffersize();
-                    interleaved = new int[buffersize * card_chans];
+                    int buffersize = audio.period_size;
+                    interleaved = new int[audio.buffer_size * card_chans];
                     if (NULL == interleaved)
                         goto bail_out;
                     memset(interleaved, 0, sizeof(int) * buffersize * card_chans);
@@ -315,7 +314,7 @@ bool AlsaEngine::prepHwparams(void)
     {
         synth->getRuntime().Log("Asked for buffersize " + asString(ask_buffersize, 2)
                     + ", Alsa dictates " + asString((unsigned int)audio.period_size), 2);
-        //synth->getRuntime().Buffersize = audio.period_size; // we shouldn't need to do this :(
+        synth->getRuntime().Buffersize = audio.period_size; // we shouldn't need to do this :(
     }
     return true;
 
@@ -357,7 +356,7 @@ bail_out:
 
 void AlsaEngine::Interleave(int offset, int buffersize)
 {
-    int idx = offset;
+    //int idx = offset;
     bool byte_swap = (little_endian != card_endian);
     unsigned short int tmp16a, tmp16b;
     int chans;
@@ -368,6 +367,7 @@ void AlsaEngine::Interleave(int offset, int buffersize)
 
     if (card_bits == 16)
     {
+        int idx = offset;
         chans = card_chans / 2; // because we're pairing them on a single integer
         for (int frame = 0; frame < buffersize; ++frame)
         {
@@ -384,6 +384,7 @@ void AlsaEngine::Interleave(int offset, int buffersize)
     }
     else
     {
+        int idx = offset << 1;
         chans = card_chans;
         for (int frame = 0; frame < buffersize; ++frame)
         {
@@ -457,14 +458,26 @@ void *AlsaEngine::AudioThread(void)
             }*/
             audio.pcm_state = snd_pcm_state(audio.handle);
         }
+
         if (audio.pcm_state == SND_PCM_STATE_RUNNING)
         {
-            int alsa_buff = ActualBufferSize;//getBuffersize();
-            for (int offset = 0; offset < alsa_buff; offset += ActualBufferSize)
+            int alsa_buff = audio.buffer_size;
+            int offset = 0;
+            int loops = 0;
+            while ((offset + ActualBufferSize) < alsa_buff)
             {
-                synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);//getAudio();
+                synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);
                 Interleave(offset, ActualBufferSize);
+                offset += ActualBufferSize;
+                ++ loops;
             }
+            int remainder = alsa_buff - offset;
+            if ( remainder > 0)
+            {
+                synth->MasterAudio(zynLeft, zynRight, remainder);
+                Interleave(offset, remainder);
+            }
+
             Write(alsa_buff);
         }
         else

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -361,8 +361,8 @@ void AlsaEngine::Interleave(int offset, int buffersize)
 
     if (card_bits == 16)
     {
-        int idx = offset;
         int chans = card_chans / 2; // because we're pairing them on a single integer
+        int idx = offset * chans;
         for (int frame = 0; frame < buffersize; ++frame)
         {
             uint16_t tmp16a = uint16_t(zynLeft[NUM_MIDI_PARTS][frame] * float(0x7800));
@@ -378,7 +378,7 @@ void AlsaEngine::Interleave(int offset, int buffersize)
     }
     else
     {
-        int idx = offset << 1;
+        int idx = offset * card_chans;
         float shift;
         if (card_bits == 32)
             shift = float(0x78000000);

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -319,7 +319,6 @@ bool AlsaEngine::prepHwparams(void)
     {
         synth->getRuntime().Log("Asked for buffersize " + asString(ask_buffersize, 2)
                     + ", Alsa dictates " + asString((unsigned int)audio.period_size), 2);
-        synth->getRuntime().Buffersize = audio.period_size; // we shouldn't need to do this :(
     }
     return true;
 

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -27,12 +27,17 @@
 #include "MusicIO/AlsaEngine.h"
 #include <iostream>
 
-AlsaEngine::AlsaEngine(SynthEngine *_synth) :MusicIO(_synth)
+AlsaEngine::AlsaEngine(SynthEngine *_synth) : MusicIO(_synth),
+    little_endian(synth->getRuntime().isLittleEndian),
+    card_endian(little_endian),
+    card_signed(true),
+    card_chans(2),
+    card_bits(8),
+    pcmWrite(NULL)
 {
     audio.handle = NULL;
     audio.period_count = 0; // re-used as number of periods
     audio.samplerate = 0;
-    audio.period_size = 0;
     audio.period_size = 0;
     audio.buffer_size = 0;
     audio.alsaId = -1;
@@ -41,7 +46,6 @@ AlsaEngine::AlsaEngine(SynthEngine *_synth) :MusicIO(_synth)
     midi.handle = NULL;
     midi.alsaId = -1;
     midi.pThread = 0;
-    little_endian = synth->getRuntime().isLittleEndian;
 }
 
 

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -32,7 +32,7 @@ AlsaEngine::AlsaEngine(SynthEngine *_synth) :MusicIO(_synth)
     audio.handle = NULL;
     audio.period_count = 0; // re-used as number of periods
     audio.samplerate = 0;
-    audio.buffer_size = 0;
+    audio.period_size = 0;
     audio.period_size = 0;
     audio.buffer_size = 0;
     audio.alsaId = -1;
@@ -396,7 +396,7 @@ void AlsaEngine::Interleave(int offset, int buffersize)
                 tmp32b = (tmp32b >> 24) | ((tmp32b << 8) & 0x00FF0000) | ((tmp32b >> 8) & 0x0000FF00) | (tmp32b << 24);
             }
             interleaved[idx] = int32_t(tmp32a);
-            interleaved[idx + card_chans] = int32_t(tmp32b);
+            interleaved[idx + 1] = int32_t(tmp32b);
             idx += card_chans;
         }
     }
@@ -459,9 +459,9 @@ void *AlsaEngine::AudioThread(void)
 
         if (audio.pcm_state == SND_PCM_STATE_RUNNING)
         {
-            int alsa_buff = audio.buffer_size;
+            int alsa_buff = audio.period_size;//audio.buffer_size;
             int offset = 0;
-            while ((offset + ActualBufferSize) <= alsa_buff)
+            while (alsa_buff - offset >= ActualBufferSize)
             {
                 synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);
                 Interleave(offset, ActualBufferSize);

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -466,14 +466,14 @@ void *AlsaEngine::AudioThread(void)
             int offset = 0;
             while (alsa_buff - offset >= synth->buffersize)
             {
-                synth->MasterAudio(zynLeft, zynRight, synth->buffersize);
+                synth->MasterAudio(zynLeft, zynRight);
                 Interleave(offset, synth->buffersize);
                 offset += synth->buffersize;
             }
-            int remainder = alsa_buff - offset;
+            int remainder = alsa_buff - offset;    ////////////////////////TODO: handle discrepancy between SyntEngine::buffersize and output buffersize
             if ( remainder > 0)
             {
-                synth->MasterAudio(zynLeft, zynRight, remainder);
+                synth->MasterAudio(zynLeft, zynRight); ////////////////////TODO , remainder);
                 Interleave(offset, remainder);
             }
 

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -62,7 +62,7 @@ class AlsaEngine : public MusicIO
     private:
         bool prepHwparams(void);
         bool prepSwparams(void);
-        void Interleave(int offset, int buffersize);
+        void pushAudioOutput(uint32_t offset, uint32_t sample_count) override;
         void Write(snd_pcm_uframes_t towrite);
         bool Recover(int err);
         bool xrunRecover(void);

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -55,9 +55,9 @@ class AlsaEngine : public MusicIO
 
         bool little_endian;
         bool card_endian;
-        int card_bits;
         bool card_signed;
         unsigned int card_chans;
+        int card_bits;
 
     private:
         bool prepHwparams(void);

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -62,7 +62,7 @@ class AlsaEngine : public MusicIO
     private:
         bool prepHwparams(void);
         bool prepSwparams(void);
-        void Interleave(int buffersize);
+        void Interleave(int offset, int buffersize);
         void Write(snd_pcm_uframes_t towrite);
         bool Recover(int err);
         bool xrunRecover(void);

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -45,7 +45,7 @@ class AlsaEngine : public MusicIO
         void Close(void);
 
         unsigned int getSamplerate(void) { return audio.samplerate; }
-        int getBuffersize(void) { return audio.period_size; }
+        int getOutputBufferSize(void) { return audio.period_size; }
 
         std::string audioClientName(void);
         std::string midiClientName(void);

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -37,7 +37,7 @@ class AlsaEngine : public MusicIO
 {
     public:
         AlsaEngine(SynthEngine *_synth);
-        ~AlsaEngine() { }
+        virtual ~AlsaEngine() { }
 
         bool openAudio(void);
         bool openMidi(void);

--- a/src/MusicIO/JackEngine.cpp
+++ b/src/MusicIO/JackEngine.cpp
@@ -134,7 +134,6 @@ bool JackEngine::openJackClient(std::string server)
 bool JackEngine::Start(void)
 {
     bool jackPortsRegistered = true;
-    internalbuff = synth->getRuntime().Buffersize;
     jack_set_xrun_callback(jackClient, _xrunCallback, this);
     #if defined(JACK_SESSION)
         if (jack_set_session_callback

--- a/src/MusicIO/JackEngine.cpp
+++ b/src/MusicIO/JackEngine.cpp
@@ -404,10 +404,10 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
         return false;
     }
 
-    int framesize = sizeof(float) * ActualBufferSize;
-    for (unsigned int pos = 0; pos < nframes; pos += ActualBufferSize)
+    int framesize = sizeof(float) * synth->buffersize;
+    for (unsigned int pos = 0; pos < nframes; pos += synth->buffersize)
     {
-        if (nframes < ActualBufferSize)
+        if (nframes < synth->buffersize)   //////////TODO comparison signed / unsigned; however, this whole "calculate remainder" approach is questionable...
         {
             synth->MasterAudio(zynLeft, zynRight, nframes);
             sendAudio(sizeof(float) * nframes, 0);
@@ -415,7 +415,7 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
         }
         else
         {
-            synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);
+            synth->MasterAudio(zynLeft, zynRight, synth->buffersize);
             sendAudio(framesize, pos);
         }
     }

--- a/src/MusicIO/JackEngine.cpp
+++ b/src/MusicIO/JackEngine.cpp
@@ -405,20 +405,19 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
         return false;
     }
 
-    int framesize;
-    if (nframes < internalbuff)
+    int framesize = sizeof(float) * ActualBufferSize;
+    for (unsigned int pos = 0; pos < nframes; pos += ActualBufferSize)
     {
-        framesize = sizeof(float) * nframes;
-        synth->MasterAudio(zynLeft, zynRight, nframes);
-        sendAudio(framesize, 0);
-    }
-    else
-    {
-        framesize = sizeof(float) * internalbuff;
-        for (unsigned int pos = 0; pos < nframes; pos += internalbuff)
+        if (nframes < ActualBufferSize)
         {
-        synth->MasterAudio(zynLeft, zynRight, internalbuff);
-        sendAudio(framesize, pos);
+            synth->MasterAudio(zynLeft, zynRight, nframes);
+            sendAudio(sizeof(float) * nframes, 0);
+            break;
+        }
+        else
+        {
+            synth->MasterAudio(zynLeft, zynRight, ActualBufferSize);
+            sendAudio(framesize, pos);
         }
     }
     return true;

--- a/src/MusicIO/JackEngine.cpp
+++ b/src/MusicIO/JackEngine.cpp
@@ -408,14 +408,14 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
     for (unsigned int pos = 0; pos < nframes; pos += synth->buffersize)
     {
         if (nframes < synth->buffersize)   //////////TODO comparison signed / unsigned; however, this whole "calculate remainder" approach is questionable...
-        {
-            synth->MasterAudio(zynLeft, zynRight, nframes);
+        {                    ////////////////////////TODO: handle discrepancy between SyntEngine::buffersize and output buffersize
+            synth->MasterAudio(zynLeft, zynRight); //TODO  , nframes);
             sendAudio(sizeof(float) * nframes, 0);
             break;
         }
         else
         {
-            synth->MasterAudio(zynLeft, zynRight, synth->buffersize);
+            synth->MasterAudio(zynLeft, zynRight);
             sendAudio(framesize, pos);
         }
     }

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -41,7 +41,7 @@ class JackEngine : public MusicIO
 {
     public:
         JackEngine(SynthEngine *_synth);
-        ~JackEngine() { Close(); }
+        virtual ~JackEngine() { Close(); }
         bool isConnected(void) { return (NULL != jackClient); }
         bool connectServer(std::string server);
         bool openAudio(void);

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -73,7 +73,6 @@ class JackEngine : public MusicIO
 #if defined(JACK_SESSION)
             static void _jsessionCallback(jack_session_event_t *event, void *arg);
             void jsessionCallback(jack_session_event_t *event);
-            jack_session_event_t *lastevent;
 #endif
 
 #if defined(JACK_LATENCY)
@@ -94,8 +93,6 @@ class JackEngine : public MusicIO
             jack_ringbuffer_t *ringBuf;
             pthread_t          pThread;
         } midi;
-
-        unsigned int internalbuff;
 };
 
 #endif

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -49,7 +49,7 @@ class JackEngine : public MusicIO
         bool Start(void);
         void Close(void);
         unsigned int getSamplerate(void) { return audio.jackSamplerate; }
-        int getBuffersize(void) { return audio.jackNframes; }
+        int getOutputBufferSize(void) { return audio.jackNframes; }
         std::string clientName(void);
         int clientId(void);
         virtual std::string audioClientName(void) { return clientName(); }

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -62,7 +62,7 @@ class JackEngine : public MusicIO
         bool openJackClient(std::string server);
         bool connectJackPorts(void);
         bool processAudio(jack_nframes_t nframes);
-        void sendAudio(int framesize, unsigned int offset);
+        void pushAudioOutput(uint32_t offset, uint32_t sample_count) override;
         bool processMidi(jack_nframes_t nframes);
         bool latencyPrep(void);
         int processCallback(jack_nframes_t nframes);

--- a/src/MusicIO/MusicClient.cpp
+++ b/src/MusicIO/MusicClient.cpp
@@ -269,17 +269,6 @@ unsigned int MusicClient::getSamplerate()
 }
 
 
-int MusicClient::getBuffersize()
-{
-    if(audioIO)
-    {
-        return audioIO->getBuffersize();
-    }
-
-    return synth->getRuntime().Buffersize;
-}
-
-
 std::string MusicClient::audioClientName()
 {
     if(audioIO)

--- a/src/MusicIO/MusicClient.h
+++ b/src/MusicIO/MusicClient.h
@@ -68,7 +68,6 @@ public:
     bool Start(void);
     void Close(void);
     unsigned int getSamplerate(void);
-    int getBuffersize(void);
     std::string audioClientName(void);
     std::string midiClientName(void);
     int audioClientId(void);

--- a/src/MusicIO/MusicIO.cpp
+++ b/src/MusicIO/MusicIO.cpp
@@ -32,7 +32,7 @@
 
 MusicIO::MusicIO(SynthEngine *_synth) :
     interleaved(NULL),
-    synth(_synth)//,
+    synth(_synth)
 {
     memset(zynLeft, 0, sizeof(float *) * (NUM_MIDI_PARTS + 1));
     memset(zynRight, 0, sizeof(float *) * (NUM_MIDI_PARTS + 1));

--- a/src/MusicIO/MusicIO.cpp
+++ b/src/MusicIO/MusicIO.cpp
@@ -153,7 +153,7 @@ bail_out:
 
 /*
  * Pull sound samples from the engine, possibly triggering sound synthesis calculations.
- * The retrieved sound data will be sent to the output sink by calling pushOutput() at least once,
+ * The retrieved sound data will be sent to the output sink by calling pushAudioOutput() at least once,
  * but possibly several times. At the end, precisely the requested amount of samples will be sent
  * to output. Param sample_count is a variable integer, not necessarily a power of two (due to LV2),
  * and can possibly be zero. The only requirement is that sample_count <= output buffer size.
@@ -177,7 +177,7 @@ void MusicIO::pullAudio(uint32_t samples_to_send)
             {// send only some part of the calculated samples
                 chunk = samples_to_send;
             }
-        pushOutput(outputStart, chunk);
+        pushAudioOutput(outputStart, chunk);
         samples_to_send -= chunk;
         outputStart += chunk;
         samplesUsed += chunk;

--- a/src/MusicIO/MusicIO.cpp
+++ b/src/MusicIO/MusicIO.cpp
@@ -110,7 +110,7 @@ void MusicIO::setMidi(unsigned char par0, unsigned char par1, unsigned char par2
 
 bool MusicIO::prepBuffers(void)
 {
-    int buffersize = getBuffersize();
+    int buffersize = synth->getRuntime().Buffersize;
     if (buffersize > 0)
     {
         for (int part = 0; part < (NUM_MIDI_PARTS + 1); part++)

--- a/src/MusicIO/MusicIO.h
+++ b/src/MusicIO/MusicIO.h
@@ -47,14 +47,19 @@ class MusicIO : virtual protected MiscFuncs
         virtual void registerAudioPort(int) = 0;
 
     protected:
-        bool LV2_engine;
-        bool prepBuffers(void);
-        void setMidi(unsigned char par0, unsigned char par1, unsigned char par2, bool in_place = false);
         float *zynLeft [NUM_MIDI_PARTS + 1];
         float *zynRight [NUM_MIDI_PARTS + 1];
         int *interleaved;
 
         SynthEngine *synth;
+        bool LV2_engine;
+        uint32_t samplesUsed;
+
+    protected:
+        bool prepBuffers(void);
+        void setMidi(unsigned char par0, unsigned char par1, unsigned char par2, bool in_place = false);
+        void pullAudio(uint32_t samples_to_send);
+        virtual void pushOutput(uint32_t startpos, uint32_t sample_count)  =0;
 };
 
 #endif

--- a/src/MusicIO/MusicIO.h
+++ b/src/MusicIO/MusicIO.h
@@ -35,7 +35,7 @@ class MusicIO : virtual protected MiscFuncs
         MusicIO(SynthEngine *_synth);
         virtual ~MusicIO();
         virtual unsigned int getSamplerate(void) = 0;
-        virtual int getBuffersize(void) = 0;
+        virtual int getOutputBufferSize(void) = 0;
         virtual bool Start(void) = 0;
         virtual void Close(void) = 0;
         virtual bool openAudio(void) = 0;

--- a/src/MusicIO/MusicIO.h
+++ b/src/MusicIO/MusicIO.h
@@ -49,7 +49,6 @@ class MusicIO : virtual protected MiscFuncs
     protected:
         bool LV2_engine;
         bool prepBuffers(void);
-        void getAudio(void) { if (synth) synth->MasterAudio(zynLeft, zynRight); }
         void setMidi(unsigned char par0, unsigned char par1, unsigned char par2, bool in_place = false);
         float *zynLeft [NUM_MIDI_PARTS + 1];
         float *zynRight [NUM_MIDI_PARTS + 1];

--- a/src/MusicIO/MusicIO.h
+++ b/src/MusicIO/MusicIO.h
@@ -59,7 +59,7 @@ class MusicIO : virtual protected MiscFuncs
         bool prepBuffers(void);
         void setMidi(unsigned char par0, unsigned char par1, unsigned char par2, bool in_place = false);
         void pullAudio(uint32_t samples_to_send);
-        virtual void pushOutput(uint32_t startpos, uint32_t sample_count)  =0;
+        virtual void pushAudioOutput(uint32_t offset, uint32_t sample_count)  =0;
 };
 
 #endif

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -929,6 +929,7 @@ float ADnoteParameters::getLimits(CommandBlock *getData)
 
             case ADDSYNTH::control::dePop:
                 def = FADEIN_ADJUSTMENT_SCALE;
+                break;
 
             case ADDSYNTH::control::punchStrength: // just ensures it doesn't get caught by default
                 break;

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -4,7 +4,7 @@
     Original ZynAddSubFX author Nasca Octavian Paul
     Copyright (C) 2002-2005 Nasca Octavian Paul
     Copyright 2009-2011, Alan Calvert
-    Copyright 2017-2018, Will Godfrey
+    Copyright 2017-2019, Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -22,7 +22,7 @@
 
     This file is derivative of ZynAddSubFX original code.
 
-    Modified October 2018
+    Modified March 2019
 */
 
 #include <cmath>
@@ -281,7 +281,7 @@ int Controller::initportamento(float oldfreq, float newfreq, bool in_progress)
         portamentotime *= powf(0.1f, (64.0f - portamento.updowntimestretch) / 64.0f);
     }
 
-    portamento.dx = synth->sent_all_buffersize_f / (portamentotime * synth->samplerate_f);
+    portamento.dx = synth->sent_buffersize_f / (portamentotime * synth->samplerate_f);
     portamento.origfreqrap = oldfreq / newfreq;
 
     float tmprap = (portamento.origfreqrap > 1.0f)

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -281,7 +281,7 @@ int Controller::initportamento(float oldfreq, float newfreq, bool in_progress)
         portamentotime *= powf(0.1f, (64.0f - portamento.updowntimestretch) / 64.0f);
     }
 
-    portamento.dx = synth->sent_buffersize_f / (portamentotime * synth->samplerate_f);
+    portamento.dx = synth->buffersize_f / (portamentotime * synth->samplerate_f);
     portamento.origfreqrap = oldfreq / newfreq;
 
     float tmprap = (portamento.origfreqrap > 1.0f)

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -297,7 +297,6 @@ float PADnoteParameters::getprofile(float *smp, int size)
     float max = 0.0f;
     for (int i = 0; i < size; ++i)
     {
-        smp[i] = smp[i];
         if (smp[i] > max)
             max = smp[i];
     }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -221,10 +221,8 @@ void ADnote::construct()
                 break;
 
             case 2:  // unison for 2 subvoices
-                {
-                    unison_base_freq_rap[nvoice][0] = 1.0f / unison_real_spread;
-                    unison_base_freq_rap[nvoice][1] = unison_real_spread;
-                }
+                unison_base_freq_rap[nvoice][0] = 1.0f / unison_real_spread;
+                unison_base_freq_rap[nvoice][1] = unison_real_spread;
                 break;
 
             default: // unison for more than 2 subvoices
@@ -251,6 +249,7 @@ void ADnote::construct()
                             powf(2.0f, (unison_spread * unison_values[k]) / 1200.0f);
                     }
                 }
+                break;
         }
         if (is_pwm)
             for (int i = true_unison - 1; i >= 0; i--)
@@ -474,6 +473,7 @@ void ADnote::construct()
                 default:
                     NoteVoicePar[nvoice].FMEnabled = NONE;
                     freqbasedmod[nvoice] = false;
+                    break;
             }
 
         NoteVoicePar[nvoice].FMDetuneFromBaseOsc =
@@ -509,6 +509,7 @@ void ADnote::construct()
                     fmvoldamp = 1.0f;
                 NoteVoicePar[nvoice].FMVolume =
                     adpars->VoicePar[nvoice].PFMVolume / 127.0f * fmvoldamp;
+                break;
         }
 
         // Voice's modulator velocity sensing
@@ -811,6 +812,7 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
                     fmvoldamp = 1.0f;
                 NoteVoicePar[nvoice].FMVolume =
                     adpars->VoicePar[nvoice].PFMVolume / 127.0f * fmvoldamp;
+                break;
         }
 
         // Voice's modulator velocity sensing

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1552,7 +1552,7 @@ void ADnote::computeCurrentParameters(void)
 void ADnote::fadein(float *smps)
 {
     int zerocrossings = 0;
-    for (int i = 1; i < synth->buffersize; ++i)
+    for (int i = 1; i < synth->sent_buffersize; ++i)
         if (smps[i - 1] < 0.0f && smps[i] > 0.0f)
             zerocrossings++; // this is only the positive crossings
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -273,7 +273,7 @@ void ADnote::construct()
         unison_vibratto[nvoice].position = new float[unison];
         unison_vibratto[nvoice].amplitude = (unison_real_spread - 1.0f) * unison_vibratto_a;
 
-        float increments_per_second = synth->samplerate_f / synth->sent_buffersize_f;
+        float increments_per_second = synth->samplerate_f / synth->buffersize_f;
         const float vib_speed = adpars->VoicePar[nvoice].Unison_vibratto_speed / 127.0f;
         float vibratto_base_period  = 0.25f * powf(2.0f, (1.0f - vib_speed) * 4.0f);
         for (int k = 0; k < unison; ++k)
@@ -1554,7 +1554,7 @@ void ADnote::computeCurrentParameters(void)
 void ADnote::fadein(float *smps)
 {
     int zerocrossings = 0;
-    for (int i = 1; i < synth->sent_buffersize; ++i)
+    for (int i = 1; i < synth->buffersize; ++i)
         if (smps[i - 1] < 0.0f && smps[i] > 0.0f)
             zerocrossings++; // this is only the positive crossings
 
@@ -1606,7 +1606,7 @@ inline void ADnote::computeVoiceOscillatorLinearInterpolation(int nvoice)
         float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(oscfreqlo[nvoice][k] < 1.0f);
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             tw[i]  = (smps[poshi] * ((1<<24) - poslo) + smps[poshi + 1] * poslo)/(1.0f*(1<<24));
             poslo += freqlo;
@@ -1634,7 +1634,7 @@ void ADnote::applyVoiceOscillatorMorph(int nvoice)
         float *tw = tmpwave_unison[k];
         float *mod = tmpmod_unison[k];
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float amp = interpolateAmplitude(FMoldamplitude[nvoice],
                                        FMnewamplitude[nvoice], i,
@@ -1658,7 +1658,7 @@ void ADnote::applyVoiceOscillatorRingModulation(int nvoice)
         float *tw = tmpwave_unison[k];
         float *mod = tmpmod_unison[k];
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             amp = interpolateAmplitude(FMoldamplitude[nvoice],
                                        FMnewamplitude[nvoice], i,
@@ -1688,7 +1688,7 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
             const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
             // For historical/compatibility reasons we do not reduce volume here
             // if are using stereo. See same section in computeVoiceOscillator.
-            memcpy(tmpmod_unison[k], smps, synth->sent_bufferbytes);
+            memcpy(tmpmod_unison[k], smps, synth->bufferbytes);
         }
     }
     else if (parentFMmod != NULL) {
@@ -1707,7 +1707,7 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
         for (int k = 0; k < unison_size[nvoice]; ++k)
         {
             float *tw = tmpmod_unison[k];
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 tw[i] *= interpolateAmplitude(FMoldamplitude[nvoice],
                                               FMnewamplitude[nvoice], i,
                                               synth->buffersize);
@@ -1718,7 +1718,7 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
         for (int k = 0; k < unison_size[nvoice]; ++k)
         {
             float *tw = tmpmod_unison[k];
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 tw[i] *= FMnewamplitude[nvoice];
         }
     }
@@ -1733,7 +1733,7 @@ void ADnote::normalizeVoiceModulatorFrequencyModulation(int nvoice, int FMmode)
     if (FMmode == PW_MOD) { // PWM modulation
         for (int k = 1; k < unison_size[nvoice]; k += 2) {
             float *tw = tmpmod_unison[k];
-            for (int i = 1; i < synth->sent_buffersize; ++i)
+            for (int i = 1; i < synth->buffersize; ++i)
                 tw[i] = -tw[i];
         }
     }
@@ -1746,7 +1746,7 @@ void ADnote::normalizeVoiceModulatorFrequencyModulation(int nvoice, int FMmode)
         {
             float *tw = tmpmod_unison[k];
             float  fmold = FMoldsmp[nvoice][k];
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
             {
                 fmold = fmold + tw[i] * normalize;
                 tw[i] = fmold;
@@ -1760,7 +1760,7 @@ void ADnote::normalizeVoiceModulatorFrequencyModulation(int nvoice, int FMmode)
         for (int k = 0; k < unison_size[nvoice]; ++k)
         {
             float *tw = tmpmod_unison[k];
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 tw[i] *= normalize;
         }
     }
@@ -1771,7 +1771,7 @@ void ADnote::normalizeVoiceModulatorFrequencyModulation(int nvoice, int FMmode)
         float *tmp = parentFMmod;
         for (int k = 0; k < unison_size[nvoice]; ++k) {
             float *tw = tmpmod_unison[k];
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
                 tw[i] += tmp[i];
         }
     }
@@ -1790,7 +1790,7 @@ void ADnote::computeVoiceModulatorLinearInterpolation(int nvoice)
         float *tw = tmpmod_unison[k];
         const float *smps = NoteVoicePar[nvoice].FMSmp;
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             tw[i] = (smps[poshiFM] * (1 - posloFM)
                      + smps[poshiFM + 1] * posloFM) / (1.0f);
@@ -1830,7 +1830,7 @@ void ADnote::computeVoiceModulatorFrequencyModulation(int nvoice, int FMmode)
             / ((float)oscfreqhi[nvoice][k] + oscfreqlo[nvoice][k]);
         const float *smps = NoteVoicePar[nvoice].FMSmp;
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float pMod = parentFMmod[i] * oscVsFMratio;
             int FMmodfreqhi = int(pMod);
@@ -1897,9 +1897,8 @@ void ADnote::computeVoiceModulatorForFMFrequencyModulation(int nvoice)
         float oldsmpOrig = FMFMoldsmpOrig[nvoice][k];
 
         // Cache the samples we calculate for a certain nearby range. This is
-        // possible since the base frequency never changes within one
-        // `sent_buffersize`.
-        const int cacheSize = synth->samplerate * 2 + synth->sent_buffersize;
+        // possible since the base frequency never changes within one `buffersize`.
+        const int cacheSize = synth->samplerate * 2 + synth->buffersize;
         float cachedSamples[cacheSize];
         int cachedBackwards, cachedForwards, cacheCenter;
         cachedBackwards = cachedForwards = cacheCenter = cacheSize / 2 - 1;
@@ -1907,7 +1906,7 @@ void ADnote::computeVoiceModulatorForFMFrequencyModulation(int nvoice)
         // The last cached sample was the previous sample.
         cachedSamples[cacheCenter++] = oldsmpOrig;
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float pMod = parentFMmod[i] * oscVsFMratio;
             float sampleDistanceF = pMod / ((float)freqhiFM + freqloFM);
@@ -1921,7 +1920,7 @@ void ADnote::computeVoiceModulatorForFMFrequencyModulation(int nvoice)
                 // the usefulness for audio is questionable. At these rates it
                 // is ridiculously memory and CPU intensive to keep going, so
                 // just bail out with a zero curve instead.
-                memset(tw, 0, synth->sent_buffersize * sizeof(float));
+                memset(tw, 0, synth->buffersize * sizeof(float));
                 return;
             }
 
@@ -2013,7 +2012,7 @@ void ADnote::computeVoiceOscillatorFrequencyModulation(int nvoice)
         // modulation at all this function should not be called.
         const float *mod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             int FMmodfreqhi = int(mod[i]);
             float FMmodfreqlo = mod[i]-FMmodfreqhi;
@@ -2064,21 +2063,21 @@ void ADnote::computeVoiceOscillatorForFMFrequencyModulation(int nvoice)
         float oldsmpModded = oscFMoldsmpModded[nvoice][k];
         float oldsmpOrig = oscFMoldsmpOrig[nvoice][k];
 
-        const int cacheSize = synth->samplerate * 2 + synth->sent_buffersize;
+        const int cacheSize = synth->samplerate * 2 + synth->buffersize;
         float cachedSamples[cacheSize];
         int cachedBackwards, cachedForwards, cacheCenter;
         cachedBackwards = cachedForwards = cacheCenter = cacheSize / 2 - 1;
 
         cachedSamples[cacheCenter++] = oldsmpOrig;
 
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float sampleDistanceF = mod[i] / ((float)freqhi + freqlo);
             int cachePosNear = cacheCenter + (int)roundf(sampleDistanceF);
             int cachePosFar = cachePosNear + ((sampleDistanceF < 0) ? -1 : +1);
 
             if (cachePosFar < 0 || cachePosFar >= cacheSize) {
-                memset(tw, 0, synth->sent_buffersize * sizeof(float));
+                memset(tw, 0, synth->buffersize * sizeof(float));
                 return;
             }
 
@@ -2162,7 +2161,7 @@ void ADnote::computeVoiceNoise(int nvoice)
     for (int k = 0; k < unison_size[nvoice]; ++k)
     {
         float *tw = tmpwave_unison[k];
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
             tw[i] = synth->numRandom() * 2.0f - 1.0f;
     }
 }
@@ -2175,7 +2174,7 @@ void ADnote::ComputeVoicePinkNoise(int nvoice)
     {
         float *tw = tmpwave_unison[k];
         float *f = &pinking[nvoice][k > 0 ? 7 : 0];
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float white = (synth->numRandom() - 0.5 ) / 4.0;
             f[0] = 0.99886*f[0]+white*0.0555179;
@@ -2266,7 +2265,7 @@ void ADnote::ComputeVoiceSpotNoise(int nvoice)
     for (int k = 0; k < unison_size[nvoice]; ++k)
     {
         float *tw = tmpwave_unison[k];
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             if (spot <= 0)
             {
@@ -2293,16 +2292,16 @@ int ADnote::noteout(float *outl, float *outr)
     float *bypassr = Runtime.genTmp4;
     int i, nvoice;
     if (outl != NULL) {
-        memset(outl, 0, synth->sent_bufferbytes);
-        memset(outr, 0, synth->sent_bufferbytes);
+        memset(outl, 0, synth->bufferbytes);
+        memset(outr, 0, synth->bufferbytes);
     }
 
     if (!NoteEnabled)
         return 0;
 
     if (subVoiceNumber == -1) {
-        memset(bypassl, 0, synth->sent_bufferbytes);
-        memset(bypassr, 0, synth->sent_bufferbytes);
+        memset(bypassl, 0, synth->bufferbytes);
+        memset(bypassr, 0, synth->bufferbytes);
     }
 
     computeCurrentParameters();
@@ -2328,9 +2327,9 @@ int ADnote::noteout(float *outl, float *outr)
         computeVoiceOscillator(nvoice);
 
         // Mix subvoices into voice
-        memset(tmpwavel, 0, synth->sent_bufferbytes);
+        memset(tmpwavel, 0, synth->bufferbytes);
         if (stereo)
-            memset(tmpwaver, 0, synth->sent_bufferbytes);
+            memset(tmpwaver, 0, synth->bufferbytes);
         for (int k = 0; k < unison_size[nvoice]; ++k)
         {
             float *tw = tmpwave_unison[k];
@@ -2375,13 +2374,13 @@ int ADnote::noteout(float *outl, float *outr)
                     rvol = -rvol;
                 }
 
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     tmpwavel[i] += tw[i] * lvol;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     tmpwaver[i] += tw[i] * rvol;
             }
             else
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     tmpwavel[i] += tw[i];
         }
 
@@ -2394,34 +2393,34 @@ int ADnote::noteout(float *outl, float *outr)
 
         if (aboveAmplitudeThreshold(oldam, newam))
         {
-            int rest = synth->sent_buffersize;
+            int rest = synth->buffersize;
             // test if the amplitude if rising and the difference is high
             if (newam > oldam && (newam - oldam) > 0.25f)
             {
                 rest = 10;
-                if (rest > synth->sent_buffersize)
-                    rest = synth->sent_buffersize;
-                for (int i = 0; i < synth->sent_buffersize - rest; ++i)
+                if (rest > synth->buffersize)
+                    rest = synth->buffersize;
+                for (int i = 0; i < synth->buffersize - rest; ++i)
                     tmpwavel[i] *= oldam;
                 if (stereo)
-                    for (int i = 0; i < synth->sent_buffersize - rest; ++i)
+                    for (int i = 0; i < synth->buffersize - rest; ++i)
                         tmpwaver[i] *= oldam;
             }
             // Amplitude interpolation
             for (i = 0; i < rest; ++i)
             {
                 float amp = interpolateAmplitude(oldam, newam, i, rest);
-                tmpwavel[i + (synth->sent_buffersize - rest)] *= amp;
+                tmpwavel[i + (synth->buffersize - rest)] *= amp;
                 if (stereo)
-                    tmpwaver[i + (synth->sent_buffersize - rest)] *= amp;
+                    tmpwaver[i + (synth->buffersize - rest)] *= amp;
             }
         }
         else
         {
-            for (i = 0; i < synth->sent_buffersize; ++i)
+            for (i = 0; i < synth->buffersize; ++i)
                 tmpwavel[i] *= newam;
             if (stereo)
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     tmpwaver[i] *= newam;
         }
 
@@ -2447,11 +2446,11 @@ int ADnote::noteout(float *outl, float *outr)
         {
             if (NoteVoicePar[nvoice].AmpEnvelope->finished())
             {
-                for (i = 0; i < synth->sent_buffersize; ++i)
-                    tmpwavel[i] *= 1.0f - float(i) / synth->sent_buffersize_f;
+                for (i = 0; i < synth->buffersize; ++i)
+                    tmpwavel[i] *= 1.0f - float(i) / synth->buffersize_f;
                 if (stereo)
-                    for (i = 0; i < synth->sent_buffersize; ++i)
-                        tmpwaver[i] *= 1.0f - float(i) / synth->sent_buffersize_f;
+                    for (i = 0; i < synth->buffersize; ++i)
+                        tmpwaver[i] *= 1.0f - float(i) / synth->buffersize_f;
             }
             // the voice is killed later
         }
@@ -2461,10 +2460,10 @@ int ADnote::noteout(float *outl, float *outr)
         if (NoteVoicePar[nvoice].VoiceOut)
         {
             if (stereo)
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     NoteVoicePar[nvoice].VoiceOut[i] = tmpwavel[i] + tmpwaver[i];
             else // mono
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                     NoteVoicePar[nvoice].VoiceOut[i] = tmpwavel[i];
             if (NoteVoicePar[nvoice].Volume == 0.0f)
                 // If we are muted, we are done.
@@ -2486,21 +2485,21 @@ int ADnote::noteout(float *outl, float *outr)
                 if (stereo)
                 {
 
-                    for (i = 0; i < synth->sent_buffersize; ++i) // stereo
+                    for (i = 0; i < synth->buffersize; ++i) // stereo
                     {
                         outl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume * pangainL;
                         outr[i] += tmpwaver[i] * NoteVoicePar[nvoice].Volume * pangainR;
                     }
                 }
                 else
-                    for (i = 0; i < synth->sent_buffersize; ++i)
+                    for (i = 0; i < synth->buffersize; ++i)
                         outl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume * 0.7f; // mono
             }
             else // bypass the filter
             {
                 if (stereo)
                 {
-                    for (i = 0; i < synth->sent_buffersize; ++i) // stereo
+                    for (i = 0; i < synth->buffersize; ++i) // stereo
                     {
                         bypassl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume
                                       * pangainL;
@@ -2509,7 +2508,7 @@ int ADnote::noteout(float *outl, float *outr)
                     }
                 }
                 else
-                    for (i = 0; i < synth->sent_buffersize; ++i)
+                    for (i = 0; i < synth->buffersize; ++i)
                         bypassl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume; // mono
             }
             // check if there is necessary to process the voice longer
@@ -2526,13 +2525,13 @@ int ADnote::noteout(float *outl, float *outr)
 
         if (!stereo) // set the right channel=left channel
         {
-            memcpy(outr, outl, synth->sent_bufferbytes);
-            memcpy(bypassr, bypassl, synth->sent_bufferbytes);
+            memcpy(outr, outl, synth->bufferbytes);
+            memcpy(bypassr, bypassl, synth->bufferbytes);
         }
         else
             NoteGlobalPar.GlobalFilterR->filterout(outr);
 
-        for (i = 0; i < synth->sent_buffersize; ++i)
+        for (i = 0; i < synth->buffersize; ++i)
         {
             outl[i] += bypassl[i];
             outr[i] += bypassr[i];
@@ -2549,18 +2548,18 @@ int ADnote::noteout(float *outl, float *outr)
         if (aboveAmplitudeThreshold(globaloldamplitude, globalnewamplitude))
         {
             // Amplitude Interpolation
-            for (i = 0; i < synth->sent_buffersize; ++i)
+            for (i = 0; i < synth->buffersize; ++i)
             {
                 float tmpvol = interpolateAmplitude(globaloldamplitude,
                                                     globalnewamplitude, i,
-                                                    synth->sent_buffersize);
+                                                    synth->buffersize);
                 outl[i] *= tmpvol * pangainL;
                 outr[i] *= tmpvol * pangainR;
             }
         }
         else
         {
-            for (i = 0; i < synth->sent_buffersize; ++i)
+            for (i = 0; i < synth->buffersize; ++i)
             {
                 outl[i] *= globalnewamplitude * pangainL;
                 outr[i] *= globalnewamplitude * pangainR;
@@ -2570,7 +2569,7 @@ int ADnote::noteout(float *outl, float *outr)
         // Apply the punch
         if (NoteGlobalPar.Punch.Enabled)
         {
-            for (i = 0; i < synth->sent_buffersize; ++i)
+            for (i = 0; i < synth->buffersize; ++i)
             {
                 float punchamp = NoteGlobalPar.Punch.initialvalue
                                  * NoteGlobalPar.Punch.t + 1.0f;
@@ -2589,15 +2588,15 @@ int ADnote::noteout(float *outl, float *outr)
         if (Legato.silent)    // Silencer
             if (Legato.msg != LM_FadeIn)
             {
-                memset(outl, 0, synth->sent_bufferbytes);
-                memset(outr, 0, synth->sent_bufferbytes);
+                memset(outl, 0, synth->bufferbytes);
+                memset(outr, 0, synth->bufferbytes);
             }
         switch(Legato.msg)
         {
             case LM_CatchUp:  // Continue the catch-up...
                 if (Legato.decounter == -10)
                     Legato.decounter = Legato.fade.length;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                 { // Yea, could be done without the loop...
                     Legato.decounter--;
                     if (Legato.decounter < 1)
@@ -2621,7 +2620,7 @@ int ADnote::noteout(float *outl, float *outr)
                 if (Legato.decounter == -10)
                     Legato.decounter = Legato.fade.length;
                 Legato.silent = false;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                 {
                     Legato.decounter--;
                     if (Legato.decounter < 1)
@@ -2639,12 +2638,12 @@ int ADnote::noteout(float *outl, float *outr)
             case LM_FadeOut:  // Fade-out, then set the catch-up
                 if (Legato.decounter == -10)
                     Legato.decounter = Legato.fade.length;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                for (i = 0; i < synth->buffersize; ++i)
                 {
                     Legato.decounter--;
                     if (Legato.decounter < 1)
                     {
-                        for (int j = i; j < synth->sent_buffersize; j++)
+                        for (int j = i; j < synth->buffersize; j++)
                             outl[j] = outr[j] = 0.0f;
                         Legato.decounter = -10;
                         Legato.silent = true;
@@ -2677,9 +2676,9 @@ int ADnote::noteout(float *outl, float *outr)
     if (NoteGlobalPar.AmpEnvelope->finished())
     {
         if (outl != NULL) {
-            for (i = 0; i < synth->sent_buffersize; ++i) // fade-out
+            for (i = 0; i < synth->buffersize; ++i) // fade-out
             {
-                float tmp = 1.0f - float(i) / synth->sent_buffersize_f;
+                float tmp = 1.0f - float(i) / synth->buffersize_f;
                 outl[i] *= tmp;
                 outr[i] *= tmp;
             }

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -13,7 +13,7 @@
 
     yoshimi is distributed in the hope that it will be useful, but WITHOUT ANY
     WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-    FOR A PARTICULAR PURPOSE.   See the GNU General Public License (version 2 or
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License (version 2 or
     later) for more details.
 
     You should have received a copy of the GNU General Public License along with

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -83,6 +83,7 @@ Envelope::Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth)
 
             default:
                 envval[i] = envpars->Penvval[i] / 127.0f;
+                break;
         }
     }
 

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -4,6 +4,7 @@
     Original ZynAddSubFX author Nasca Octavian Paul
     Copyright (C) 2002-2005 Nasca Octavian Paul
     Copyright 2009-2011 Alan Calvert
+    Copyright 2019 Will Godfrey
 
     This file is part of yoshimi, which is free software: you can redistribute
     it and/or modify it under the terms of the GNU Library General Public
@@ -19,7 +20,8 @@
     yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-    This file is a derivative of a ZynAddSubFX original, modified January 2011
+    This file is a derivative of a ZynAddSubFX original.
+    Modified March 2019
 */
 
 #include "Misc/SynthEngine.h"
@@ -40,7 +42,7 @@ Envelope::Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth)
     if (!envpars->Pfreemode)
         envpars->converttofree();
 
-    float bufferdt = synth->sent_all_buffersize_f / synth->samplerate_f;
+    float bufferdt = synth->sent_buffersize_f / synth->samplerate_f;
 
     int mode = envpars->Envmode;
 

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -42,7 +42,7 @@ Envelope::Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth)
     if (!envpars->Pfreemode)
         envpars->converttofree();
 
-    float bufferdt = synth->sent_buffersize_f / synth->samplerate_f;
+    float bufferdt = synth->buffersize_f / synth->samplerate_f;
 
     int mode = envpars->Envmode;
 

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -104,7 +104,7 @@ inline void LFO::RecomputeFreq(void)
         powf(basefreq / 440.0f, (float)((int)lfopars->Pstretch - 64) / 63.0f); // max 2x/octave
 
     float lfofreq = lfopars->Pfreq * lfostretch;
-    incx = fabsf(lfofreq) * synth->buffersize_f / synth->samplerate_f;
+    incx = fabsf(lfofreq) * synth->sent_buffersize_f / synth->samplerate_f;
 
     // Limit the Frequency (or else...)
     if (incx > 0.49999999f)
@@ -178,7 +178,7 @@ float LFO::lfoout(void)
             computenextincrnd();
         }
     } else
-        lfodelay -= synth->sent_all_buffersize_f / synth->samplerate_f;
+        lfodelay -= synth->buffersize / synth->samplerate_f;
 
     return out;
 }

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -154,6 +154,7 @@ float LFO::lfoout(void)
 
         default:
             out = cosf( x * TWOPI); // LFO_SINE
+            break;
     }
 
     if (lfotype == 0 || lfotype == 1)

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -178,7 +178,7 @@ float LFO::lfoout(void)
             computenextincrnd();
         }
     } else
-        lfodelay -= synth->buffersize / synth->samplerate_f;
+        lfodelay -= synth->sent_buffersize / synth->samplerate_f;
 
     return out;
 }

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -104,7 +104,7 @@ inline void LFO::RecomputeFreq(void)
         powf(basefreq / 440.0f, (float)((int)lfopars->Pstretch - 64) / 63.0f); // max 2x/octave
 
     float lfofreq = lfopars->Pfreq * lfostretch;
-    incx = fabsf(lfofreq) * synth->sent_buffersize_f / synth->samplerate_f;
+    incx = fabsf(lfofreq) * synth->buffersize_f / synth->samplerate_f;
 
     // Limit the Frequency (or else...)
     if (incx > 0.49999999f)
@@ -179,7 +179,7 @@ float LFO::lfoout(void)
             computenextincrnd();
         }
     } else
-        lfodelay -= synth->sent_buffersize / synth->samplerate_f;
+        lfodelay -= synth->buffersize / synth->samplerate_f;
 
     return out;
 }

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -530,6 +530,7 @@ void OscilGen::getbasefunction(float *smps)
 
                 default:
                     smps[i] = -sinf(TWOPI * (float)i / synth->oscilsize_f);
+                    break;
         }
     }
 }

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -588,7 +588,6 @@ int PADnote::noteout(float *outl,float *outr)
                     break;
                 }
                 Legato.fade.m += Legato.fade.step;
-                Legato.fade.m = Legato.fade.m;
                 outl[i] *= Legato.fade.m;
                 outr[i] *= Legato.fade.m;
             }
@@ -621,7 +620,6 @@ int PADnote::noteout(float *outl,float *outr)
                     break;
                 }
                 Legato.fade.m -= Legato.fade.step;
-                Legato.fade.m = Legato.fade.m;
                 outl[i] *= Legato.fade.m;
                 outr[i] *= Legato.fade.m;
             }

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -323,7 +323,7 @@ PADnote::~PADnote()
 inline void PADnote::fadein(float *smps)
 {
     int zerocrossings = 0;
-    for (int i = 1; i < synth->sent_buffersize; ++i)
+    for (int i = 1; i < synth->buffersize; ++i)
         if (smps[i - 1] < 0.0 && smps[i] > 0.0)
             zerocrossings++; // this is only the positive crossings
 
@@ -393,7 +393,7 @@ int PADnote::Compute_Linear(float *outl, float *outr, int freqhi, float freqlo)
         return 1;
     }
     int size = pars->sample[nsample].size;
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         poshi_l += freqhi;
         poshi_r += freqhi;
@@ -425,7 +425,7 @@ int PADnote::Compute_Cubic(float *outl, float *outr, int freqhi, float freqlo)
     }
     int size = pars->sample[nsample].size;
     float xm1, x0, x1, x2, a, b, c;
-    for (int i = 0; i < synth->sent_buffersize; ++i)
+    for (int i = 0; i < synth->buffersize; ++i)
     {
         poshi_l += freqhi;
         poshi_r += freqhi;
@@ -470,8 +470,8 @@ int PADnote::noteout(float *outl,float *outr)
     float *smps = pars->sample[nsample].smp;
     if (smps == NULL)
     {
-        memset(outl, 0, synth->sent_buffersize * sizeof(float));
-        memset(outr, 0, synth->sent_buffersize * sizeof(float));
+        memset(outl, 0, synth->buffersize * sizeof(float));
+        memset(outr, 0, synth->buffersize * sizeof(float));
         return 1;
     }
     float smpfreq = pars->sample[nsample].basefreq;
@@ -498,7 +498,7 @@ int PADnote::noteout(float *outl,float *outr)
     // Apply the punch
     if (NoteGlobalPar.Punch.Enabled != 0)
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float punchamp =
                 NoteGlobalPar.Punch.initialvalue * NoteGlobalPar.Punch.t + 1.0;
@@ -524,7 +524,7 @@ int PADnote::noteout(float *outl,float *outr)
     if (aboveAmplitudeThreshold(globaloldamplitude,globalnewamplitude))
     {
         // Amplitude Interpolation
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             float tmpvol = interpolateAmplitude(globaloldamplitude,
                                                 globalnewamplitude, i,
@@ -535,7 +535,7 @@ int PADnote::noteout(float *outl,float *outr)
     }
     else
     {
-        for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->buffersize; ++i)
         {
             outl[i] *= globalnewamplitude * pangainL;
             outr[i] *= globalnewamplitude * pangainR;
@@ -547,8 +547,8 @@ int PADnote::noteout(float *outl,float *outr)
     { // Silencer
         if (Legato.msg != LM_FadeIn)
         {
-            memset(outl, 0, synth->sent_bufferbytes);
-            memset(outr, 0, synth->sent_bufferbytes);
+            memset(outl, 0, synth->bufferbytes);
+            memset(outr, 0, synth->bufferbytes);
         }
     }
     switch (Legato.msg)
@@ -556,7 +556,7 @@ int PADnote::noteout(float *outl,float *outr)
         case LM_CatchUp : // Continue the catch-up...
             if (Legato.decounter == -10)
                 Legato.decounter = Legato.fade.length;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
             {   //Yea, could be done without the loop...
                 Legato.decounter--;
                 if (Legato.decounter < 1)
@@ -578,7 +578,7 @@ int PADnote::noteout(float *outl,float *outr)
             if (Legato.decounter == -10)
                 Legato.decounter = Legato.fade.length;
             Legato.silent = false;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
             {
                 Legato.decounter--;
                 if (Legato.decounter < 1)
@@ -596,12 +596,12 @@ int PADnote::noteout(float *outl,float *outr)
         case LM_FadeOut : // Fade-out, then set the catch-up
             if (Legato.decounter == -10)
                 Legato.decounter = Legato.fade.length;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->buffersize; ++i)
             {
                 Legato.decounter--;
                 if (Legato.decounter < 1)
                 {
-                    for (int j = i; j < synth->sent_buffersize; ++j)
+                    for (int j = i; j < synth->buffersize; ++j)
                         outl[j] = outr[j] = 0.0;
                     Legato.decounter = -10;
                     Legato.silent = true;
@@ -633,7 +633,7 @@ int PADnote::noteout(float *outl,float *outr)
     // If it does, disable the note
     if (NoteGlobalPar.AmpEnvelope->finished() != 0)
     {
-        for (int i = 0 ; i < synth->sent_buffersize; ++i)
+        for (int i = 0 ; i < synth->buffersize; ++i)
         {   // fade-out
             float tmp = 1.0f - (float)i / synth->buffersize;
             outl[i] *= tmp;

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -21,7 +21,7 @@
     Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
     This file is derivative of ZynAddSubFX original code
-    Modified January 2019
+    Modified March 2019
 */
 #include <cmath>
 
@@ -327,14 +327,14 @@ inline void PADnote::fadein(float *smps)
         if (smps[i - 1] < 0.0 && smps[i] > 0.0)
             zerocrossings++; // this is only the positive crossings
 
-    float tmp = (synth->sent_buffersize_f - 1.0) / (zerocrossings + 1) / 3.0;
+    float tmp = (synth->buffersize - 1.0) / (zerocrossings + 1) / 3.0;
     if (tmp < 8.0)
         tmp = 8.0;
     tmp *= NoteGlobalPar.Fadein_adjustment;
 
     int n = int(tmp); // how many samples is the fade-in
-    if (n > synth->sent_buffersize)
-        n = synth->sent_buffersize;
+    if (n > synth->buffersize)
+        n = synth->buffersize;
     for (int i = 0; i < n; ++i)
     {   // fade-in
         float tmp = 0.5 - cosf((float)i / (float) n * PI) * 0.5f;
@@ -528,7 +528,7 @@ int PADnote::noteout(float *outl,float *outr)
         {
             float tmpvol = interpolateAmplitude(globaloldamplitude,
                                                 globalnewamplitude, i,
-                                                synth->sent_buffersize);
+                                                synth->buffersize);
             outl[i] *= tmpvol * pangainL;
             outr[i] *= tmpvol * pangainR;
         }
@@ -637,7 +637,7 @@ int PADnote::noteout(float *outl,float *outr)
     {
         for (int i = 0 ; i < synth->sent_buffersize; ++i)
         {   // fade-out
-            float tmp = 1.0f - (float)i / synth->sent_buffersize_f;
+            float tmp = 1.0f - (float)i / synth->buffersize;
             outl[i] *= tmp;
             outr[i] *= tmp;
         }

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -740,7 +740,6 @@ int SUBnote::noteout(float *outl, float *outr)
                     break;
                 }
                 Legato.fade.m += Legato.fade.step;
-                Legato.fade.m = Legato.fade.m;
                 outl[i] *= Legato.fade.m;
                 outr[i] *= Legato.fade.m;
             }
@@ -772,7 +771,6 @@ int SUBnote::noteout(float *outl, float *outr)
                     break;
                 }
                 Legato.fade.m -= Legato.fade.step;
-                Legato.fade.m = Legato.fade.m;
                 outl[i] *= Legato.fade.m;
                 outr[i] *= Legato.fade.m;
             }
@@ -859,6 +857,7 @@ void SUBnote::initfilterbank(void)
 
             default:
                 hgain = 1.0f - hmagnew;
+                break;
         }
         gain *= hgain;
         reduceamp += hgain;

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -787,7 +787,7 @@ int SUBnote::noteout(float *outl, float *outr)
     {
         for (int i = 0; i < synth->sent_buffersize; ++i)
         {   // fade-out
-            float tmp = 1.0f - (float)i / synth->sent_buffersize_f;
+            float tmp = 1.0f - (float)i / synth->sent_buffersize;
             outl[i] *= tmp;
             outr[i] *= tmp;
         }

--- a/src/UI/ConfigUI.fl
+++ b/src/UI/ConfigUI.fl
@@ -105,6 +105,55 @@ class ConfigUI {: {private MiscFuncs, FileMgr}
               xywh {75 75 100 20} labelfont 1 labelsize 12
             }
           }
+          Fl_Choice buff_size {
+            label {* Internal Buffer Size}
+            callback {//
+                        send_data(0, CONFIG::control::bufferSize, 16 << o->value(), TOPLEVEL::type::Integer);}
+            tooltip {Number of samples} xywh {249 75 100 20} down_box BORDER_BOX labelsize 12 textsize 12
+            code0 {o->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);}
+            code1 {if (synth->getUniqueId() != 0) o->hide(); else if (synth->getIsLV2Plugin()) o->deactivate();}
+          } {
+            MenuItem {} {
+              label 16
+              xywh {55 55 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 32
+              xywh {45 45 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 64
+              xywh {35 35 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 128
+              xywh {45 45 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 256
+              xywh {55 55 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 512
+              xywh {55 55 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 1024
+              xywh {65 65 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 2048
+              xywh {65 65 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 4096
+              xywh {65 65 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 8192
+              xywh {65 65 100 20} labelfont 1 labelsize 12
+            }
+          }
           Fl_Choice pad_interpol {
             label {PADsynth Interpolation}
             callback {//
@@ -353,55 +402,6 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
                         send_data(TOPLEVEL::action::forceUpdate, CONFIG::control::alsaPreferredMidi, o->value(), TOPLEVEL::type::Integer);}
             xywh {195 80 37 26} down_box DOWN_BOX labelsize 12 align 4
             code0 {if (synth->getRuntime().midiEngine == alsa_midi) o->value(1);}
-          }
-          Fl_Choice buff_size {
-            label {Buffer Size}
-            callback {//
-                        send_data(0, CONFIG::control::bufferSize, 16 << o->value(), TOPLEVEL::type::Integer);}
-            tooltip {Number of samples} xywh {195 110 121 22} down_box BORDER_BOX labelsize 12 textsize 12
-            code0 {o->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);}
-            code1 {if (synth->getUniqueId() != 0) o->hide(); else if (synth->getIsLV2Plugin()) o->deactivate();}
-          } {
-            MenuItem {} {
-              label 16
-              xywh {60 60 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 32
-              xywh {50 50 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 64
-              xywh {40 40 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 128
-              xywh {50 50 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 256
-              xywh {60 60 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 512
-              xywh {60 60 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 1024
-              xywh {70 70 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 2048
-              xywh {70 70 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 4096
-              xywh {70 70 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 8192
-              xywh {70 70 100 20} labelfont 1 labelsize 12
-            }
           }
           Fl_Input alsaDevice {
             label {Alsa Audio Device}
@@ -1024,6 +1024,7 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
             {
                 case 1 : // Main
                     osc_size->value( (int)(logf(synth->getRuntime().Oscilsize / 256.0f - 1.0f) / logf(2.0f)) + 1);
+                    buff_size->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);
                     pad_interpol->value(synth->getRuntime().Interpolation);
                     v_keyboard->value(synth->getRuntime().VirKeybLayout);
                     compression->value(synth->getRuntime().GzipCompression);
@@ -1054,7 +1055,6 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
                             alsaMidi->value(1);
                             jackMidi->value(0);
                         }
-                        buff_size->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);
                         alsaDevice->value(synth->getRuntime().alsaAudioDevice.c_str());
                         if (synth->getRuntime().audioEngine == alsa_audio)
                         {

--- a/src/UI/ConfigUI.fl
+++ b/src/UI/ConfigUI.fl
@@ -105,55 +105,6 @@ class ConfigUI {: {private MiscFuncs, FileMgr}
               xywh {75 75 100 20} labelfont 1 labelsize 12
             }
           }
-          Fl_Choice buff_size {
-            label {* Internal Buffer Size}
-            callback {//
-                        send_data(0, CONFIG::control::bufferSize, 16 << o->value(), TOPLEVEL::type::Integer);}
-            tooltip {Number of samples} xywh {249 75 100 20} down_box BORDER_BOX labelsize 12 textsize 12
-            code0 {o->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);}
-            code1 {if (synth->getUniqueId() != 0) o->hide(); else if (synth->getIsLV2Plugin()) o->deactivate();}
-          } {
-            MenuItem {} {
-              label 16
-              xywh {55 55 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 32
-              xywh {45 45 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 64
-              xywh {35 35 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 128
-              xywh {45 45 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 256
-              xywh {55 55 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 512
-              xywh {55 55 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 1024
-              xywh {65 65 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 2048
-              xywh {65 65 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 4096
-              xywh {65 65 100 20} labelfont 1 labelsize 12
-            }
-            MenuItem {} {
-              label 8192
-              xywh {65 65 100 20} labelfont 1 labelsize 12
-            }
-          }
           Fl_Choice pad_interpol {
             label {PADsynth Interpolation}
             callback {//
@@ -402,6 +353,55 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
                         send_data(TOPLEVEL::action::forceUpdate, CONFIG::control::alsaPreferredMidi, o->value(), TOPLEVEL::type::Integer);}
             xywh {195 80 37 26} down_box DOWN_BOX labelsize 12 align 4
             code0 {if (synth->getRuntime().midiEngine == alsa_midi) o->value(1);}
+          }
+          Fl_Choice buff_size {
+            label {Buffer Size}
+            callback {//
+                        send_data(0, CONFIG::control::bufferSize, 16 << o->value(), TOPLEVEL::type::Integer);}
+            tooltip {Number of samples} xywh {195 110 121 22} down_box BORDER_BOX labelsize 12 textsize 12
+            code0 {o->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);}
+            code1 {if (synth->getUniqueId() != 0) o->hide(); else if (synth->getIsLV2Plugin()) o->deactivate();}
+          } {
+            MenuItem {} {
+              label 16
+              xywh {60 60 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 32
+              xywh {50 50 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 64
+              xywh {40 40 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 128
+              xywh {50 50 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 256
+              xywh {60 60 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 512
+              xywh {60 60 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 1024
+              xywh {70 70 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 2048
+              xywh {70 70 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 4096
+              xywh {70 70 100 20} labelfont 1 labelsize 12
+            }
+            MenuItem {} {
+              label 8192
+              xywh {70 70 100 20} labelfont 1 labelsize 12
+            }
           }
           Fl_Input alsaDevice {
             label {Alsa Audio Device}
@@ -1024,7 +1024,6 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
             {
                 case 1 : // Main
                     osc_size->value( (int)(logf(synth->getRuntime().Oscilsize / 256.0f - 1.0f) / logf(2.0f)) + 1);
-                    buff_size->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);
                     pad_interpol->value(synth->getRuntime().Interpolation);
                     v_keyboard->value(synth->getRuntime().VirKeybLayout);
                     compression->value(synth->getRuntime().GzipCompression);
@@ -1055,6 +1054,7 @@ or when that loads it will revert to the previous value} xywh {270 60 27 25} dow
                             alsaMidi->value(1);
                             jackMidi->value(0);
                         }
+                        buff_size->value( (int)(logf(synth->getRuntime().Buffersize / 16.0f - 1.0f) / logf(2.0f)) + 1);
                         alsaDevice->value(synth->getRuntime().alsaAudioDevice.c_str());
                         if (synth->getRuntime().audioEngine == alsa_audio)
                         {

--- a/src/globals.h
+++ b/src/globals.h
@@ -95,6 +95,7 @@ const unsigned int MIN_OSCIL_SIZE = 256; // MAX_AD_HARMONICS * 2
 const unsigned int MAX_OSCIL_SIZE = 16384;
 const unsigned int MIN_BUFFER_SIZE = 16;
 const unsigned int MAX_BUFFER_SIZE = 8192;
+const int ActualBufferSize = 128;
 const unsigned char NO_MSG = 255; // these two may become different
 const unsigned char UNUSED = 255;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,7 +336,7 @@ int mainCreateNewInstance(unsigned int forceId, bool loadState)
         goto bail_out;
     }
 
-    if (!synth->Init(musicClient->getSamplerate(), musicClient->getBuffersize()))
+    if (!synth->Init(musicClient->getSamplerate()))
     {
         synth->getRuntime().Log("SynthEngine init failed");
         goto bail_out;


### PR DESCRIPTION
The goal of this refactoring was to avoid sonic problems due to changing the buffer size dynamically in the middle of ongoing calculations. Especially this addresses problems observed with LV2 and the plugin host "Carla".

The solution proposed hereby is to distinguish between
 - the internal calculation chunk size of the engine
 - the size of the current output request by the I/O system (Jack, Alsa, LV2)

The internal calculation chunk size and buffer can be set by the user through the settings pane.