### PR TITLE
Fix use-after-free and general functionality in preset copy/paste

### DIFF
--- a/src/Misc/XMLwrapper.cpp
+++ b/src/Misc/XMLwrapper.cpp
@@ -49,9 +49,9 @@ const char *XMLwrapper_whitespace_callback(mxml_node_t *node, int where)
 {
     const char *name = mxmlGetElement(node);
 
-    if (where == MXML_WS_BEFORE_OPEN && !strcmp(name, "?xml"))
+    if (where == MXML_WS_BEFORE_OPEN && !strncmp(name, "?xml", 4))
         return NULL;
-    if (where == MXML_WS_BEFORE_CLOSE && !strcmp(name, "string"))
+    if (where == MXML_WS_BEFORE_CLOSE && !strncmp(name, "string", 6))
         return NULL;
 
     if (where == MXML_WS_BEFORE_OPEN || where == MXML_WS_BEFORE_CLOSE)

--- a/src/Params/Presets.cpp
+++ b/src/Params/Presets.cpp
@@ -45,7 +45,6 @@ void Presets::setpresettype(const char *type_)
 void Presets::copy(const char *name)
 {
     XMLwrapper *xml = new XMLwrapper(synth);
-    bool oldMinimal = xml->minimal;
     // used only for the clipboard
     if (name == NULL)
         xml->minimal = false;
@@ -74,7 +73,6 @@ void Presets::copy(const char *name)
 
     delete(xml);
     nelement = -1;
-    xml->minimal = oldMinimal;
 }
 
 


### PR DESCRIPTION
Fixes #61

Preset copy/paste has a use-after-free bug, and pasting from the clipboard doesn't actually do anything. This fixes that.

See also: https://github.com/Yoshimi/yoshimi/issues/61#issuecomment-533875713