### PR TITLE
Fix various undefined behaviour

### DIFF
--- a/src/Interface/Data2Text.cpp
+++ b/src/Interface/Data2Text.cpp
@@ -60,9 +60,6 @@ string DataText::resolveAll(SynthEngine *_synth, CommandBlock *getData, bool add
     showValue = true;
     string commandName;
 
-    Part *part;
-    part = synth->part[npart];
-
     // this is unique and placed here to avoid Xruns
     if (npart == TOPLEVEL::section::scales && (control <= SCALES::control::tuning || control >= SCALES::control::retune))
         synth->setAllPartMaps();
@@ -96,23 +93,30 @@ string DataText::resolveAll(SynthEngine *_synth, CommandBlock *getData, bool add
         commandName = "Invalid kit " + to_string(int(kititem) + 1);
     }
 
-    else if (kititem != 0 && engine != UNUSED && control != PART::control::enable && part->kit[kititem].Penabled == false)
-        commandName = "Part " + to_string(int(npart) + 1) + " Kit item " + to_string(int(kititem) + 1) + " not enabled";
-
-    else if (kititem == UNUSED || insert == TOPLEVEL::insert::kitGroup)
+    else if (kititem != 0)
     {
-        if (control != PART::control::kitMode && kititem != UNUSED && part->Pkitmode == 0)
+        Part *part;
+        part = synth->part[npart];
+
+        if (engine != UNUSED && control != PART::control::enable && part->kit[kititem].Penabled == false)
+            commandName = "Part " + to_string(int(npart) + 1) + " Kit item " + to_string(int(kititem) + 1) + " not enabled";
+
+        else if (kititem == UNUSED || insert == TOPLEVEL::insert::kitGroup)
+        {
+            if (control != PART::control::kitMode && kititem != UNUSED && part->Pkitmode == 0)
+            {
+                showValue = false;
+                commandName = "Part " + to_string(int(npart) + 1) + " Kitmode not enabled";
+            }
+            else
+                commandName = resolvePart(getData, addValue);
+        }
+
+        else if (part->Pkitmode == 0)
         {
             showValue = false;
             commandName = "Part " + to_string(int(npart) + 1) + " Kitmode not enabled";
         }
-        else
-            commandName = resolvePart(getData, addValue);
-    }
-    else if (kititem > 0 && part->Pkitmode == 0)
-    {
-        showValue = false;
-        commandName = "Part " + to_string(int(npart) + 1) + " Kitmode not enabled";
     }
 
     else if (engine == PART::engine::padSynth)

--- a/src/Misc/Microtonal.cpp
+++ b/src/Misc/Microtonal.cpp
@@ -209,7 +209,8 @@ float Microtonal::getNoteFreq(int note, int keyshift)
     {
         int nt = note - PAnote + scaleshift;
         int ntkey = (nt + octavesize * 100) % octavesize;
-        int ntoct = (nt - ntkey) / octavesize;
+        // cast octavesize to a signed type so the expression stays signed
+        int ntoct = (nt - ntkey) / int(octavesize);
 
         float oct  = octave[octavesize - 1].tuning;
         freq = octave[(ntkey + octavesize - 1) % octavesize].tuning

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -155,6 +155,7 @@ void ADnote::construct()
         NoteVoicePar[nvoice].FMSmp = NULL;
         NoteVoicePar[nvoice].VoiceOut = NULL;
 
+        NoteVoicePar[nvoice].FMEnabled = NONE;
         NoteVoicePar[nvoice].FMVoice = -1;
         unison_size[nvoice] = 1;
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -588,25 +588,27 @@ void ADnote::initSubVoices(void)
             || adpars->VoicePar[nvoice].POffsetHz != 64
             || adpars->VoicePar[nvoice].PfixedfreqET != 0;
 
-        bool oscFreqSettingsDiffer =
-               (adpars->VoicePar[nvoice].PBendAdjust
-                != adpars->VoicePar[NoteVoicePar[nvoice].Voice].PBendAdjust)
-            || (adpars->VoicePar[nvoice].Pfixedfreq
-                != adpars->VoicePar[NoteVoicePar[nvoice].Voice].Pfixedfreq);
+        if (NoteVoicePar[nvoice].Voice != -1)
+        {
+            bool oscFreqSettingsDiffer =
+                   (adpars->VoicePar[nvoice].PBendAdjust
+                    != adpars->VoicePar[NoteVoicePar[nvoice].Voice].PBendAdjust)
+                || (adpars->VoicePar[nvoice].Pfixedfreq
+                    != adpars->VoicePar[NoteVoicePar[nvoice].Voice].Pfixedfreq);
 
-        if (NoteVoicePar[nvoice].Voice != -1
-            && (subVoiceNumber != -1
+            if (subVoiceNumber != -1
                 || oscHasFreqAdj
                 || oscFreqSettingsDiffer
-                || freqbasedmod[nvoice]))
-        {
-            subVoice[nvoice] = new ADnote*[unison_size[nvoice]];
-            for (int k = 0; k < unison_size[nvoice]; ++k) {
-                float *freqmod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
-                subVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
-                                                 getVoiceBaseFreq(nvoice),
-                                                 NoteVoicePar[nvoice].Voice,
-                                                 freqmod, forFM);
+                || freqbasedmod[nvoice])
+            {
+                subVoice[nvoice] = new ADnote*[unison_size[nvoice]];
+                for (int k = 0; k < unison_size[nvoice]; ++k) {
+                    float *freqmod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
+                    subVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                                                     getVoiceBaseFreq(nvoice),
+                                                     NoteVoicePar[nvoice].Voice,
+                                                     freqmod, forFM);
+                }
             }
         }
 
@@ -617,28 +619,30 @@ void ADnote::initSubVoices(void)
             || adpars->VoicePar[nvoice].PFMCoarseDetune != 0
             || adpars->VoicePar[nvoice].PFMDetune != 8192;
 
-        bool modFreqSettingsDiffer =
-               (adpars->VoicePar[nvoice].PBendAdjust
-                != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].PBendAdjust)
-            || (adpars->VoicePar[nvoice].PFMFixedFreq
-                != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq)
-            || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc
-                && (adpars->VoicePar[nvoice].Pfixedfreq
-                    != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq));
-
-        if (NoteVoicePar[nvoice].FMVoice != -1
-            && (subVoiceNumber != -1
-                || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc && oscHasFreqAdj)
-                || modHasFreqAdj
-                || modFreqSettingsDiffer))
+        if (NoteVoicePar[nvoice].FMVoice != -1)
         {
-            bool voiceForFM = NoteVoicePar[nvoice].FMEnabled == FREQ_MOD;
-            subFMVoice[nvoice] = new ADnote*[unison_size[nvoice]];
-            for (int k = 0; k < unison_size[nvoice]; ++k) {
-                subFMVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
-                                                   getFMVoiceBaseFreq(nvoice),
-                                                   NoteVoicePar[nvoice].FMVoice,
-                                                   parentFMmod, voiceForFM);
+            bool modFreqSettingsDiffer =
+                   (adpars->VoicePar[nvoice].PBendAdjust
+                    != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].PBendAdjust)
+                || (adpars->VoicePar[nvoice].PFMFixedFreq
+                    != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq)
+                || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc
+                    && (adpars->VoicePar[nvoice].Pfixedfreq
+                        != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq));
+
+            if (subVoiceNumber != -1
+                    || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc && oscHasFreqAdj)
+                    || modHasFreqAdj
+                    || modFreqSettingsDiffer)
+            {
+                bool voiceForFM = NoteVoicePar[nvoice].FMEnabled == FREQ_MOD;
+                subFMVoice[nvoice] = new ADnote*[unison_size[nvoice]];
+                for (int k = 0; k < unison_size[nvoice]; ++k) {
+                    subFMVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                                                       getFMVoiceBaseFreq(nvoice),
+                                                       NoteVoicePar[nvoice].FMVoice,
+                                                       parentFMmod, voiceForFM);
+                }
             }
         }
     }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -950,14 +950,14 @@ void ADnote::killVoice(int nvoice)
     if (subVoice[nvoice] != NULL) {
         for (int k = 0; k < unison_size[nvoice]; ++k)
             delete subVoice[nvoice][k];
-        delete subVoice[nvoice];
+        delete [] subVoice[nvoice];
     }
     subVoice[nvoice] = NULL;
 
     if (subFMVoice[nvoice] != NULL) {
         for (int k = 0; k < unison_size[nvoice]; ++k)
             delete subFMVoice[nvoice][k];
-        delete subFMVoice[nvoice];
+        delete [] subFMVoice[nvoice];
     }
     subFMVoice[nvoice] = NULL;
 

