### PR TITLE
Fix for OscilGen thread issue and one cleanup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,6 +384,7 @@ set (Params_sources
     Params/SUBnoteParameters.cpp  Params/PADnoteParameters.cpp
     Params/Controller.cpp  Params/Presets.cpp
     Params/PresetsStore.cpp  Params/UnifiedPresets.cpp
+    Params/OscilParameters.cpp
 )
 
 set (Synth_sources

--- a/src/DSP/FFTwrapper.cpp
+++ b/src/DSP/FFTwrapper.cpp
@@ -69,7 +69,7 @@ void FFTwrapper::deleteFFTFREQS(FFTFREQS *f)
 
 
 // Fast Fourier Transform
-void FFTwrapper::smps2freqs(float *smps, FFTFREQS *freqs)
+void FFTwrapper::smps2freqs(const float *smps, FFTFREQS *freqs)
 {
     memcpy(data1, smps, fftsize * sizeof(float));
     fftwf_execute(planBasic);
@@ -81,7 +81,7 @@ void FFTwrapper::smps2freqs(float *smps, FFTFREQS *freqs)
 
 
 // Inverse Fast Fourier Transform
-void FFTwrapper::freqs2smps(FFTFREQS *freqs, float *smps)
+void FFTwrapper::freqs2smps(const FFTFREQS *freqs, float *smps)
 {
     memcpy(data2, freqs->c, half_fftsize * sizeof(float));
     data2[half_fftsize] = 0.0;

--- a/src/DSP/FFTwrapper.h
+++ b/src/DSP/FFTwrapper.h
@@ -38,8 +38,8 @@ class FFTwrapper
     public:
         FFTwrapper(int fftsize_);
         ~FFTwrapper();
-        void smps2freqs(float *smps, FFTFREQS *freqs);
-        void freqs2smps(FFTFREQS *freqs, float *smps);
+        void smps2freqs(const float *smps, FFTFREQS *freqs);
+        void freqs2smps(const FFTFREQS *freqs, float *smps);
         static void newFFTFREQS(FFTFREQS *f, int size);
         static void deleteFFTFREQS(FFTFREQS *f);
 

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -1829,13 +1829,13 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                 commandEnvelope(getData);
                 break;
             case TOPLEVEL::insert::oscillatorGroup:
-                commandOscillator(getData,  part->kit[kititem].padpars->oscilgen);
+                commandOscillator(getData,  part->kit[kititem].padpars->POscil);
                 break;
             case TOPLEVEL::insert::harmonicAmplitude:
-                commandOscillator(getData,  part->kit[kititem].padpars->oscilgen);
+                commandOscillator(getData,  part->kit[kititem].padpars->POscil);
                 break;
             case TOPLEVEL::insert::harmonicPhaseBandwidth:
-                commandOscillator(getData,  part->kit[kititem].padpars->oscilgen);
+                commandOscillator(getData,  part->kit[kititem].padpars->POscil);
                 break;
             case TOPLEVEL::insert::resonanceGroup:
                 commandResonance(getData, part->kit[kititem].padpars->resonance);
@@ -1921,7 +1921,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                         }   // force it to external mod
                     }
 
-                    commandOscillator(getData,  part->kit[kititem].adpars->VoicePar[engine].FMSmp);
+                    commandOscillator(getData,  part->kit[kititem].adpars->VoicePar[engine].POscilFM);
                 }
                 else
                 {
@@ -1937,7 +1937,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                         }   // force it to external voice
                     }
 
-                    commandOscillator(getData,  part->kit[kititem].adpars->VoicePar[engine].OscilSmp);
+                    commandOscillator(getData,  part->kit[kititem].adpars->VoicePar[engine].POscil);
                 }
                 break;
         }
@@ -4825,7 +4825,7 @@ void InterChange::commandPad(CommandBlock *getData)
 }
 
 
-void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
+void InterChange::commandOscillator(CommandBlock *getData, OscilParameters *oscil)
 {
     float value = getData->data.value.F;
     unsigned char type = getData->data.type;
@@ -4845,7 +4845,7 @@ void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
             oscil->Phmag[control] = value_int;
             if (value_int == 64)
                 oscil->Phphase[control] = 64;
-            oscil->prepare();
+            oscil->presetsUpdated();
         }
         else
             getData->data.value.F = oscil->Phmag[control];
@@ -4856,7 +4856,7 @@ void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
         if (write)
         {
             oscil->Phphase[control] = value_int;
-            oscil->prepare();
+            oscil->presetsUpdated();
         }
         else
             getData->data.value.F = oscil->Phphase[control];
@@ -4932,7 +4932,9 @@ void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
         case OSCILLATOR::control::useAsBaseFunction:
             if (write)
             {
-                oscil->useasbase();
+                FFTwrapper fft(synth->oscilsize);
+                OscilGen gen(&fft, NULL, synth, oscil);
+                gen.useasbase();
                 if (value_bool)
                 {
                     for (int i = 0; i < MAX_AD_HARMONICS; ++ i)
@@ -4946,7 +4948,7 @@ void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
                     oscil->Pfiltertype = 0;
                     oscil->Psatype = 0;
                 }
-                oscil->prepare();
+                oscil->presetsUpdated();
             }
             break;
 
@@ -5074,12 +5076,17 @@ void InterChange::commandOscillator(CommandBlock *getData, OscilGen *oscil)
                     oscil->Phphase[i]=64;
                 }
                 oscil->Phmag[0]=127;
-                oscil->prepare();
+                oscil->presetsUpdated();
             }
             break;
         case OSCILLATOR::control::convertToSine:
             if (write)
-                oscil->convert2sine();
+            {
+                FFTwrapper fft(synth->oscilsize);
+                OscilGen gen(&fft, NULL, synth, oscil);
+                gen.convert2sine();
+                oscil->presetsUpdated();
+            }
             break;
     }
     if (!write)
@@ -6246,7 +6253,7 @@ float InterChange::returnLimits(CommandBlock *getData)
         }
         if (insert >= TOPLEVEL::insert::oscillatorGroup && insert <= TOPLEVEL::insert::harmonicPhaseBandwidth)
         {
-            return part->kit[0].adpars->VoicePar[0].OscilSmp->getLimits(getData);
+            return part->kit[0].adpars->VoicePar[0].POscil->getLimits(getData);
             // we also use this for pad limits
             // as oscillator values identical
         }

--- a/src/Interface/InterChange.h
+++ b/src/Interface/InterChange.h
@@ -31,7 +31,7 @@
 #include "Params/LFOParams.h"
 #include "Params/FilterParams.h"
 #include "Params/EnvelopeParams.h"
-#include "Synth/OscilGen.h"
+#include "Params/OscilParameters.h"
 #include "Synth/Resonance.h"
 
 class SynthEngine;
@@ -109,7 +109,7 @@ class InterChange : private DataText
         void commandAddVoice(CommandBlock *getData);
         void commandSub(CommandBlock *getData);
         void commandPad(CommandBlock *getData);
-        void commandOscillator(CommandBlock *getData, OscilGen *oscil);
+        void commandOscillator(CommandBlock *getData, OscilParameters *oscil);
         void commandResonance(CommandBlock *getData, Resonance *respar);
         void commandLFO(CommandBlock *getData);
         void lfoReadWrite(CommandBlock *getData, LFOParams *pars);

