### PR TITLE
Silence warnings

### DIFF
--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -24,10 +24,10 @@
 
 */
 
-using namespace std;
-
 #include "Misc/SynthEngine.h"
 #include "Effects/Alienwah.h"
+
+using namespace std;
 
 static const int PRESET_SIZE = 11;
 static const int NUM_PRESETS = 4;

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -282,7 +282,7 @@ void InterChange::indirectTransfers(CommandBlock *getData, bool noForward)
     if (write)
         __sync_or_and_fetch(&blockRead, 2);
     bool guiTo = false;
-    guiTo = guiTo; // suppress warning when headless build
+    (void) guiTo; // suppress warning when headless build
     unsigned char newMsg = false;//NO_MSG;
 
     if (npart == TOPLEVEL::section::main && control == MAIN::control::loadFileFromList)

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -378,7 +378,7 @@ class MasterUI {selected : {private GuiUpdates}
         Submenu Instruments {
           label {&Instruments}
           xywh {0 0 100 20} labelsize 12
-          code0 {o = o; // suppress warning}
+          code0 {(void) o; // suppress warning}
           code1 {vector <string> listType = *synth->getHistory(TOPLEVEL::XML::Instrument);}
           code2 {if (listType.size() == 0) RecentInstruments->deactivate(); else RecentInstruments->activate();}
         } {
@@ -459,7 +459,7 @@ class MasterUI {selected : {private GuiUpdates}
         Submenu Parameters {
           label {&Patch Sets}
           xywh {0 0 70 20} labelsize 12
-          code0 {o = o; // suppress warning}
+          code0 {(void) o; // suppress warning}
           code1 {vector <string> listType = *synth->getHistory(TOPLEVEL::XML::Patch);}
           code2 {if (listType.size() == 0) RecentParams->deactivate(); else RecentParams->activate();}
         } {
@@ -519,7 +519,7 @@ class MasterUI {selected : {private GuiUpdates}
         Submenu Scales {
           label {&Scales}
           tooltip {Clear all parameters to default settings} xywh {0 0 60 20} labelsize 12
-          code0 {o = o; // suppress warning}
+          code0 {(void) o; // suppress warning}
           code1 {vector <string> listType = *synth->getHistory(TOPLEVEL::XML::Scale);}
           code2 {if (listType.size() == 0) RecentScale->deactivate(); else RecentScale->activate();}
         } {
@@ -585,7 +585,7 @@ paramsui->Show(TOPLEVEL::XML::Scale);}
         Submenu {} {
           label {S&tate}
           xywh {0 0 60 20} labelsize 12
-          code0 {o = o; // suppress warning}
+          code0 {(void) o; // suppress warning}
           code1 {vector <string> listType = *synth->getHistory(TOPLEVEL::XML::State);}
           code2 {if (listType.size() == 0) RecentState->deactivate(); else RecentState->activate();}
         } {

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -835,7 +835,7 @@ class OscilEditor {: {public PresetsUI_}
       Fl_Light_Button autoclearbutton {
         label {Clr.}
         callback {// not used directly now
-        Fl_Light_Button *a = o; o = a; // suppress warning
+        (void) o; // suppress warning
         //send_data(TOPLEVEL::action::forceUpdate, OSCILLATOR::control::autoClear, o->value(), TOPLEVEL::type::Integer);}
         tooltip {Auto clear when using the oscillator as base function} xywh {95 313 35 20} box THIN_UP_BOX value 1 labelfont 1 labelsize 10
       }

--- a/src/UI/VectorUI.fl
+++ b/src/UI/VectorUI.fl
@@ -80,7 +80,7 @@ class VectorUI {
       Fl_Menu_Button {} {
         label Options
         xywh {275 12 74 20} labelsize 12 textsize 12
-        code0 {o = o; // suppress warning}
+        code0 {(void) o; // suppress warning}
         code1 {vector <string> listType = *synth->getHistory(TOPLEVEL::XML::Vector);}
         code2 {if (listType.size() == 0) recenthistory->deactivate(); else recenthistory->activate();}
       } {
@@ -168,7 +168,7 @@ class VectorUI {
         }
         Fl_Button XL {
           callback {//
-          Fl_Button *a = o; o = a; // suppress warning
+          (void) o; // suppress warning
           synth->getGuiMaster()->activePart = BaseChan;
           bankui->Show();}
           tooltip {Part corresponding to joystick 'left' position} xywh {20 53 160 20} box UP_FRAME color 51 labelsize 12 align 64
@@ -187,7 +187,7 @@ class VectorUI {
         }
         Fl_Button XR {
           callback {//
-          Fl_Button *a = o; o = a; // suppress warning
+          (void) o; // suppress warning
           synth->getGuiMaster()->activePart = BaseChan + NUM_MIDI_CHANNELS;
           bankui->Show();}
           tooltip {Part corresponding to joystick 'right' position} xywh {20 115 160 20} box UP_FRAME color 51 labelsize 12 align 64
@@ -348,7 +348,7 @@ class VectorUI {
         }
         Fl_Button YU {
           callback {//
-          Fl_Button *a = o; o = a; // suppress warning
+          (void) o; // suppress warning
           synth->getGuiMaster()->activePart = BaseChan + NUM_MIDI_CHANNELS * 2;
           bankui->Show();}
           tooltip {Part corresponding to joystick 'up' position} xywh {20 163 160 20} box UP_FRAME color 51 labelsize 12 align 64
@@ -367,7 +367,7 @@ class VectorUI {
         }
         Fl_Button YD {
           callback {//
-          Fl_Button *a = o; o = a; // suppress warning
+          (void) o; // suppress warning
           synth->getGuiMaster()->activePart = BaseChan + NUM_MIDI_CHANNELS * 3;
           bankui->Show();}
           tooltip {Part corresponding to joystick 'down'position} xywh {20 225 160 20} box UP_FRAME color 51 labelsize 12 align 64
@@ -506,7 +506,7 @@ class VectorUI {
       Fl_Button Loaded {
         label {No Name}
         callback {//
-        Fl_Button *a = o; o = a; // suppress warning
+        (void) o; // suppress warning
         const char *tmp = NULL;
         tmp = fl_input("Vector name:", loadlabel[BaseChan].c_str());
         if (tmp != NULL && !string(tmp).empty())


### PR DESCRIPTION
This fixes some code that Clang complains about (again, GCC doesn't seem to care).

The misplaced `using namespace std;` could technically cause problems with more strictly standards-compliant compilers, but both GCC and Clang implicitly define the `std` namespace even when no headers have been included to declare it.

The changes to warning suppression in the FLTK files are purely to make both GCC and Clang shut up, rather than replacing one warning with another in Clang's case.

Brief testing reveals that the `(void) x;` method removes a redundant write at `-O0` with Clang compared to the `x = x;` method, while GCC optimizes it out regardless, even at `-O0`. Splitting hairs, but still.