--- a/src/UI/DynamicTooltip.cpp
+++ b/src/UI/DynamicTooltip.cpp
@@ -61,6 +61,7 @@ DynTooltip::DynTooltip():Fl_Menu_Window(1,1)
 
     valueType = VC_plainValue;
     graphicsType = VC_plainValue;
+    onlyValue = false;
 
     positioned = false;
     yoffs = 20;

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -252,8 +252,6 @@ void GuiUpdates::decode_updates(SynthEngine *synth, CommandBlock *getData)
         return;
     }
 
-    Part *part = synth->part[npart];
-
     if (kititem >= EFFECT::type::none && kititem != UNUSED) // effects
     {
         if (npart == TOPLEVEL::section::systemEffects)
@@ -321,6 +319,8 @@ void GuiUpdates::decode_updates(SynthEngine *synth, CommandBlock *getData)
     }
     if (kititem == UNUSED || insert == TOPLEVEL::insert::kitGroup) // part
     {
+        Part *part = synth->part[npart];
+
         if (control != PART::control::kitMode && kititem != UNUSED && part->Pkitmode == 0)
             return; // invalid access
         synth->getGuiMaster()->partui->returns_update(getData);


### PR DESCRIPTION
Testing with Clang's AddressSanitizer and UndefinedBehaviorSanitizer revealed some more bugs, which I have fixed here.

Clang's LeakSanitizer also reports some memory leaks, but I'm not sure they aren't just one-time initializations intended to live until program exit, or maybe even false positives.

MemorySanitizer (which detects uninitialized reads and some other bugs) might reveal more uninitialized variables, but it apparently gives false positives unless *every* linked library is also compiled with MemorySanitizer, which isn't too fun.

I haven't tested Yoshimi very rigorously, but this should take care of a good chunk of the remaining UB/memory bugs.