--- a/src/LV2_Plugin/CMakeLists.txt
+++ b/src/LV2_Plugin/CMakeLists.txt
@@ -56,6 +56,7 @@ file (GLOB yoshimi_params_files
     ../Params/ADnoteParameters.h  ../Params/EnvelopeParams.h
     ../Params/FilterParams.h  ../Params/LFOParams.h
     ../Params/SUBnoteParameters.h  ../Params/PADnoteParameters.h
+    ../Params/OscilParameters.cpp ../Params/OscilParameters.h
     ../Params/Controller.h  ../Params/Presets.h ../Params/PresetsStore.h)
 file (GLOB yoshimi_synth_files
     ../Synth/ADnote.cpp  ../Synth/Envelope.cpp  ../Synth/LFO.cpp  ../Synth/OscilGen.cpp

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -158,8 +158,8 @@ void ADnoteParameters::defaults(int n)
     VoicePar[nvoice].PFMAmpEnvelopeEnabled = 0;
     VoicePar[nvoice].PFMVelocityScaleFunction = 64;
 
-    VoicePar[nvoice].OscilSmp->defaults();
-    VoicePar[nvoice].FMSmp->defaults();
+    VoicePar[nvoice].POscil->defaults();
+    VoicePar[nvoice].POscilFM->defaults();
 
     VoicePar[nvoice].AmpEnvelope->defaults();
     VoicePar[nvoice].AmpLfo->defaults();
@@ -179,8 +179,10 @@ void ADnoteParameters::defaults(int n)
 // Init the voice parameters
 void ADnoteParameters::enableVoice(int nvoice)
 {
-    VoicePar[nvoice].OscilSmp = new OscilGen(fft, GlobalPar.Reson, synth);
-    VoicePar[nvoice].FMSmp = new OscilGen(fft, NULL, synth);
+    VoicePar[nvoice].POscil = new OscilParameters(synth);
+    VoicePar[nvoice].POscilFM = new OscilParameters(synth);
+    VoicePar[nvoice].OscilSmp = new OscilGen(fft, GlobalPar.Reson, synth, VoicePar[nvoice].POscil);
+    VoicePar[nvoice].FMSmp = new OscilGen(fft, NULL, synth, VoicePar[nvoice].POscilFM);
 
     VoicePar[nvoice].AmpEnvelope = new EnvelopeParams(64, 1, synth);
     VoicePar[nvoice].AmpEnvelope->ADSRinit_dB(0, 100, 127, 100);
@@ -225,6 +227,8 @@ void ADnoteParameters::killVoice(int nvoice)
 {
     delete VoicePar[nvoice].OscilSmp;
     delete VoicePar[nvoice].FMSmp;
+    delete VoicePar[nvoice].POscil;
+    delete VoicePar[nvoice].POscilFM;
 
     delete VoicePar[nvoice].AmpEnvelope;
     delete VoicePar[nvoice].AmpLfo;
@@ -331,7 +335,7 @@ void ADnoteParameters::add2XMLsection(XMLwrapper *xml, int n)
     xml->addpar("fm_enabled", VoicePar[nvoice].PFMEnabled);
 
     xml->beginbranch("OSCIL");
-        VoicePar[nvoice].OscilSmp->add2XML(xml);
+        VoicePar[nvoice].POscil->add2XML(xml);
     xml->endbranch();
 
 
@@ -440,7 +444,7 @@ void ADnoteParameters::add2XMLsection(XMLwrapper *xml, int n)
                 }
 
                 xml->beginbranch("OSCIL");
-                    VoicePar[nvoice].FMSmp->add2XML(xml);
+                    VoicePar[nvoice].POscilFM->add2XML(xml);
                 xml->endbranch();
 
             xml->endbranch();
@@ -663,7 +667,7 @@ void ADnoteParameters::getfromXMLsection(XMLwrapper *xml, int n)
 
     if (xml->enterbranch("OSCIL"))
     {
-        VoicePar[nvoice].OscilSmp->getfromXML(xml);
+        VoicePar[nvoice].POscil->getfromXML(xml);
         xml->exitbranch();
     }
 
@@ -839,7 +843,7 @@ void ADnoteParameters::getfromXMLsection(XMLwrapper *xml, int n)
 
             if (xml->enterbranch("OSCIL"))
             {
-                VoicePar[nvoice].FMSmp->getfromXML(xml);
+                VoicePar[nvoice].POscilFM->getfromXML(xml);
                 xml->exitbranch();
             }
 

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -30,8 +30,9 @@
 #include "Params/EnvelopeParams.h"
 #include "Params/LFOParams.h"
 #include "Params/FilterParams.h"
-#include "Synth/OscilGen.h"
+#include "Params/OscilParameters.h"
 #include "Synth/Resonance.h"
+#include "Synth/OscilGen.h"
 #include "Misc/XMLwrapper.h"
 #include "DSP/FFTwrapper.h"
 #include "Params/Presets.h"
@@ -101,12 +102,13 @@ struct ADnoteVoiceParam { // Voice parameters
     unsigned char PDelay;                   // Voice Delay
     unsigned char Presonance;               // If resonance is enabled for this voice
     short int     Pextoscil,                // What external oscil should I use,
-                  PextFMoscil;              // -1 for internal OscilSmp & FMSmp
+                  PextFMoscil;              // -1 for internal POscil & POscilFM
                                             // it is not allowed that the externoscil,
                                             // externFMoscil => current voice
     unsigned char Poscilphase, PFMoscilphase; // oscillator phases
     unsigned char Pfilterbypass;            // filter bypass
-    OscilGen     *OscilSmp;
+    OscilParameters *POscil;
+    OscilGen        *OscilSmp;
 
     // Frequency parameters
     unsigned char Pfixedfreq;   // If the base frequency is fixed to 440 Hz
@@ -160,15 +162,16 @@ struct ADnoteVoiceParam { // Voice parameters
 
 
     short int     PVoice;     // Voice that I use as external oscillator.
-                              // It is -1 if I use OscilSmp(default).
+                              // It is -1 if I use POscil(default).
                               // It may not be equal or bigger than current voice
 
     // Modullator parameters
     unsigned char PFMEnabled; // 0 = off, 1 = Morph, 2 = RM, 3 = PM, 4 = FM, 5 = PWM
-    short int     PFMVoice;   // Voice that I use as modullator instead of FMSmp.
-                              // It is -1 if I use FMSmp(default).
+    short int     PFMVoice;   // Voice that I use as modullator instead of POscilFM.
+                              // It is -1 if I use POscilFM(default).
                               // It may not be equal or bigger than current voice
-    OscilGen *FMSmp;          // Modullator oscillator
+    OscilParameters *POscilFM;// Modullator oscillator
+    OscilGen        *FMSmp;
 
     unsigned char      PFMVolume;                // Modulator Volume
     unsigned char      PFMVolumeDamp;            // Modulator damping at higher frequencies

--- a/src/Params/OscilParameters.cpp
+++ b/src/Params/OscilParameters.cpp
@@ -35,6 +35,7 @@ OscilParameters::OscilParameters(SynthEngine *_synth) :
 {
     setpresettype("Poscilgen");
     FFTwrapper::newFFTFREQS(&basefuncFFTfreqs, MAX_OSCIL_SIZE);
+    defaults();
 }
 
 OscilParameters::~OscilParameters()

--- a/src/Params/OscilParameters.cpp
+++ b/src/Params/OscilParameters.cpp
@@ -1,0 +1,479 @@
+/*
+    OscilGen.h - Waveform generator for ADnote
+
+    Original ZynAddSubFX author Nasca Octavian Paul
+    Copyright (C) 2002-2005 Nasca Octavian Paul
+    Copyright 2009-2011, Alan Calvert
+    Copyright 2017-2019 Will Godfrey & others.
+    Copyright 2019 Kristian Amlie
+
+    This file is part of yoshimi, which is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either version 2 of
+    the License, or (at your option) any later version.
+
+    yoshimi is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.   See the GNU General Public License (version 2 or
+    later) for more details.
+
+    You should have received a copy of the GNU General Public License along with
+    yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
+    Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    This file is derivative of original ZynAddSubFX code.
+*/
+
+#include <math.h>
+
+#include "Misc/SynthEngine.h"
+#include "OscilParameters.h"
+
+OscilParameters::OscilParameters(SynthEngine *_synth) :
+    Presets(_synth),
+    ADvsPAD(false)
+{
+    setpresettype("Poscilgen");
+    FFTwrapper::newFFTFREQS(&basefuncFFTfreqs, MAX_OSCIL_SIZE);
+}
+
+OscilParameters::~OscilParameters()
+{
+    FFTwrapper::deleteFFTFREQS(&basefuncFFTfreqs);
+}
+
+void OscilParameters::updatebasefuncFFTfreqs(const FFTFREQS *src, int samples)
+{
+    memcpy(basefuncFFTfreqs.c, src->c, samples * sizeof(float));
+    memcpy(basefuncFFTfreqs.s, src->s, samples * sizeof(float));
+}
+
+void OscilParameters::defaults()
+{
+    memset(basefuncFFTfreqs.s, 0, MAX_OSCIL_SIZE * sizeof(float));
+    memset(basefuncFFTfreqs.c, 0, MAX_OSCIL_SIZE * sizeof(float));
+
+    for (int i = 0; i < MAX_AD_HARMONICS; ++i)
+    {
+        Phmag[i] = 64;
+        Phphase[i] = 64;
+    }
+    Phmag[0] = 127;
+    Phmagtype = 0;
+    if (ADvsPAD)
+        Prand = 127; // max phase randomness (useful if the oscil will be
+                     // imported to a ADsynth from a PADsynth
+    else
+        Prand = 64; // no randomness
+
+    Pcurrentbasefunc = 0;
+    Pbasefuncpar = 64;
+
+    Pbasefuncmodulation = 0;
+    Pbasefuncmodulationpar1 = 64;
+    Pbasefuncmodulationpar2 = 64;
+    Pbasefuncmodulationpar3 = 32;
+
+    Pmodulation = 0;
+    Pmodulationpar1 = 64;
+    Pmodulationpar2 = 64;
+    Pmodulationpar3 = 32;
+
+    Pwaveshapingfunction = 0;
+    Pwaveshaping = 64;
+    Pfiltertype = 0;
+    Pfilterpar1 = 64;
+    Pfilterpar2 = 64;
+    Pfilterbeforews = 0;
+    Psatype = 0;
+    Psapar = 64;
+
+    Pamprandpower = 64;
+    Pamprandtype = 0;
+
+    Pharmonicshift = 0;
+    Pharmonicshiftfirst = 0;
+
+    Padaptiveharmonics = 0;
+    Padaptiveharmonicspower = 100;
+    Padaptiveharmonicsbasefreq = 128;
+    Padaptiveharmonicspar = 50;
+}
+
+void OscilParameters::add2XML(XMLwrapper *xml)
+{
+    xml->addpar("harmonic_mag_type", Phmagtype);
+
+    xml->addpar("base_function", Pcurrentbasefunc);
+    xml->addpar("base_function_par", Pbasefuncpar);
+    xml->addpar("base_function_modulation", Pbasefuncmodulation);
+    xml->addpar("base_function_modulation_par1", Pbasefuncmodulationpar1);
+    xml->addpar("base_function_modulation_par2", Pbasefuncmodulationpar2);
+    xml->addpar("base_function_modulation_par3", Pbasefuncmodulationpar3);
+
+    xml->addpar("modulation", Pmodulation);
+    xml->addpar("modulation_par1", Pmodulationpar1);
+    xml->addpar("modulation_par2", Pmodulationpar2);
+    xml->addpar("modulation_par3", Pmodulationpar3);
+
+    xml->addpar("wave_shaping", Pwaveshaping);
+    xml->addpar("wave_shaping_function", Pwaveshapingfunction);
+
+    xml->addpar("filter_type", Pfiltertype);
+    xml->addpar("filter_par1", Pfilterpar1);
+    xml->addpar("filter_par2", Pfilterpar2);
+    xml->addpar("filter_before_wave_shaping", Pfilterbeforews);
+
+    xml->addpar("spectrum_adjust_type", Psatype);
+    xml->addpar("spectrum_adjust_par", Psapar);
+
+    xml->addpar("rand", Prand);
+    xml->addpar("amp_rand_type", Pamprandtype);
+    xml->addpar("amp_rand_power", Pamprandpower);
+
+    xml->addpar("harmonic_shift", Pharmonicshift);
+    xml->addparbool("harmonic_shift_first", Pharmonicshiftfirst);
+
+    xml->addpar("adaptive_harmonics", Padaptiveharmonics);
+    xml->addpar("adaptive_harmonics_base_frequency", Padaptiveharmonicsbasefreq);
+    xml->addpar("adaptive_harmonics_power", Padaptiveharmonicspower);
+    xml->addpar("adaptive_harmonics_par", Padaptiveharmonicspar);
+
+    xml->beginbranch("HARMONICS");
+        for (int n = 0; n < MAX_AD_HARMONICS; ++n)
+        {
+            if (Phmag[n] == 64 && Phphase[n] == 64)
+                continue;
+            xml->beginbranch("HARMONIC", n + 1);
+                xml->addpar("mag", Phmag[n]);
+                xml->addpar("phase", Phphase[n]);
+            xml->endbranch();
+        }
+    xml->endbranch();
+
+    if (Pcurrentbasefunc == 127)
+    {
+        float max = 0.0;
+        for (int i = 0; i < synth->halfoscilsize; ++i)
+        {
+            if (max < fabsf(basefuncFFTfreqs.c[i]))
+                max = fabsf(basefuncFFTfreqs.c[i]);
+            if (max < fabsf(basefuncFFTfreqs.s[i]))
+                max = fabsf(basefuncFFTfreqs.s[i]);
+        }
+        if (max < 0.00000001)
+            max = 1.0;
+
+        xml->beginbranch("BASE_FUNCTION");
+            for (int i = 1; i < synth->halfoscilsize; ++i)
+            {
+                float xc = basefuncFFTfreqs.c[i] / max;
+                float xs = basefuncFFTfreqs.s[i] / max;
+                if (fabsf(xs) > 0.00001 && fabsf(xs) > 0.00001)
+                {
+                    xml->beginbranch("BF_HARMONIC", i);
+                        xml->addparreal("cos", xc);
+                        xml->addparreal("sin", xs);
+                    xml->endbranch();
+                }
+            }
+        xml->endbranch();
+    }
+}
+
+
+void OscilParameters::getfromXML(XMLwrapper *xml)
+{
+
+    Phmagtype = xml->getpar127("harmonic_mag_type", Phmagtype);
+
+    Pcurrentbasefunc = xml->getpar127("base_function", Pcurrentbasefunc);
+    Pbasefuncpar = xml->getpar127("base_function_par", Pbasefuncpar);
+
+    Pbasefuncmodulation = xml->getpar127("base_function_modulation", Pbasefuncmodulation);
+    Pbasefuncmodulationpar1 = xml->getpar127("base_function_modulation_par1", Pbasefuncmodulationpar1);
+    Pbasefuncmodulationpar2 = xml->getpar127("base_function_modulation_par2", Pbasefuncmodulationpar2);
+    Pbasefuncmodulationpar3 = xml->getpar127("base_function_modulation_par3", Pbasefuncmodulationpar3);
+
+    Pmodulation = xml->getpar127("modulation", Pmodulation);
+    Pmodulationpar1 = xml->getpar127("modulation_par1", Pmodulationpar1);
+    Pmodulationpar2 = xml->getpar127("modulation_par2", Pmodulationpar2);
+    Pmodulationpar3 = xml->getpar127("modulation_par3", Pmodulationpar3);
+
+    Pwaveshaping = xml->getpar127("wave_shaping", Pwaveshaping);
+    Pwaveshapingfunction = xml->getpar127("wave_shaping_function", Pwaveshapingfunction);
+
+    Pfiltertype = xml->getpar127("filter_type", Pfiltertype);
+    Pfilterpar1 = xml->getpar127("filter_par1", Pfilterpar1);
+    Pfilterpar2 = xml->getpar127("filter_par2", Pfilterpar2);
+    Pfilterbeforews = xml->getpar127("filter_before_wave_shaping", Pfilterbeforews);
+
+    Psatype = xml->getpar127("spectrum_adjust_type", Psatype);
+    Psapar = xml->getpar127("spectrum_adjust_par", Psapar);
+
+    Prand = xml->getpar127("rand", Prand);
+    Pamprandtype = xml->getpar127("amp_rand_type", Pamprandtype);
+    Pamprandpower = xml->getpar127("amp_rand_power", Pamprandpower);
+
+    Pharmonicshift = xml->getpar("harmonic_shift", Pharmonicshift, -64, 64);
+    Pharmonicshiftfirst = xml->getparbool("harmonic_shift_first", Pharmonicshiftfirst);
+
+    Padaptiveharmonics = xml->getpar("adaptive_harmonics", Padaptiveharmonics, 0, 127);
+    Padaptiveharmonicsbasefreq = xml->getpar("adaptive_harmonics_base_frequency", Padaptiveharmonicsbasefreq,0,255);
+    Padaptiveharmonicspower = xml->getpar("adaptive_harmonics_power", Padaptiveharmonicspower, 0, 200);
+    Padaptiveharmonicspar = xml->getpar("adaptive_harmonics_par", Padaptiveharmonicspar, 0, 100);
+
+    if (xml->enterbranch("HARMONICS"))
+    {
+        Phmag[0] = 64;
+        Phphase[0] = 64;
+        for (int n = 0; n < MAX_AD_HARMONICS; ++n)
+        {
+            if (xml->enterbranch("HARMONIC",n + 1) == 0)
+                continue;
+            Phmag[n] = xml->getpar127("mag", 64);
+            Phphase[n] = xml->getpar127("phase", 64);
+
+            xml->exitbranch();
+        }
+        xml->exitbranch();
+    }
+
+    if (Pcurrentbasefunc != 0)
+        presetsUpdated();
+
+    if (xml->enterbranch("BASE_FUNCTION"))
+    {
+        for (int i = 1; i < synth->halfoscilsize; ++i)
+        {
+            if (xml->enterbranch("BF_HARMONIC", i))
+            {
+                basefuncFFTfreqs.c[i] = xml->getparreal("cos", 0.0);
+                basefuncFFTfreqs.s[i] = xml->getparreal("sin", 0.0);
+
+                xml->exitbranch();
+            }
+        }
+        xml->exitbranch();
+
+        float max = 0.0;
+
+        basefuncFFTfreqs.c[0] = 0.0;
+        for (int i = 0; i < synth->halfoscilsize; ++i)
+        {
+            if (max < fabsf(basefuncFFTfreqs.c[i]))
+                max = fabsf(basefuncFFTfreqs.c[i]);
+            if (max < fabsf(basefuncFFTfreqs.s[i]))
+                max = fabsf(basefuncFFTfreqs.s[i]);
+        }
+        if (max < 0.00000001)
+            max = 1.0;
+
+        for (int i = 0; i < synth->halfoscilsize; ++i)
+        {
+            if (basefuncFFTfreqs.c[i])
+                basefuncFFTfreqs.c[i] /= max;
+            if (basefuncFFTfreqs.s[i])
+                basefuncFFTfreqs.s[i] /= max;
+        }
+    }
+}
+
+float OscilParameters::getLimits(CommandBlock *getData)
+{
+    float value = getData->data.value.F;
+    int request = int(getData->data.type & TOPLEVEL::type::Default);
+    int control = getData->data.control;
+    int insert = getData->data.insert;
+
+    unsigned char type = 0;
+
+    // oscillator defaults
+    int min = 0;
+    int max = 127;
+    float def = 0;
+    type |= TOPLEVEL::type::Integer;
+    unsigned char learnable = TOPLEVEL::type::Learnable;
+    type |= learnable;
+
+    if (insert == TOPLEVEL::insert::harmonicAmplitude || insert == TOPLEVEL::insert::harmonicPhaseBandwidth)
+    { // do harmonics stuff
+        if (insert == TOPLEVEL::insert::harmonicAmplitude && control == 0)
+            def = 127;
+        else
+            def = 64;
+        getData->data.type = type;
+        switch (request)
+        {
+            case TOPLEVEL::type::Adjust:
+                if(value < min)
+                    value = min;
+                else if(value > max)
+                    value = max;
+            break;
+            case TOPLEVEL::type::Minimum:
+                value = min;
+                break;
+            case TOPLEVEL::type::Maximum:
+                value = max;
+                break;
+            case TOPLEVEL::type::Default:
+                value = def;
+                break;
+        }
+        return value;
+    }
+
+    switch (control)
+    {
+        case OSCILLATOR::control::phaseRandomness:
+            break;
+        case OSCILLATOR::control::magType:
+            max = 4;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::harmonicAmplitudeRandomness:
+            def = 64;
+            break;
+        case OSCILLATOR::control::harmonicRandomnessType:
+            max = 2;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::baseFunctionParameter:
+            min = -64;
+            max = 63;
+            break;
+        case OSCILLATOR::control::baseFunctionType:
+            max = 15;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::baseModulationParameter1:
+            def = 64;
+            break;
+        case OSCILLATOR::control::baseModulationParameter2:
+            def = 64;
+            break;
+        case OSCILLATOR::control::baseModulationParameter3:
+            def = 32;
+            break;
+        case OSCILLATOR::control::baseModulationType:
+            max = 3;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::autoClear:
+            max = 1;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::useAsBaseFunction:
+            max = 1;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::waveshapeParameter:
+            min = -64;
+            max = 63;
+            break;
+        case OSCILLATOR::control::waveshapeType:
+            max = 10;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::filterParameter1:
+            def = 64;
+            break;
+        case OSCILLATOR::control::filterParameter2:
+            def = 64;
+            break;
+        case OSCILLATOR::control::filterBeforeWaveshape:
+            max = 1;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::filterType:
+            max = 13;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::modulationParameter1:
+            def = 64;
+            break;
+        case OSCILLATOR::control::modulationParameter2:
+            def = 64;
+            break;
+        case OSCILLATOR::control::modulationParameter3:
+            def = 32;
+            break;
+        case OSCILLATOR::control::modulationType:
+            max = 3;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::spectrumAdjustParameter:
+            def = 64;
+            break;
+        case OSCILLATOR::control::spectrumAdjustType:
+            max = 3;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::harmonicShift:
+            min = -64;
+            max = 64;
+            break;
+        case OSCILLATOR::control::clearHarmonicShift:
+            max = 1;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::shiftBeforeWaveshapeAndFilter:
+            max = 1;
+            type &= ~learnable;
+            break;
+
+        case OSCILLATOR::control::adaptiveHarmonicsParameter:
+            max = 100;
+            def = 50;
+            break;
+        case OSCILLATOR::control::adaptiveHarmonicsBase:
+            max = 255;
+            def = 128;
+            break;
+        case OSCILLATOR::control::adaptiveHarmonicsPower:
+            max = 200;
+            def = 100;
+            break;
+        case OSCILLATOR::control::adaptiveHarmonicsType:
+            max = 8;
+            type &= ~learnable;
+            break;
+
+        case OSCILLATOR::control::clearHarmonics:
+            max = 1;
+            type &= ~learnable;
+            break;
+        case OSCILLATOR::control::convertToSine:
+            max = 1;
+            type &= ~learnable;
+            break;
+        default:
+            type |= TOPLEVEL::type::Error;
+            break;
+    }
+
+    getData->data.type = type;
+    if (type & TOPLEVEL::type::Error)
+        return 1;
+
+    switch (request)
+    {
+        case TOPLEVEL::type::Adjust:
+            if(value < min)
+                value = min;
+            else if(value > max)
+                value = max;
+        break;
+        case TOPLEVEL::type::Minimum:
+            value = min;
+            break;
+        case TOPLEVEL::type::Maximum:
+            value = max;
+            break;
+        case TOPLEVEL::type::Default:
+            value = def;
+            break;
+    }
+    return value;
+}

--- a/src/Params/OscilParameters.h
+++ b/src/Params/OscilParameters.h
@@ -1,0 +1,100 @@
+/*
+    OscilGen.h - Waveform generator for ADnote
+
+    Original ZynAddSubFX author Nasca Octavian Paul
+    Copyright (C) 2002-2005 Nasca Octavian Paul
+    Copyright 2009-2011, Alan Calvert
+    Copyright 2017-2019 Will Godfrey & others.
+    Copyright 2019 Kristian Amlie
+
+    This file is part of yoshimi, which is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either version 2 of
+    the License, or (at your option) any later version.
+
+    yoshimi is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.   See the GNU General Public License (version 2 or
+    later) for more details.
+
+    You should have received a copy of the GNU General Public License along with
+    yoshimi; if not, write to the Free Software Foundation, Inc., 51 Franklin
+    Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    This file is derivative of original ZynAddSubFX code.
+*/
+
+#ifndef OSCIL_PARAMETERS_H
+#define OSCIL_PARAMETERS_H
+
+#include "Presets.h"
+#include "DSP/FFTwrapper.h"
+
+class OscilParameters : public Presets
+{
+    public:
+        OscilParameters(SynthEngine *_synth);
+        virtual ~OscilParameters();
+
+        void add2XML(XMLwrapper *xml);
+        void defaults(void);
+        void getfromXML(XMLwrapper *xml);
+        float getLimits(CommandBlock *getData);
+
+        void updatebasefuncFFTfreqs(const FFTFREQS *src, int samples);
+        const FFTFREQS *getbasefuncFFTfreqs() const { return &basefuncFFTfreqs; }
+
+    public:
+        /**
+         * The hmag and hphase starts counting from 0, so the first harmonic(1) has the index 0,
+         * 2-nd harmonic has index 1, ..the 128 harminic has index 127
+         */
+        unsigned char Phmag[MAX_AD_HARMONICS], Phphase[MAX_AD_HARMONICS];
+        // the MIDI parameters for mag. and phases
+
+        unsigned char Phmagtype; // 0 - Linear, 1 - dB scale (-40), 2 - dB scale (-60)
+                                 // 3 - dB scale (-80), 4 - dB scale (-100)
+        unsigned char Pcurrentbasefunc; // The base function used - 0=sin, 1=...
+        unsigned char Pbasefuncpar; // the parameter of the base function
+
+        unsigned char Pbasefuncmodulation; // what modulation is applied to the
+                                           // basefunc
+        unsigned char Pbasefuncmodulationpar1,
+                      Pbasefuncmodulationpar2,
+                      Pbasefuncmodulationpar3; // the parameter of the base
+                                               // function modulation
+
+        unsigned char Prand; // 64 = no randomness
+                             // 63..0 - block type randomness - 0 is maximum
+                             // 65..127 - each harmonic randomness - 127 is maximum
+        unsigned char Pwaveshaping, Pwaveshapingfunction;
+        unsigned char Pfiltertype, Pfilterpar1, Pfilterpar2;
+        unsigned char Pfilterbeforews;
+        unsigned char Psatype, Psapar; // spectrum adjust
+
+        unsigned char Pamprandpower, Pamprandtype; // amplitude randomness
+        int Pharmonicshift; // how the harmonics are shifted
+        int Pharmonicshiftfirst; // if the harmonic shift is done before
+                                 // waveshaping and filter
+
+        unsigned char Padaptiveharmonics; // the adaptive harmonics status
+                                          // (off=0,on=1,etc..)
+        unsigned char Padaptiveharmonicsbasefreq; // the base frequency of the
+                                                  // adaptive harmonic (30..3000Hz)
+        unsigned char Padaptiveharmonicspower; // the strength of the effect
+                                               // (0=off,100=full)
+        unsigned char Padaptiveharmonicspar; // the parameters in 2,3,4.. modes
+                                             // of adaptive harmonics
+
+        unsigned char Pmodulation; // what modulation is applied to the oscil
+        unsigned char Pmodulationpar1,
+                      Pmodulationpar2,
+                      Pmodulationpar3; // the parameter of the parameters
+
+        bool ADvsPAD; // if it is used by ADsynth or by PADsynth
+
+    private:
+        FFTFREQS basefuncFFTfreqs; // Base Function Frequencies
+};
+
+#endif // OSCIL_PARAMETERS_H

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -46,8 +46,9 @@ PADnoteParameters::PADnoteParameters(FFTwrapper *fft_, SynthEngine *_synth) : Pr
     fft = fft_;
 
     resonance = new Resonance(synth);
-    oscilgen = new OscilGen(fft_, resonance, synth);
-    oscilgen->ADvsPAD = true;
+    POscil = new OscilParameters(synth);
+    POscil->ADvsPAD = true;
+    oscilgen = new OscilGen(fft_, resonance, synth, POscil);
 
     FreqEnvelope = new EnvelopeParams(0, 0, synth);
     FreqEnvelope->ASRinit(64, 50, 64, 60);
@@ -73,6 +74,7 @@ PADnoteParameters::~PADnoteParameters()
 {
     deletesamples();
     delete oscilgen;
+    delete POscil;
     delete resonance;
     delete FreqEnvelope;
     delete FreqLfo;
@@ -775,7 +777,7 @@ void PADnoteParameters::add2XML(XMLwrapper *xml)
     xml->endbranch();
 
     xml->beginbranch("OSCIL");
-        oscilgen->add2XML(xml);
+        POscil->add2XML(xml);
     xml->endbranch();
 
     xml->beginbranch("RESONANCE");
@@ -877,7 +879,7 @@ void PADnoteParameters::getfromXML(XMLwrapper *xml)
 
     if (xml->enterbranch("OSCIL"))
     {
-        oscilgen->getfromXML(xml);
+        POscil->getfromXML(xml);
         xml->exitbranch();
     }
 

--- a/src/Params/PADnoteParameters.h
+++ b/src/Params/PADnoteParameters.h
@@ -32,6 +32,7 @@
 class XMLwrapper;
 class FFTwrapper;
 class OscilGen;
+class OscilParameters;
 class Resonance;
 class EnvelopeParams;
 class LFOParams;
@@ -154,6 +155,7 @@ class PADnoteParameters : public Presets
         void applyparameters(void);
         bool export2wav(std::string basefilename);
 
+        OscilParameters *POscil;
         OscilGen *oscilgen;
         Resonance *resonance;
 

--- a/src/Params/Presets.cpp
+++ b/src/Params/Presets.cpp
@@ -30,7 +30,10 @@
 
 extern SynthEngine *firstSynth;
 
-Presets::Presets(SynthEngine *_synth) : nelement(-1), synth(_synth)
+Presets::Presets(SynthEngine *_synth) :
+    nelement(-1),
+    synth(_synth),
+    updatedAt(0)
 {
     type[0] = 0;
 }

--- a/src/Params/Presets.h
+++ b/src/Params/Presets.h
@@ -93,8 +93,11 @@ class Presets
 
                 void changePresets(const Presets *presets_)
                 {
-                    presets = presets_;
-                    forceUpdate();
+                    if (presets != presets_)
+                    {
+                        presets = presets_;
+                        forceUpdate();
+                    }
                 }
 
             private:

--- a/src/Params/Presets.h
+++ b/src/Params/Presets.h
@@ -62,6 +62,50 @@ class Presets
 
     protected:
         SynthEngine *synth;
+
+    private:
+        int updatedAt; // Monotonically increasing counter that tracks last
+                       // change.  Users of the parameters compare their last
+                       // update to this counter. This can overflow, what's
+                       // important is that it's different.
+
+    public:
+        class PresetsUpdate
+        {
+            public:
+                PresetsUpdate(const Presets *presets_) :
+                    presets(presets_),
+                    lastUpdated(-1)
+                {}
+
+                // Checks if presets have been updated and resets counter.
+                bool checkUpdated()
+                {
+                    bool result = presets->updatedAt != lastUpdated;
+                    lastUpdated = presets->updatedAt;
+                    return result;
+                }
+
+                void forceUpdate()
+                {
+                    lastUpdated = presets->updatedAt - 1;
+                }
+
+                void changePresets(const Presets *presets_)
+                {
+                    presets = presets_;
+                    forceUpdate();
+                }
+
+            private:
+                const Presets *presets;
+                int lastUpdated;
+        };
+
+        void presetsUpdated()
+        {
+            updatedAt++;
+        }
 };
 
 #endif

--- a/src/Params/Presets.h
+++ b/src/Params/Presets.h
@@ -75,7 +75,7 @@ class Presets
             public:
                 PresetsUpdate(const Presets *presets_) :
                     presets(presets_),
-                    lastUpdated(-1)
+                    lastUpdated(presets->updatedAt)
                 {}
 
                 // Checks if presets have been updated and resets counter.

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1192,7 +1192,7 @@ void ADnote::initParameters(void)
                 vc = adpars->VoicePar[nvoice].PextFMoscil;
 
             float freqtmp = 1.0f;
-            if (adpars->VoicePar[vc].FMSmp->Padaptiveharmonics != 0
+            if (adpars->VoicePar[vc].POscilFM->Padaptiveharmonics != 0
                || (NoteVoicePar[nvoice].FMEnabled == MORPH)
                || (NoteVoicePar[nvoice].FMEnabled == RING_MOD))
                freqtmp = getFMVoiceBaseFreq(nvoice);

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -574,76 +574,27 @@ void ADnote::initSubVoices(void)
         if (!NoteVoicePar[nvoice].Enabled)
             continue;
 
-        // We need sub voices for every case where we are using an external
-        // voice and we need to do any kind of frequency modulations, whether
-        // via oscillator frequency modulation, frequency envelopes, frequency
-        // LFO, or detuned unison voices. Else, we optimize by using the
-        // original output from that voice (VoiceOut).
-
-        bool oscHasFreqAdj =
-            unison_size[nvoice] > 1
-            || adpars->VoicePar[nvoice].PFreqEnvelopeEnabled
-            || adpars->VoicePar[nvoice].PFreqLfoEnabled
-            || adpars->VoicePar[nvoice].PCoarseDetune != 0
-            || adpars->VoicePar[nvoice].PDetune != 8192 // 8192 is center.
-            || adpars->VoicePar[nvoice].POffsetHz != 64
-            || adpars->VoicePar[nvoice].PfixedfreqET != 0;
-
         if (NoteVoicePar[nvoice].Voice != -1)
         {
-            bool oscFreqSettingsDiffer =
-                   (adpars->VoicePar[nvoice].PBendAdjust
-                    != adpars->VoicePar[NoteVoicePar[nvoice].Voice].PBendAdjust)
-                || (adpars->VoicePar[nvoice].Pfixedfreq
-                    != adpars->VoicePar[NoteVoicePar[nvoice].Voice].Pfixedfreq);
-
-            if (subVoiceNumber != -1
-                || oscHasFreqAdj
-                || oscFreqSettingsDiffer
-                || freqbasedmod[nvoice])
-            {
-                subVoice[nvoice] = new ADnote*[unison_size[nvoice]];
-                for (int k = 0; k < unison_size[nvoice]; ++k) {
-                    float *freqmod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
-                    subVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
-                                                     getVoiceBaseFreq(nvoice),
-                                                     NoteVoicePar[nvoice].Voice,
-                                                     freqmod, forFM);
-                }
+            subVoice[nvoice] = new ADnote*[unison_size[nvoice]];
+            for (int k = 0; k < unison_size[nvoice]; ++k) {
+                float *freqmod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
+                subVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                                                 getVoiceBaseFreq(nvoice),
+                                                 NoteVoicePar[nvoice].Voice,
+                                                 freqmod, forFM);
             }
         }
 
-        // Similar conditions, just adapted to the modulator.
-
-        bool modHasFreqAdj =
-            adpars->VoicePar[nvoice].PFMFreqEnvelopeEnabled
-            || adpars->VoicePar[nvoice].PFMCoarseDetune != 0
-            || adpars->VoicePar[nvoice].PFMDetune != 8192;
-
         if (NoteVoicePar[nvoice].FMVoice != -1)
         {
-            bool modFreqSettingsDiffer =
-                   (adpars->VoicePar[nvoice].PBendAdjust
-                    != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].PBendAdjust)
-                || (adpars->VoicePar[nvoice].PFMFixedFreq
-                    != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq)
-                || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc
-                    && (adpars->VoicePar[nvoice].Pfixedfreq
-                        != adpars->VoicePar[NoteVoicePar[nvoice].FMVoice].Pfixedfreq));
-
-            if (subVoiceNumber != -1
-                    || (NoteVoicePar[nvoice].FMDetuneFromBaseOsc && oscHasFreqAdj)
-                    || modHasFreqAdj
-                    || modFreqSettingsDiffer)
-            {
-                bool voiceForFM = NoteVoicePar[nvoice].FMEnabled == FREQ_MOD;
-                subFMVoice[nvoice] = new ADnote*[unison_size[nvoice]];
-                for (int k = 0; k < unison_size[nvoice]; ++k) {
-                    subFMVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
-                                                       getFMVoiceBaseFreq(nvoice),
-                                                       NoteVoicePar[nvoice].FMVoice,
-                                                       parentFMmod, voiceForFM);
-                }
+            bool voiceForFM = NoteVoicePar[nvoice].FMEnabled == FREQ_MOD;
+            subFMVoice[nvoice] = new ADnote*[unison_size[nvoice]];
+            for (int k = 0; k < unison_size[nvoice]; ++k) {
+                subFMVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                                                   getFMVoiceBaseFreq(nvoice),
+                                                   NoteVoicePar[nvoice].FMVoice,
+                                                   parentFMmod, voiceForFM);
             }
         }
     }
