### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/Misc/FileMgrFuncs.h
+++ b/src/Misc/FileMgrFuncs.h
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <unistd.h>
 #include <zlib.h>
 
 #include "globals.h"


### PR DESCRIPTION
```
In file included from .../src/Interface/MidiLearn.cpp:25:
.../src/Misc/FileMgrFuncs.h:230:5: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
    delete memblock;
    ^
          []
.../src/Misc/FileMgrFuncs.h:224:22: note: allocated with 'new[]' here
    char *memblock = new char [size];
                     ^
.../src/Misc/FileMgrFuncs.h:260:23: error: use of undeclared identifier 'write'
    ssize_t written = write(writefile, buff, bytes);
                      ^
.../src/Misc/FileMgrFuncs.h:261:5: error: use of undeclared identifier 'close'
    close (writefile);
    ^
.../src/Misc/FileMgrFuncs.h:401:20: error: use of undeclared identifier 'getcwd'
    char *tmpath = getcwd (NULL, 0);
                   ^
1 warning and 3 errors generated.
```