### PR TITLE
Fix various mistakes

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -1545,7 +1545,7 @@ void InterChange::mutedDecode(unsigned int altData)
     {
         case TOPLEVEL::muted::stopSound:
             putData.data.control = MAIN::control::stopSound;
-            putData.data.type = TOPLEVEL::type::Write || TOPLEVEL::type::Integer;
+            putData.data.type = TOPLEVEL::type::Write | TOPLEVEL::type::Integer;
             break;
         case TOPLEVEL::muted::masterReset:
             textMsgBuffer.clear(); // make sure there are no hanging messages

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -860,7 +860,7 @@ void Config::Log(const string &msg, char tostderr)
         return;
     if (showGui && !(tostderr & 1) && toConsole)
         LogList.push_back(msg);
-    else if (!tostderr & 1)
+    else if (!(tostderr & 1))
         std::cout << msg << std::endl; // normal log
 
     else

--- a/src/Misc/FileMgrFuncs.h
+++ b/src/Misc/FileMgrFuncs.h
@@ -228,7 +228,7 @@ inline bool copyFile(string source, string destination)
     infile.close();
     outfile.write(memblock, size);
     outfile.close();
-    delete memblock;
+    delete[] memblock;
     return 0;
 }
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -2059,7 +2059,7 @@ void ADnote::computeVoiceOscillatorForFMFrequencyModulation(int nvoice)
     for (int k = 0; k < unison_size[nvoice]; ++k)
     {
         float *tw = tmpwave_unison[k];
-        float *mod = freqbasedmod ? tmpmod_unison[k] : parentFMmod;
+        float *mod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
         int poshi = oscposhi[nvoice][k];
         float poslo = oscposlo[nvoice][k];
         int freqhi = oscfreqhi[nvoice][k];

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -228,7 +228,7 @@ float OscilGen::basefunc_triangle(float x, float a)
         x = (1.0f - x) * 4.0f - 1.0f;
     x /= -a;
     if (x < -1.0f)
-        x =- 1.0f;
+        x = -1.0f;
     if (x > 1.0f)
         x = 1.0f;
     return x;
@@ -1005,7 +1005,7 @@ void OscilGen::prepare(void)
         }
 
         if (Phmag[i] < 64)
-            hmag[i] =- hmag[i];
+            hmag[i] = -hmag[i];
     }
 
     // remove the harmonics where Phmag[i]==64


### PR DESCRIPTION
I ran through Clang's list of warnings with `-Wall` (GCC may also have caught some of these, but I didn't check) and fixed a few logic errors it flagged, plus some weird formatting with `=-` and a use of `delete` which was [undefined behaviour](https://en.cppreference.com/w/cpp/language/delete).

Most of these are edge-cases, but I think I've restored the intended behaviour for each.

The case of `delete` versus `delete[]` could be improved by using `std::unique_ptr<char[]>`, which still calls `delete[]` in case of an uncaught exception (although streams won't throw exceptions by default, so we're safe in this case) but requires a C++11 compatible compiler. I didn't find any existing uses of `unique_ptr` in the codebase, but C++11 is hardly recent and modern compilers no longer even require `--std=c++11` to enable its features.

It should be relatively easy to replace all instances of `new` / `delete` with `unique_ptr`, and unless compatibility with C++03 is wanted, I think it would be a good idea.