@@ -1249,30 +1200,10 @@ void ADnote::initParameters(void)
         }
     }
 
-    for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
+    if (subVoiceNumber != -1)
     {
-        for (i = nvoice + 1; i < NUM_VOICES; ++i)
-        {
-            bool needVoiceOut = false;
-            if (subVoiceNumber != -1) {
-                needVoiceOut = true;
-            } else if (NoteVoicePar[i].Enabled) {
-                if (NoteVoicePar[i].Voice == nvoice && subVoice[i] == NULL) {
-                    needVoiceOut = true;
-                } else if (NoteVoicePar[i].FMEnabled != NONE
-                           && NoteVoicePar[i].FMVoice == nvoice
-                           && subFMVoice[i] == NULL) {
-                    needVoiceOut = true;
-                }
-            }
-
-            if (needVoiceOut)
-            {
-                NoteVoicePar[nvoice].VoiceOut = (float*)fftwf_malloc(synth->bufferbytes);
-                memset(NoteVoicePar[nvoice].VoiceOut, 0, synth->bufferbytes);
-                break;
-            }
-        }
+        NoteVoicePar[subVoiceNumber].VoiceOut = (float*)fftwf_malloc(synth->bufferbytes);
+        memset(NoteVoicePar[subVoiceNumber].VoiceOut, 0, synth->bufferbytes);
     }
 }
 
@@ -2322,7 +2253,6 @@ int ADnote::noteout(float *outl, float *outr)
             continue;
 
         if (NoteVoicePar[nvoice].Volume == 0.0f
-            && subVoiceNumber == -1
             && NoteVoicePar[nvoice].VoiceOut == NULL) {
 
             // If the voice is muted and we are not producing sound for any sub

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -29,6 +29,7 @@
 
 #include "Params/ADnoteParameters.h"
 #include "Synth/LegatoTypes.h"
+#include "Misc/RandomGen.h"
 
 class ADnoteParameters;
 class Controller;

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -1326,7 +1326,7 @@ int OscilGen::getPhase()
         return 0;
 
     int outpos;
-    outpos = (int)(prng.numRandom() * 2.0f - 1.0f) * synth->oscilsize_f * (params->Prand - 64.0f) / 64.0f;
+    outpos = (prng.numRandom() * 2.0f - 1.0f) * synth->oscilsize_f * (params->Prand - 64.0f) / 64.0f;
     outpos = (outpos + 2 * synth->oscilsize) % synth->oscilsize;
     return outpos;
 }

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -647,7 +647,15 @@ void OscilGen::oscilfilter(void)
 // Change the base function
 void OscilGen::changebasefunction(void)
 {
-    if (params->Pcurrentbasefunc != 0)
+    if (params->Pcurrentbasefunc == 127)
+    {
+        // User base function
+        memcpy(oscilFFTfreqs.c, params->getbasefuncFFTfreqs()->c,
+               synth->halfoscilsize * sizeof(float));
+        memcpy(oscilFFTfreqs.s, params->getbasefuncFFTfreqs()->s,
+               synth->halfoscilsize * sizeof(float));
+    }
+    else if (params->Pcurrentbasefunc != 0)
     {
         getbasefunction(tmpsmps);
         fft->smps2freqs(tmpsmps, &oscilFFTfreqs);

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -56,7 +56,7 @@ OscilGen::OscilGen(FFTwrapper *fft_, Resonance *res_, SynthEngine *_synth, Oscil
     else
         memset(tmpsmps, 0, synth->oscilsize * sizeof(float));
     FFTwrapper::newFFTFREQS(&oscilFFTfreqs, synth->halfoscilsize);
-    defaults();
+    genDefaults();
 }
 
 OscilGen::~OscilGen()
@@ -77,6 +77,12 @@ void OscilGen::changeParams(OscilParameters *params_)
 
 void OscilGen::defaults(void)
 {
+    params->defaults();
+    genDefaults();
+}
+
+void OscilGen::genDefaults(void)
+{
     oldbasefunc = 0;
     oldbasepar = 64;
     oldhmagtype = 0;
@@ -94,8 +100,6 @@ void OscilGen::defaults(void)
 
     memset(hmag, 0, MAX_AD_HARMONICS * sizeof(float));
     memset(hphase, 0, MAX_AD_HARMONICS * sizeof(float));
-
-    params->defaults();
 
     memset(oscilFFTfreqs.s, 0, synth->halfoscilsize * sizeof(float));
     memset(oscilFFTfreqs.c, 0, synth->halfoscilsize * sizeof(float));
@@ -926,13 +930,7 @@ void OscilGen::prepare(void)
     // because it is essentially random at which cycle position the global PRNG is just now
     prng.init(synth->randomINT() + INT_MAX/2);
 
-    if (oldbasepar != params->Pbasefuncpar
-        || oldbasefunc != params->Pcurrentbasefunc
-        || oldbasefuncmodulation != params->Pbasefuncmodulation
-        || oldbasefuncmodulationpar1 != params->Pbasefuncmodulationpar1
-        || oldbasefuncmodulationpar2 != params->Pbasefuncmodulationpar2
-        || oldbasefuncmodulationpar3 != params->Pbasefuncmodulationpar3)
-        changebasefunction();
+    changebasefunction();
 
     for (int i = 0; i < MAX_AD_HARMONICS; ++i)
         hphase[i] = (params->Phphase[i] - 64.0f) / 64.0f * PI / (i + 1);

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -669,7 +669,6 @@ void OscilGen::changebasefunction(void)
     }
     params->updatebasefuncFFTfreqs(&oscilFFTfreqs, synth->halfoscilsize);
 
-    oscilupdate.forceUpdate();
     oldbasefunc = params->Pcurrentbasefunc;
     oldbasepar = params->Pbasefuncpar;
     oldbasefuncmodulation = params->Pbasefuncmodulation;

--- a/src/Synth/OscilGen.h
+++ b/src/Synth/OscilGen.h
@@ -34,17 +34,18 @@
 #include "Misc/RandomGen.h"
 #include "Misc/WaveShapeSamples.h"
 #include "Misc/XMLwrapper.h"
-#include "DSP/FFTwrapper.h"
-#include "Params/Presets.h"
+#include "Params/OscilParameters.h"
 #include "Synth/Resonance.h"
 
 class SynthEngine;
 
-class OscilGen : public Presets, private WaveShapeSamples
+class OscilGen : private WaveShapeSamples
 {
     public:
-        OscilGen(FFTwrapper *fft_,Resonance *res_, SynthEngine *_synth);
+        OscilGen(FFTwrapper *fft_,Resonance *res_, SynthEngine *_synth, OscilParameters *params_);
         ~OscilGen();
+
+        void changeParams(OscilParameters *params_);
 
         void prepare();
 
@@ -64,67 +65,18 @@ class OscilGen : public Presets, private WaveShapeSamples
         void getcurrentbasefunction(float *smps);
         void useasbase(void);
 
-        void add2XML(XMLwrapper *xml);
         void defaults(void);
-        void getfromXML(XMLwrapper *xml);
-        float getLimits(CommandBlock *getData);
         void convert2sine();
 
         // Make a new random seed for Amplitude Randomness -
         //   should be called every noteon event
         void newrandseed() { randseed = prng.randomINT() + INT_MAX/2; }
 
-        // Parameters
-
-        /**
-         * The hmag and hphase starts counting from 0, so the first harmonic(1) has the index 0,
-         * 2-nd harmonic has index 1, ..the 128 harminic has index 127
-         */
-        unsigned char Phmag[MAX_AD_HARMONICS], Phphase[MAX_AD_HARMONICS];
-        // the MIDI parameters for mag. and phases
-
-        unsigned char Phmagtype; // 0 - Linear, 1 - dB scale (-40), 2 - dB scale (-60)
-                                 // 3 - dB scale (-80), 4 - dB scale (-100)
-        unsigned char Pcurrentbasefunc; // The base function used - 0=sin, 1=...
-        unsigned char Pbasefuncpar; // the parameter of the base function
-
-        unsigned char Pbasefuncmodulation; // what modulation is applied to the
-                                           // basefunc
-        unsigned char Pbasefuncmodulationpar1,
-                      Pbasefuncmodulationpar2,
-                      Pbasefuncmodulationpar3; // the parameter of the base
-                                               // function modulation
-
-        unsigned char Prand; // 64 = no randomness
-                             // 63..0 - block type randomness - 0 is maximum
-                             // 65..127 - each harmonic randomness - 127 is maximum
-        unsigned char Pwaveshaping, Pwaveshapingfunction;
-        unsigned char Pfiltertype, Pfilterpar1, Pfilterpar2;
-        unsigned char Pfilterbeforews;
-        unsigned char Psatype, Psapar; // spectrum adjust
-
-        unsigned char Pamprandpower, Pamprandtype; // amplitude randomness
-        int Pharmonicshift; // how the harmonics are shifted
-        int Pharmonicshiftfirst; // if the harmonic shift is done before
-                                 // waveshaping and filter
-
-        unsigned char Padaptiveharmonics; // the adaptive harmonics status
-                                          // (off=0,on=1,etc..)
-        unsigned char Padaptiveharmonicsbasefreq; // the base frequency of the
-                                                  // adaptive harmonic (30..3000Hz)
-        unsigned char Padaptiveharmonicspower; // the strength of the effect
-                                               // (0=off,100=full)
-        unsigned char Padaptiveharmonicspar; // the parameters in 2,3,4.. modes
-                                             // of adaptive harmonics
-
-        unsigned char Pmodulation; // what modulation is applied to the oscil
-        unsigned char Pmodulationpar1,
-                      Pmodulationpar2,
-                      Pmodulationpar3; // the parameter of the parameters
-
-        bool ADvsPAD; // if it is used by ADsynth or by PADsynth
-
     private:
+        OscilParameters *params;
+
+        SynthEngine *synth;
+
         float *tmpsmps;
         FFTFREQS outoscilFFTfreqs;
 
@@ -193,14 +145,14 @@ class OscilGen : public Presets, private WaveShapeSamples
             oldmodulationpar2,
             oldmodulationpar3;
 
-        FFTFREQS basefuncFFTfreqs; // Base Function Frequencies
         FFTFREQS oscilFFTfreqs; // Oscillator Frequencies - this is different
                                 // than the hamonics set-up by the user, it may
                                 // contain time-domain data if the antialiasing
                                 // is turned off
-        int oscilprepared; // 1 if the oscil is prepared, 0 if it is not
-                           // prepared and is need to call ::prepare() before
-                           // ::get()
+        Presets::PresetsUpdate oscilupdate;// whether the oscil is prepared, if
+                                           // not prepared we need to call
+                                           // ::prepare() before ::get()
+
 
         Resonance *res;
 

--- a/src/Synth/OscilGen.h
+++ b/src/Synth/OscilGen.h
@@ -65,6 +65,7 @@ class OscilGen : private WaveShapeSamples
         void getcurrentbasefunction(float *smps);
         void useasbase(void);
 
+        void genDefaults(void);
         void defaults(void);
         void convert2sine();
 

--- a/src/UI/ADnoteUI.fl
+++ b/src/UI/ADnoteUI.fl
@@ -200,6 +200,9 @@ class ADvoicelistitem {: {public Fl_Group}
     npart = npart_;
     kititem = kititem_;
     nvoice = nvoice_;
+    fft = new FFTwrapper(synth->oscilsize);
+    oscil = new OscilGen(fft, NULL, synth, parameters->VoicePar[nvoice].POscil);
+    oscilFM = new OscilGen(fft, NULL, synth, parameters->VoicePar[nvoice].POscilFM);
     make_window();
     if (pars->VoicePar[nvoice].PFreqLfoEnabled > 0)
         voicelistvibratto->activate();
@@ -223,7 +226,8 @@ class ADvoicelistitem {: {public Fl_Group}
                 nvp = nvs = pars->VoicePar[nvs].PVoice;
         else if (pars->VoicePar[nvoice].Pextoscil != -1)
             nvs = pars->VoicePar[nvoice].Pextoscil;
-        osc->init(pars->VoicePar[nvs].OscilSmp, 0, pars->VoicePar[nvp].Poscilphase, synth);
+        oscil->changeParams(pars->VoicePar[nvs].POscil);
+        osc->init(oscil, 0, pars->VoicePar[nvp].Poscilphase, synth);
         if (pars->VoicePar[nvoice].Enabled == 0)
             voicelistitemgroup->deactivate();
         else
@@ -242,7 +246,8 @@ if (pars->VoicePar[nvoice].PVoice != -1)
         nvp = nvs = pars->VoicePar[nvs].PVoice;
 else if (pars->VoicePar[nvoice].Pextoscil != -1)
     nvs = pars->VoicePar[nvoice].Pextoscil;
-osc->init(pars->VoicePar[nvs].OscilSmp,0,pars->VoicePar[nvp].Poscilphase, synth);
+oscil->changeParams(pars->VoicePar[nvs].POscil);
+osc->init(oscil,0,pars->VoicePar[nvp].Poscilphase, synth);
 
 if (pars->VoicePar[nvoice].PVoice >= 0 || pars->VoicePar[nvoice].Type != 0)
     voiceoscil->deactivate();
@@ -295,11 +300,13 @@ if (pars->VoicePar[nvoice].PFMVoice != -1) {
     nvp = nvs = pars->VoicePar[nvs].PFMVoice;
     while (pars->VoicePar[nvs].PVoice != -1)
         nvp = nvs = pars->VoicePar[nvs].PVoice;
-    modosc->init(pars->VoicePar[nvs].OscilSmp,0,pars->VoicePar[nvp].Poscilphase, synth);
+    oscilFM->changeParams(pars->VoicePar[nvs].POscil);
+    modosc->init(oscilFM,0,pars->VoicePar[nvp].Poscilphase, synth);
 } else {
     if (pars->VoicePar[nvoice].PextFMoscil != -1)
         nvs = pars->VoicePar[nvoice].PextFMoscil;
-    modosc->init(pars->VoicePar[nvs].FMSmp,0,pars->VoicePar[nvp].PFMoscilphase, synth);
+    oscilFM->changeParams(pars->VoicePar[nvs].POscilFM);
+    modosc->init(oscilFM,0,pars->VoicePar[nvp].PFMoscilphase, synth);
 }
 
 if (pars->VoicePar[nvoice].PFMEnabled == NONE || pars->VoicePar[nvoice].PFMVoice >= 0)
@@ -342,11 +349,20 @@ else
   }
   Function {~ADvoicelistitem()} {} {
     code {//
-        ADnoteVoiceListItem->hide();} {}
+        ADnoteVoiceListItem->hide();
+        delete oscil;
+        delete oscilFM;
+        delete fft;} {}
   }
   decl {ADnoteParameters *pars;} {private local
   }
   decl {int nvoice;} {public local
+  }
+  decl {FFTwrapper *fft;} {private local
+  }
+  decl {OscilGen *oscil;} {private local
+  }
+  decl {OscilGen *oscilFM;} {private local
   }
   decl {Oscilloscope *osc;} {private local
   }
@@ -537,7 +553,7 @@ send_data(TOPLEVEL::action::forceUpdate, ADDVOICE::control::modulatorFrequencyAs
                     int nv = nvoice;
                     if (pars->VoicePar[nvoice].PextFMoscil >= 0)
                         nv = pars->VoicePar[nvoice].PextFMoscil;
-                    oscedit = new OscilEditor(pars->VoicePar[nv].FMSmp, modOscDisplay, NULL, NULL, synth, npart, kititem, nvoice + PART::engine::addMod1);
+                    oscedit = new OscilEditor(pars->VoicePar[nv].POscilFM, modOscDisplay, NULL, NULL, synth, npart, kititem, nvoice + PART::engine::addMod1);
                     if ((Fl::event_button() == 3))
                         synth->getGuiMaster()->partui->adnoteui->ADnoteVoice->hide();}
                   xywh {666 372 62 12} box THIN_UP_BOX labelfont 1 labelsize 9
@@ -778,7 +794,7 @@ Oscillator}
     int nv = nvoice;
     if (pars->VoicePar[nvoice].Pextoscil >= 0)
         nv=pars->VoicePar[nvoice].Pextoscil;
-    oscedit = new OscilEditor(pars->VoicePar[nv].OscilSmp, oscDisplay, NULL, NULL, synth, npart, kititem, nvoice + PART::engine::addVoice1);
+    oscedit = new OscilEditor(pars->VoicePar[nv].POscil, oscDisplay, NULL, NULL, synth, npart, kititem, nvoice + PART::engine::addVoice1);
     if ((Fl::event_button() == 3))
         synth->getGuiMaster()->partui->adnoteui->ADnoteVoice->hide();}
                   xywh {10 534 70 21} box THIN_UP_BOX labelfont 1 labelsize 11
@@ -1629,7 +1645,8 @@ if (pars->VoicePar[nvoice].PVoice != -1)
         nvp = nvs = pars->VoicePar[nvs].PVoice;
 else if (pars->VoicePar[nvoice].Pextoscil != -1)
     nvs = pars->VoicePar[nvoice].Pextoscil;
-osc->init(pars->VoicePar[nvs].OscilSmp,0,pars->VoicePar[nvp].Poscilphase, synth);} {}
+oscil->changeParams(pars->VoicePar[nvs].POscil);
+osc->init(oscil,0,pars->VoicePar[nvp].Poscilphase, synth);} {}
   }
   Function {update_fmoscil()} {} {
     code {int nv=nvoice;
@@ -1638,21 +1655,26 @@ if (pars->VoicePar[nvoice].PFMVoice >= 0) {
     while (pars->VoicePar[nv].PVoice >= 0) {
         nv = pars->VoicePar[nv].PVoice;
     }
-    oscFM->init(pars->VoicePar[nv].OscilSmp,0,pars->VoicePar[nv].Poscilphase, synth);
+    oscilFM->changeParams(pars->VoicePar[nv].POscil);
+    oscFM->init(oscilFM,0,pars->VoicePar[nv].Poscilphase, synth);
 } else {
     if (pars->VoicePar[nvoice].PextFMoscil >= 0) {
         nv = pars->VoicePar[nvoice].PextFMoscil;
     }
-    oscFM->init(pars->VoicePar[nv].FMSmp,0,pars->VoicePar[nvoice].PFMoscilphase, synth);
+    oscilFM->changeParams(pars->VoicePar[nv].POscilFM);
+    oscFM->init(oscilFM,0,pars->VoicePar[nvoice].PFMoscilphase, synth);
 }} {}
   }
   Function {init(ADnoteParameters *parameters,int npart_, int kititem_, int nvoice_)} {} {
     code {//
-    synth = parameters->getSynthEngine();
+        synth = parameters->getSynthEngine();
         pars = parameters;
         npart = npart_;
         kititem = kititem_;
         nvoice = nvoice_;
+        fft = new FFTwrapper(synth->oscilsize);
+        oscil = new OscilGen(fft, NULL, synth, parameters->VoicePar[nvoice].POscil);
+        oscilFM = new OscilGen(fft, NULL, synth, parameters->VoicePar[nvoice].POscilFM);
         make_window();
         end();
         if (nvoice == 0)
@@ -1670,7 +1692,10 @@ if (pars->VoicePar[nvoice].PFMVoice >= 0) {
         if (oscedit)
         {
             delete oscedit;
-        }} {}
+        }
+        delete oscil;
+        delete oscilFM;
+        delete fft;} {}
   }
   decl {int nvoice;} {public local
   }
@@ -1681,6 +1706,12 @@ if (pars->VoicePar[nvoice].PFMVoice >= 0) {
   decl {ADnoteParameters *pars;} {private local
   }
   decl {OscilEditor *oscedit;} {public local
+  }
+  decl {FFTwrapper *fft;} {private local
+  }
+  decl {OscilGen *oscil;} {private local
+  }
+  decl {OscilGen *oscilFM;} {private local
   }
   decl {Oscilloscope *osc;} {private local
   }

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -90,12 +90,12 @@ decl {\#include "Misc/NumericFuncs.h"
 class OscilSpectrum {: {public Fl_Box}
 } {
   Function {OscilSpectrum(int x,int y, int w, int h, const char *label=0):Fl_Box(x,y,w,h,label)} {} {
-    code {oscil=NULL;} {}
+    code {oscilSmp=NULL;} {}
   }
-  Function {init(OscilGen *oscil_,int oscbase_, SynthEngine *_synth)} {} {
+  Function {init(OscilGen *oscilSmp_,int oscbase_, SynthEngine *_synth)} {} {
     code {//
     synth = _synth;
-    oscil = oscil_;
+    oscilSmp = oscilSmp_;
     oscbase = oscbase_;} {}
   }
   Function {draw()} {} {
@@ -116,9 +116,9 @@ class OscilSpectrum {: {public Fl_Box}
         spc[i] = 0.0;
 
     if (oscbase == 0)
-        oscil->getspectrum(n, spc, 0);
+        oscilSmp->getspectrum(n, spc, 0);
     else
-        oscil->getspectrum(n, spc, 1);
+        oscilSmp->getspectrum(n, spc, 1);
 
     // normalize
     float max = 0;
@@ -178,7 +178,7 @@ class OscilSpectrum {: {public Fl_Box}
     }
     delete [] spc;} {}
   }
-  decl {OscilGen *oscil;} {private local
+  decl {OscilGen *oscilSmp;} {private local
   }
   decl {int oscbase;} {private local
   }
@@ -226,25 +226,25 @@ class Oscilloscope {: {public Fl_Box}
 } {
   Function {Oscilloscope(int x,int y, int w, int h, const char *label=0):Fl_Box(x,y,w,h,label)} {} {
     code {//
-    oscil=NULL;
+    oscilSmp=NULL;
     phase=64;
     oscbase=0;} {}
   }
-  Function {init(OscilGen *oscil_, SynthEngine *_synth)} {} {
+  Function {init(OscilGen *oscilSmp_, SynthEngine *_synth)} {} {
     code {//
     synth = _synth;
-    oscil=oscil_;} {}
+    oscilSmp=oscilSmp_;} {}
   }
-  Function {init(OscilGen *oscil_,int oscbase_, SynthEngine *_synth)} {} {
+  Function {init(OscilGen *oscilSmp_,int oscbase_, SynthEngine *_synth)} {} {
     code {//
     synth = _synth;
-    oscil=oscil_;
+    oscilSmp=oscilSmp_;
     oscbase=oscbase_;} {}
   }
-  Function {init(OscilGen *oscil_,int oscbase_,int phase_, SynthEngine *_synth)} {} {
+  Function {init(OscilGen *oscilSmp_,int oscbase_,int phase_, SynthEngine *_synth)} {} {
     code {//
     synth = _synth;
-    oscil=oscil_;
+    oscilSmp=oscilSmp_;
     oscbase=oscbase_;
     phase=phase_;} {}
   }
@@ -256,9 +256,9 @@ class Oscilloscope {: {public Fl_Box}
     int ly = h() - 1;
     float smps[synth->oscilsize];
     if (oscbase == 0)
-        oscil->get(smps, -1.0);
+        oscilSmp->get(smps, -1.0);
     else
-        oscil->getcurrentbasefunction(smps);
+        oscilSmp->getcurrentbasefunction(smps);
 
     if (damage( )!= 1)
     {
@@ -320,7 +320,7 @@ class Oscilloscope {: {public Fl_Box}
                 (int)(y2 * ly / 2.0) + oy + ly / 2);
             }} {}
   }
-  decl {OscilGen *oscil;} {private local
+  decl {OscilGen *oscilSmp;} {private local
   }
   decl {int oscbase;} {private local
   }
@@ -411,7 +411,7 @@ class Oscilharmonic {: {public Fl_Group}
         type |= TOPLEVEL::type::Write;
         collect_data(synth, value, action, (Fl::event_button() | type), control, npart, kititem, engine, insert);} {}
   }
-  Function {init(OscilGen *oscil_,int n_,Fl_Group *display_,Fl_Widget *oldosc_,Fl_Widget *cbwidget_,Fl_Widget *applybutton_, SynthEngine *_synth, int npart_, int kititem_, int engine_)} {} {
+  Function {init(OscilParameters *oscil_,int n_,Fl_Group *display_,Fl_Widget *oldosc_,Fl_Widget *cbwidget_,Fl_Widget *applybutton_, SynthEngine *_synth, int npart_, int kititem_, int engine_)} {} {
     code {//
     synth = _synth;
     oscil=oscil_;
@@ -446,7 +446,7 @@ class Oscilharmonic {: {public Fl_Group}
     code {//
     harmonic->hide();} {}
   }
-  decl {OscilGen *oscil;} {private local
+  decl {OscilParameters *oscil;} {private local
   }
   decl {Fl_Group *display;} {private local
   }
@@ -486,7 +486,7 @@ class OscilEditor {: {public PresetsUI_}
         Fl_Group {} {
           xywh {10 85 350 190} box THIN_DOWN_BOX color 32 selection_color 71 labelcolor 179
           code0 {Oscilloscope *osc=new Oscilloscope(o->x(),o->y(),o->w(),o->h(),"");}
-          code1 {osc->init(oscil, synth);}
+          code1 {osc->init(oscilSmp, synth);}
         } {}
         Fl_Box {} {
           label Oscillator
@@ -506,7 +506,7 @@ class OscilEditor {: {public PresetsUI_}
         Fl_Group {} {
           xywh {10 30 350 50} box THIN_DOWN_BOX color 32 selection_color 218 labelcolor 63
           code0 {OscilSpectrum *spc=new OscilSpectrum(o->x(),o->y(),o->w(),o->h(),"");}
-          code1 {spc->init(oscil,0, synth);}
+          code1 {spc->init(oscilSmp,0, synth);}
         } {}
         Fl_Group {} {
           xywh {246 277 115 25} box ENGRAVED_BOX
@@ -545,7 +545,7 @@ class OscilEditor {: {public PresetsUI_}
         Fl_Group {} {
           xywh {370 85 350 190} box THIN_DOWN_BOX color 32 selection_color 71 labelcolor 179
           code0 {Oscilloscope *osc=new Oscilloscope(o->x(),o->y(),o->w(),o->h(),"");}
-          code1 {osc->init(oscil,1, synth);}
+          code1 {osc->init(oscilSmp,1, synth);}
         } {}
         Fl_Dial bfslider {
           callback {//
@@ -635,7 +635,7 @@ class OscilEditor {: {public PresetsUI_}
         Fl_Group {} {
           xywh {370 30 350 50} box THIN_DOWN_BOX color 32 selection_color 218 labelcolor 63
           code0 {OscilSpectrum *spc=new OscilSpectrum (o->x(),o->y(),o->w(),o->h(),"");}
-          code1 {spc->init(oscil,1, synth);}
+          code1 {spc->init(oscilSmp,1, synth);}
         } {}
         Fl_Box {} {
           label {Par.}
@@ -1396,13 +1396,15 @@ class OscilEditor {: {public PresetsUI_}
     code {//
         return collect_readData(synth, value, control, part, kititem, engine, insert, parameter, offset, miscmsg, request);} {}
   }
-  Function {OscilEditor(OscilGen *oscil_, Fl_Widget *oldosc_, Fl_Widget *cbwidget_, Fl_Widget *cbapplywidget_, SynthEngine *_synth, int npart_, int kititem_, int engine_)} {} {
+  Function {OscilEditor(OscilParameters *oscil_, Fl_Widget *oldosc_, Fl_Widget *cbwidget_, Fl_Widget *cbapplywidget_, SynthEngine *_synth, int npart_, int kititem_, int engine_)} {} {
     code {//
     synth = _synth;
     npart = npart_;
     kititem = kititem_;
     engine = engine_;
     oscil = oscil_;
+    fft = new FFTwrapper(synth->oscilsize);
+    oscilSmp = new OscilGen(fft, NULL, synth, oscil);
     oldosc = oldosc_;
     cbwidget = cbwidget_;
     cbapplywidget=cbapplywidget_;
@@ -1413,7 +1415,9 @@ class OscilEditor {: {public PresetsUI_}
   Function {~OscilEditor()} {return_type virtual
   } {
     code {osceditUI->hide();
-    delete (osceditUI);} {}
+    delete (osceditUI);
+    delete oscilSmp;
+    delete fft;} {}
   }
   Function {refresh()} {} {
     code {//
@@ -1495,7 +1499,7 @@ class OscilEditor {: {public PresetsUI_}
     for (int i=0;i<MAX_AD_HARMONICS;i++)
         h[i]->refresh();
 
-    oscil->prepare();
+    oscilSmp->prepare();
 
     basefuncdisplaygroup->redraw();
     redrawoscil();} {}
@@ -1551,7 +1555,11 @@ class OscilEditor {: {public PresetsUI_}
         applybutton->redraw();
 };} {}
   }
-  decl {OscilGen *oscil;} {private local
+  decl {OscilParameters *oscil;} {private local
+  }
+  decl {FFTwrapper *fft;} {private local
+  }
+  decl {OscilGen *oscilSmp;} {private local
   }
   decl {Fl_Widget *oldosc,*cbwidget,*cbapplywidget;} {private local
   }

--- a/src/UI/PADnoteUI.fl
+++ b/src/UI/PADnoteUI.fl
@@ -438,7 +438,7 @@ class PADnoteUI {: {public PresetsUI_}
             label Waveform
             callback {//
             if (oscui!=NULL) delete (oscui);
-                oscui = new OscilEditor(pars->oscilgen, osc, cbwidget, applybutton, synth, npart, kititem, 2);
+                oscui = new OscilEditor(pars->POscil, osc, cbwidget, applybutton, synth, npart, kititem, 2);
             if ((Fl::event_button() == 3))
                 padnotewindow->hide();}
             tooltip {Right click: also close this} xywh {375 270 80 20} box THIN_UP_BOX labelfont 1 labelsize 11


### PR DESCRIPTION
This fixes the OscilGen thread-safety issue and cleans up one unneeded optimization. See the individual commits for details.

The patch looks big, but the vast majority is just moving code around to split OscilGen into OscilParameters and OscilGen, and renaming parameters thereafter. There isn't a whole lot of new code here.