### PR TITLE
Live parameter feedback for Yoshimi

### DIFF
--- a/src/DSP/Filter.h
+++ b/src/DSP/Filter.h
@@ -36,7 +36,7 @@ class SynthEngine;
 class Filter
 {
     public:
-        Filter(FilterParams *pars, SynthEngine *_synth);
+        Filter(FilterParams *pars_, SynthEngine *_synth);
         ~Filter();
         void filterout(float *smp);
         void setfreq(float frequency);
@@ -45,6 +45,10 @@ class Filter
         float getrealfreq(float freqpitch);
 
     private:
+        void updateCurrentParameters();
+
+        FilterParams *pars;
+        Presets::PresetsUpdate parsUpdate;
         Filter_ *filter;
         unsigned char category;
 

--- a/src/DSP/FormantFilter.h
+++ b/src/DSP/FormantFilter.h
@@ -34,7 +34,7 @@ class SynthEngine;
 class FormantFilter : public Filter_
 {
     public:
-        FormantFilter(FilterParams *pars, SynthEngine *_synth);
+        FormantFilter(FilterParams *pars_, SynthEngine *_synth);
         ~FormantFilter();
         void filterout(float *smp);
         void setfreq(float frequency);
@@ -44,7 +44,10 @@ class FormantFilter : public Filter_
 
     private:
         void setpos(float input);
+        void updateCurrentParameters();
 
+        FilterParams *pars;
+        Presets::PresetsUpdate parsUpdate;
 
         AnalogFilter *formant[FF_MAX_FORMANTS];
         float *inbuffer, *tmpbuf;

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -38,7 +38,6 @@ SVFilter::SVFilter(unsigned char Ftype, float Ffreq, float Fq,
     stages(Fstages),
     freq(Ffreq),
     q(Fq),
-    gain(1.0f),
     needsinterpolation(0),
     firsttime(1),
     synth(_synth)
@@ -122,13 +121,6 @@ void SVFilter::setq(float q_)
 void SVFilter::settype(int type_)
 {
     type = type_;
-    computefiltercoefs();
-}
-
-
-void SVFilter::setgain(float dBgain)
-{
-    gain = dB2rap(dBgain);
     computefiltercoefs();
 }
 

--- a/src/DSP/SVFilter.h
+++ b/src/DSP/SVFilter.h
@@ -40,7 +40,6 @@ class SVFilter : public Filter_
         void setq(float q_);
 
         void settype(int type_);
-        void setgain(float dBgain);
         void setstages(int stages_);
         void cleanup();
 
@@ -59,7 +58,6 @@ class SVFilter : public Filter_
         int stages;    // how many times the filter is applied (0->1,1->2,etc.)
         float freq; // Frequency given in Hz
         float q;    // Q factor (resonance or Q factor)
-        float gain; // the gain of the filter (if are shelf/peak) filters
 
         int abovenq;   // this is 1 if the frequency is above the nyquist
         int oldabovenq;

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -1849,6 +1849,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                 commandResonance(getData, part->kit[kititem].padpars->resonance);
                 break;
         }
+        part->kit[kititem].padpars->presetsUpdated();
         return true;
     }
 
@@ -1878,6 +1879,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                 commandEnvelope(getData);
                 break;
         }
+        part->kit[kititem].subpars->presetsUpdated();
         return true;
     }
 

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -1943,6 +1943,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                 }
                 break;
         }
+        part->kit[kititem].adpars->presetsUpdated();
         return true;
     }
 
@@ -1969,6 +1970,7 @@ bool InterChange::commandSendReal(CommandBlock *getData)
                 commandResonance(getData, part->kit[kititem].adpars->GlobalPar.Reson);
                 break;
         }
+        part->kit[kititem].adpars->presetsUpdated();
         return true;
     }
     getData->data.source = TOPLEVEL::action::noAction;
@@ -5296,7 +5298,9 @@ void InterChange::lfoReadWrite(CommandBlock *getData, LFOParams *pars)
             break;
     }
 
-    if (!write)
+    if (write)
+        pars->presetsUpdated();
+    else
         getData->data.value.F = val;
 }
 
@@ -5567,7 +5571,9 @@ void InterChange::filterReadWrite(CommandBlock *getData, FilterParams *pars, uns
             break;
     }
 
-    if (!write)
+    if (write)
+        pars->presetsUpdated();
+    else
         getData->data.value.F = val;
 }
 
@@ -5865,6 +5871,8 @@ void InterChange::envelopeReadWrite(CommandBlock *getData, EnvelopeParams *pars)
                 val = pars->Penvsustain;
             break;
     }
+    if (write)
+        pars->presetsUpdated();
     getData->data.value.F = val;
     getData->data.offset = Xincrement;
     return;

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1048,15 +1048,6 @@ void Part::ComputePartSmps(void)
             KillNotePos(k);
     }
 
-    for (int item = 0; item < NUM_KIT_ITEMS; ++item)
-    {
-        if (kit[item].adpars)
-            kit[item].adpars->postrender();
-        if (kit[item].subpars)
-            kit[item].subpars->postrender();
-        if (kit[item].padpars)
-            kit[item].padpars->postrender();
-    }
     // Apply part's effects and mix them
     for (int nefx = 0; nefx < NUM_PART_EFX; ++nefx)
     {

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1245,21 +1245,3 @@ float ADnoteParameters::getLimits(CommandBlock *getData)
     }
     return value;
 }
-
-void ADnoteParameters::postrender(void)
-{
-    // loop over our gathered dirty flags and unset them for the next period
-      GlobalPar.AmpLfo->updated
-    = GlobalPar.FilterLfo->updated
-    = GlobalPar.FreqLfo->updated
-    = false;
-    for (int i = 0; i < NUM_VOICES; ++i)
-    {
-        if (VoicePar[i].Enabled)
-              VoicePar[i].AmpLfo->updated
-            = VoicePar[i].FilterLfo->updated
-            = VoicePar[i].FreqLfo->updated
-            = false;
-
-    }
-}

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -206,7 +206,6 @@ class ADnoteParameters : public Presets
         ADnoteGlobalParam GlobalPar;
         ADnoteVoiceParam VoicePar[NUM_VOICES];
         static int ADnote_unison_sizes[15];
-        void postrender(void);
 
     private:
         void defaults(int n); // n is the nvoice

--- a/src/Params/LFOParams.cpp
+++ b/src/Params/LFOParams.cpp
@@ -60,7 +60,7 @@ LFOParams::LFOParams(float Pfreq_, unsigned char Pintensity_,
             break;
     };
     defaults();
-    updated = true;
+    presetsUpdated();
 }
 
 
@@ -83,7 +83,7 @@ void LFOParams::setPfreq(int32_t n)
 
     PfreqI = n;
     Pfreq = (powf(2.0f, (float(n) / float(Fmul2I)) * 10.0f) - 1.0f) / 12.0f;
-    updated = true;
+    presetsUpdated();
 }
 
 
@@ -117,7 +117,7 @@ void LFOParams::getfromXML(XMLwrapper *xml)
     Pdelay = xml->getpar127("delay", Pdelay);
     Pstretch = xml->getpar127("stretch", Pstretch);
     Pcontinous = xml->getparbool("continous", Pcontinous);
-    updated = true;
+    presetsUpdated();
 }
 
 float LFOlimit::getLFOlimits(CommandBlock *getData)

--- a/src/Params/LFOParams.h
+++ b/src/Params/LFOParams.h
@@ -47,14 +47,14 @@ class LFOParams : public Presets
         void defaults(void);
         void setPfreq(int32_t n);
         void getfromXML(XMLwrapper *xml);
-        void setPintensity(unsigned char n) { Pintensity = n; updated = true; }
+        void setPintensity(unsigned char n) { Pintensity = n; presetsUpdated(); }
         void setPstartphase(unsigned char n) { Pstartphase = n; }
-        void setPLFOtype(unsigned char n) { PLFOtype = n; updated = true; }
-        void setPrandomness(unsigned char n) { Prandomness = n; updated = true; }
-        void setPfreqrand(unsigned char n) { Pfreqrand = n; updated = true; }
+        void setPLFOtype(unsigned char n) { PLFOtype = n; presetsUpdated(); }
+        void setPrandomness(unsigned char n) { Prandomness = n; presetsUpdated(); }
+        void setPfreqrand(unsigned char n) { Pfreqrand = n; presetsUpdated(); }
         void setPdelay(unsigned char n) { Pdelay = n; }
-        void setPcontinous(unsigned char n) { Pcontinous = n; updated = true; }
-        void setPstretch(unsigned char n) { Pstretch = n; updated = true; }
+        void setPcontinous(unsigned char n) { Pcontinous = n; presetsUpdated(); }
+        void setPstretch(unsigned char n) { Pstretch = n; presetsUpdated(); }
 
         // MIDI Parameters
         int32_t PfreqI;
@@ -70,7 +70,6 @@ class LFOParams : public Presets
 
         int fel;         // kind of LFO - 0 frequency, 1 amplitude, 2 filter
        // static int time; // used by Pcontinous - moved to SynthEngine to make it per-instance
-        bool updated;
 
     private:
         // Default parameters

--- a/src/Params/OscilParameters.cpp
+++ b/src/Params/OscilParameters.cpp
@@ -240,9 +240,6 @@ void OscilParameters::getfromXML(XMLwrapper *xml)
         xml->exitbranch();
     }
 
-    if (Pcurrentbasefunc != 0)
-        presetsUpdated();
-
     if (xml->enterbranch("BASE_FUNCTION"))
     {
         for (int i = 1; i < synth->halfoscilsize; ++i)
@@ -278,6 +275,8 @@ void OscilParameters::getfromXML(XMLwrapper *xml)
                 basefuncFFTfreqs.s[i] /= max;
         }
     }
+
+    presetsUpdated();
 }
 
 float OscilParameters::getLimits(CommandBlock *getData)

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -1233,13 +1233,3 @@ float PADnoteParameters::getLimits(CommandBlock *getData)
     }
     return value;
 }
-
-void PADnoteParameters::postrender(void)
-{
-    // loop over our gathered dirty flags and unset them for the next period
-      AmpLfo->updated
-    = FilterLfo->updated
-    = FreqLfo->updated
-    = false;
-
-}

--- a/src/Params/PADnoteParameters.h
+++ b/src/Params/PADnoteParameters.h
@@ -53,7 +53,6 @@ class PADnoteParameters : public Presets
         void add2XML(XMLwrapper *xml);
         void getfromXML(XMLwrapper *xml);
         float getLimits(CommandBlock *getData);
-        void postrender(void);
 
         //returns a value between 0.0-1.0 that represents the estimation
         // perceived bandwidth

--- a/src/Params/SUBnoteParameters.cpp
+++ b/src/Params/SUBnoteParameters.cpp
@@ -554,8 +554,3 @@ float SUBnoteParameters::getLimits(CommandBlock *getData)
     }
     return value;
 }
-
-void SUBnoteParameters::postrender(void)
-{
-    return;
-}

--- a/src/Params/SUBnoteParameters.h
+++ b/src/Params/SUBnoteParameters.h
@@ -46,7 +46,6 @@ class SUBnoteParameters : public Presets
         void getfromXML(XMLwrapper *xml);
         float getLimits(CommandBlock *getData);
         void updateFrequencyMultipliers(void);
-        void postrender(void);
 
         // Amplitude Parametrers
         bool Pstereo; // true = stereo, false = mono

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -348,7 +348,6 @@ void ADnote::construct()
     }
 
     initParameters();
-    computeNoteParameters();
     initSubVoices();
 
     globalnewamplitude = NoteGlobalPar.Volume
@@ -527,6 +526,14 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
                     adpars->VoicePar[vc].FMSmp->newrandseed();
             }
         }
+    }
+
+    computeNoteParameters();
+
+    for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
+    {
+        if (!NoteVoicePar[nvoice].Enabled)
+            continue;
 
         FMnewamplitude[nvoice] = NoteVoicePar[nvoice].FMVolume * ctl->fmamp.relamp;
 
@@ -535,8 +542,6 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
             FMnewamplitude[nvoice] *=
                 NoteVoicePar[nvoice].FMAmpEnvelope->envout_dB();
     }
-
-    computeNoteParameters();
 
     globalnewamplitude = NoteGlobalPar.Volume
                          * NoteGlobalPar.AmpEnvelope->envout_dB()
@@ -805,14 +810,24 @@ void ADnote::initParameters(void)
                 new Envelope(adpars->VoicePar[nvoice].FMFreqEnvelope,
                              basefreq, synth);
 
-        FMnewamplitude[nvoice] = NoteVoicePar[nvoice].FMVolume
-                                 * ctl->fmamp.relamp;
-
         if (adpars->VoicePar[nvoice].PFMAmpEnvelopeEnabled != 0)
-        {
             NoteVoicePar[nvoice].FMAmpEnvelope =
                 new Envelope(adpars->VoicePar[nvoice].FMAmpEnvelope,
                              basefreq, synth);
+    }
+
+    computeNoteParameters();
+
+    for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
+    {
+        if (!NoteVoicePar[nvoice].Enabled)
+            continue;
+
+        FMnewamplitude[nvoice] = NoteVoicePar[nvoice].FMVolume
+                                 * ctl->fmamp.relamp;
+
+        if (NoteVoicePar[nvoice].FMAmpEnvelope != NULL)
+        {
             FMnewamplitude[nvoice] *=
                 NoteVoicePar[nvoice].FMAmpEnvelope->envout_dB();
         }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -63,6 +63,7 @@ ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
     subVoiceNumber(-1),
     origVoice(NULL),
     parentFMmod(NULL),
+    paramsUpdate(adpars),
     synth(_synth)
 {
     Legato.silent = besilent;
@@ -85,6 +86,7 @@ ADnote::ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmo
     subVoiceNumber(subVoiceNumber_),
     origVoice(orig),
     parentFMmod(parentFMmod_),
+    paramsUpdate(adpars),
     synth(orig->synth)
 {
     Legato.silent = orig->Legato.silent;
@@ -108,23 +110,11 @@ void ADnote::construct()
     Legato.param.portamento = portamento;
     Legato.param.midinote = midinote;
 
-    NoteGlobalPar.Detune = getDetune(adpars->GlobalPar.PDetuneType,
-                                     adpars->GlobalPar.PCoarseDetune,
-                                     adpars->GlobalPar.PDetune);
-    bandwidthDetuneMultiplier = adpars->getBandwidthDetuneMultiplier();
+    paramSeed = synth->randomINT();
 
-    if (adpars->randomGlobalPan())
-    {
-        float t = synth->numRandom();
-        NoteGlobalPar.randpanL = cosf(t * HALFPI);
-        NoteGlobalPar.randpanR = cosf((1.0f - t) * HALFPI);
-    }
-    else
-        NoteGlobalPar.randpanL = NoteGlobalPar.randpanR = 0.7f;
-    NoteGlobalPar.FilterCenterPitch =
-        adpars->GlobalPar.GlobalFilter->getfreq() // center freq
-        + adpars->GlobalPar.PFilterVelocityScale / 127.0f * 6.0f
-        * (velF(velocity, adpars->GlobalPar.PFilterVelocityScaleFunction) - 1);
+    float t = synth->numRandom();
+    NoteGlobalPar.randpanL = cosf(t * HALFPI);
+    NoteGlobalPar.randpanR = cosf((1.0f - t) * HALFPI);
 
     NoteGlobalPar.Fadein_adjustment =
         adpars->GlobalPar.Fadein_adjustment / (float)FADEIN_ADJUSTMENT_SCALE;
@@ -171,24 +161,6 @@ void ADnote::construct()
             continue; // the voice is disabled
         }
 
-        if (subVoiceNumber == -1) {
-            int BendAdj = adpars->VoicePar[nvoice].PBendAdjust - 64;
-            if (BendAdj % 24 == 0)
-                NoteVoicePar[nvoice].BendAdjust = BendAdj / 24;
-            else
-                NoteVoicePar[nvoice].BendAdjust = BendAdj / 24.0f;
-        } else {
-            // No bend adjustments for sub voices. Take from parent via
-            // detuneFromParent.
-            NoteVoicePar[nvoice].BendAdjust = 0.0f;
-        }
-
-        float offset_val = (adpars->VoicePar[nvoice].POffsetHz - 64)/64.0f;
-        NoteVoicePar[nvoice].OffsetHz =
-            15.0f*(offset_val * sqrtf(fabsf(offset_val)));
-
-        unison_stereo_spread[nvoice] =
-            adpars->VoicePar[nvoice].Unison_stereo_spread / 127.0f;
         int unison = adpars->VoicePar[nvoice].Unison_size;
         if (unison < 1)
             unison = 1;
@@ -216,133 +188,30 @@ void ADnote::construct()
         unison_base_freq_rap[nvoice] = new float[unison];
         unison_freq_rap[nvoice] = new float[unison];
         unison_invert_phase[nvoice] = new bool[unison];
-        float unison_spread = adpars->getUnisonFrequencySpreadCents(nvoice);
-        float unison_real_spread = powf(2.0f, (unison_spread * 0.5f) / 1200.0f);
-        float unison_vibratto_a = adpars->VoicePar[nvoice].Unison_vibratto / 127.0f;                                  //0.0 .. 1.0
-
-        int true_unison = unison / (is_pwm ? 2 : 1);
-        switch (true_unison)
-        {
-            case 1: // if no unison, set the subvoice to the default note
-                unison_base_freq_rap[nvoice][0] = 1.0f;
-                break;
-
-            case 2:  // unison for 2 subvoices
-                {
-                    unison_base_freq_rap[nvoice][0] = 1.0f / unison_real_spread;
-                    unison_base_freq_rap[nvoice][1] = unison_real_spread;
-                }
-                break;
-
-            default: // unison for more than 2 subvoices
-                {
-                    float unison_values[unison];
-                    float min = -1e-6f, max = 1e-6f;
-                    for (int k = 0; k < true_unison; ++k)
-                    {
-                        float step = (k / (float) (true_unison - 1)) * 2.0f - 1.0f;  //this makes the unison spread more uniform
-                        float val  = step + (synth->numRandom() * 2.0f - 1.0f) / (true_unison - 1);
-                        unison_values[k] = val;
-                        if (val > max)
-                            max = val;
-                        if (val < min)
-                            min = val;
-                    }
-                    float diff = max - min;
-                    for (int k = 0; k < true_unison; ++k)
-                    {
-                        unison_values[k] =
-                            (unison_values[k] - (max + min) * 0.5f) / diff;
-                            // the lowest value will be -1 and the highest will be 1
-                        unison_base_freq_rap[nvoice][k] =
-                            powf(2.0f, (unison_spread * unison_values[k]) / 1200.0f);
-                    }
-                }
-        }
-        if (is_pwm)
-            for (int i = true_unison - 1; i >= 0; i--)
-            {
-                unison_base_freq_rap[nvoice][2*i + 1] =
-                    unison_base_freq_rap[nvoice][i];
-                unison_base_freq_rap[nvoice][2*i] =
-                    unison_base_freq_rap[nvoice][i];
-            }
-
-        // unison vibrattos
-        if(unison > 2 || (!is_pwm && unison > 1))
-        {
-            for (int k = 0; k < unison; ++k) // reduce the frequency difference
-                                             // for larger vibrattos
-                unison_base_freq_rap[nvoice][k] =
-                    1.0f + (unison_base_freq_rap[nvoice][k] - 1.0f)
-                    * (1.0f - unison_vibratto_a);
-        }
         unison_vibratto[nvoice].step = new float[unison];
         unison_vibratto[nvoice].position = new float[unison];
-        unison_vibratto[nvoice].amplitude = (unison_real_spread - 1.0f) * unison_vibratto_a;
 
-        float increments_per_second = synth->samplerate_f / synth->sent_all_buffersize_f;
-        const float vib_speed = adpars->VoicePar[nvoice].Unison_vibratto_speed / 127.0f;
-        float vibratto_base_period  = 0.25f * powf(2.0f, (1.0f - vib_speed) * 4.0f);
         for (int k = 0; k < unison; ++k)
         {
             unison_vibratto[nvoice].position[k] = synth->numRandom() * 1.8f - 0.9f;
-            // make period to vary randomly from 50% to 200% vibratto base period
-            float vibratto_period = vibratto_base_period * powf(2.0f, synth->numRandom() * 2.0f - 1.0f);
-            float m = 4.0f / (vibratto_period * increments_per_second);
-            if (synth->numRandom() < 0.5f)
-                m = -m;
-            unison_vibratto[nvoice].step[k] = m;
 
             // Ugly, but the alternative is likely uglier.
             if (is_pwm)
                 for (int i = 0; i < unison; i += 2)
-                {
-                    unison_vibratto[nvoice].step[i+1] =
-                        unison_vibratto[nvoice].step[i];
                     unison_vibratto[nvoice].position[i+1] =
                         unison_vibratto[nvoice].position[i];
-                }
+
+            // Give step a random direction. The amplitude doesn't matter right
+            // now, only the sign, which will be preserved in
+            // computeNoteParameters().
+            if (synth->numRandom() < 0.5f)
+                unison_vibratto[nvoice].position[k] = -1.0f;
+            else
+                unison_vibratto[nvoice].position[k] = 1.0f;
         }
 
         if (unison <= 2) // no vibratto for a single voice
-        {
-            if (is_pwm)
-            {
-                unison_vibratto[nvoice].step[1]     = 0.0f;
-                unison_vibratto[nvoice].position[1] = 0.0f;
-            }
-            if (is_pwm || unison == 1)
-            {
-                unison_vibratto[nvoice].step[0] = 0.0f;
-                unison_vibratto[nvoice].position[0] = 0.0f;
-                unison_vibratto[nvoice].amplitude = 0.0f;
-            }
-        }
-
-        // phase invert for unison
-        unison_invert_phase[nvoice][0] = false;
-        if (unison != 1)
-        {
-            int inv = adpars->VoicePar[nvoice].Unison_invert_phase;
-            switch(inv)
-            {
-                case 0:
-                    for (int k = 0; k < unison; ++k)
-                        unison_invert_phase[nvoice][k] = false;
-                    break;
-
-                case 1:
-                    for (int k = 0; k < unison; ++k)
-                        unison_invert_phase[nvoice][k] = (synth->numRandom() > 0.5f);
-                    break;
-
-                default:
-                    for (int k = 0; k < unison; ++k)
-                        unison_invert_phase[nvoice][k] = (k % inv == 0) ? true : false;
-                    break;
-            }
-        }
+            unison_vibratto[nvoice].position[1] = 0.0f;
 
         oscfreqhi[nvoice] = new int[unison];
         oscfreqlo[nvoice] = new float[unison];
@@ -354,38 +223,6 @@ void ADnote::construct()
         oscposloFM[nvoice] = new float[unison];
 
         NoteVoicePar[nvoice].Enabled = true;
-        NoteVoicePar[nvoice].fixedfreq = adpars->VoicePar[nvoice].Pfixedfreq;
-        NoteVoicePar[nvoice].fixedfreqET = adpars->VoicePar[nvoice].PfixedfreqET;
-
-        // use the Globalpars.detunetype if the detunetype is 0
-        if (adpars->VoicePar[nvoice].PDetuneType)
-        {
-            NoteVoicePar[nvoice].Detune =
-                getDetune(adpars->VoicePar[nvoice].PDetuneType,
-                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
-            NoteVoicePar[nvoice].FineDetune =
-                getDetune(adpars->VoicePar[nvoice].PDetuneType, 0,
-                          adpars->VoicePar[nvoice].PDetune); // fine detune
-        }
-        else
-        {
-            NoteVoicePar[nvoice].Detune =
-                getDetune(adpars->GlobalPar.PDetuneType,
-                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
-            NoteVoicePar[nvoice].FineDetune =
-                getDetune(adpars->GlobalPar.PDetuneType, 0,
-                          adpars->VoicePar[nvoice].PDetune); // fine detune
-        }
-        if (adpars->VoicePar[nvoice].PFMDetuneType != 0)
-            NoteVoicePar[nvoice].FMDetune =
-                getDetune(adpars->VoicePar[nvoice].PFMDetuneType,
-                          adpars->VoicePar[nvoice].PFMCoarseDetune,
-                          adpars->VoicePar[nvoice].PFMDetune);
-        else
-            NoteVoicePar[nvoice].FMDetune =
-                getDetune(adpars->GlobalPar.PDetuneType, adpars->VoicePar[nvoice].
-                          PFMCoarseDetune, adpars->VoicePar[nvoice].PFMDetune);
-
         memset(oscposhi[nvoice], 0, unison * sizeof(int));
         memset(oscposlo[nvoice], 0, unison * sizeof(float));
         memset(oscposhiFM[nvoice], 0, unison * sizeof(int));
@@ -407,24 +244,17 @@ void ADnote::construct()
             // Get the voice's oscil or external's voice oscil
             if (!adpars->GlobalPar.Hrandgrouping)
                 adpars->VoicePar[vc].OscilSmp->newrandseed();
-            adpars->VoicePar[vc].OscilSmp->get(NoteVoicePar[nvoice].OscilSmp,
-                                               getVoiceBaseFreq(nvoice),
-                                               adpars->VoicePar[nvoice].Presonance);
 
-            // I store the first elements to the last position for speedups
-            for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
-                NoteVoicePar[nvoice].OscilSmp[synth->oscilsize + i] = NoteVoicePar[nvoice].OscilSmp[i];
+            // Actual OscilSmp rendering done later.
         } else {
             // If subvoice, use oscillator from original voice.
             NoteVoicePar[nvoice].OscilSmp = origVoice->NoteVoicePar[nvoice].OscilSmp;
         }
 
+        NoteVoicePar[nvoice].phase_offset = 0;
+
         int oscposhi_start =
             adpars->VoicePar[vc].OscilSmp->getPhase();
-        NoteVoicePar[nvoice].phase_offset = (int)((adpars->VoicePar[nvoice].Poscilphase - 64.0f)
-                                    / 128.0f * synth->oscilsize + synth->oscilsize * 4);
-        oscposhi_start += NoteVoicePar[nvoice].phase_offset;
-
         int kth_start = oscposhi_start;
         for (int k = 0; k < unison; ++k)
         {
@@ -444,14 +274,6 @@ void ADnote::construct()
         NoteVoicePar[nvoice].VoiceFilterR = NULL;
         NoteVoicePar[nvoice].FilterEnvelope = NULL;
         NoteVoicePar[nvoice].FilterLfo = NULL;
-
-        NoteVoicePar[nvoice].FilterCenterPitch =
-            adpars->VoicePar[nvoice].VoiceFilter->getfreq()
-            + adpars->VoicePar[nvoice].PFilterVelocityScale
-            / 127.0f * 6.0f       //velocity sensing
-            * (velF(velocity,
-                    adpars->VoicePar[nvoice].PFilterVelocityScaleFunction) - 1);
-        NoteVoicePar[nvoice].filterbypass = adpars->VoicePar[nvoice].Pfilterbypass;
 
         if (adpars->VoicePar[nvoice].Type != 0)
             NoteVoicePar[nvoice].FMEnabled = NONE;
@@ -483,44 +305,9 @@ void ADnote::construct()
                     freqbasedmod[nvoice] = false;
             }
 
-        NoteVoicePar[nvoice].FMDetuneFromBaseOsc =
-            (adpars->VoicePar[nvoice].PFMDetuneFromBaseOsc != 0);
         NoteVoicePar[nvoice].FMVoice = adpars->VoicePar[nvoice].PFMVoice;
         NoteVoicePar[nvoice].FMFreqEnvelope = NULL;
         NoteVoicePar[nvoice].FMAmpEnvelope = NULL;
-        NoteVoicePar[nvoice].FMFreqFixed  = adpars->VoicePar[nvoice].PFMFixedFreq;
-
-        // Compute the Voice's modulator volume (incl. damping)
-        float fmvoldamp = powf(440.0f / getVoiceBaseFreq(nvoice),
-                               adpars->VoicePar[nvoice].PFMVolumeDamp
-                               / 64.0f - 1.0f);
-        switch (NoteVoicePar[nvoice].FMEnabled)
-        {
-            case PHASE_MOD:
-            case PW_MOD:
-                fmvoldamp = powf(440.0f / getVoiceBaseFreq(nvoice),
-                                 adpars->VoicePar[nvoice].PFMVolumeDamp / 64.0f);
-                NoteVoicePar[nvoice].FMVolume =
-                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
-                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
-                break;
-
-            case FREQ_MOD:
-                NoteVoicePar[nvoice].FMVolume =
-                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
-                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
-                break;
-
-            default:
-                if (fmvoldamp > 1.0f)
-                    fmvoldamp = 1.0f;
-                NoteVoicePar[nvoice].FMVolume =
-                    adpars->VoicePar[nvoice].PFMVolume / 127.0f * fmvoldamp;
-        }
-
-        // Voice's modulator velocity sensing
-        NoteVoicePar[nvoice].FMVolume *=
-            velF(velocity, adpars->VoicePar[nvoice].PFMVelocityScaleFunction);
 
         FMoldsmp[nvoice] = new float [unison];
         memset(FMoldsmp[nvoice], 0, unison * sizeof(float));
@@ -561,8 +348,12 @@ void ADnote::construct()
     }
 
     initParameters();
-
+    computeNoteParameters();
     initSubVoices();
+
+    globalnewamplitude = NoteGlobalPar.Volume
+                         * NoteGlobalPar.AmpEnvelope->envout_dB()
+                         * NoteGlobalPar.AmpLfo->amplfoout();
 
     ready = 1;
 }
@@ -658,61 +449,10 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
             Legato.msg = LM_Norm;
     }
 
-    NoteGlobalPar.Detune = getDetune(adpars->GlobalPar.PDetuneType,
-                                     adpars->GlobalPar.PCoarseDetune,
-                                     adpars->GlobalPar.PDetune);
-    bandwidthDetuneMultiplier = adpars->getBandwidthDetuneMultiplier();
-
-    if (adpars->randomGlobalPan())
-    {
-        float t = synth->numRandom();
-        NoteGlobalPar.randpanL = cosf(t * HALFPI);
-        NoteGlobalPar.randpanR = cosf((1.0f - t) * HALFPI);
-    }
-    else
-        NoteGlobalPar.randpanL = NoteGlobalPar.randpanR = 0.7f;
-
-    NoteGlobalPar.FilterCenterPitch =
-        adpars->GlobalPar.GlobalFilter->getfreq()
-        + adpars->GlobalPar.PFilterVelocityScale / 127.0f * 6.0f
-        * (velF(velocity, adpars->GlobalPar.PFilterVelocityScaleFunction) - 1);
-
     for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
     {
         if (NoteVoicePar[nvoice].Enabled == 0)
             continue; //(gf) Stay the same as first note in legato.
-
-        NoteVoicePar[nvoice].fixedfreq = adpars->VoicePar[nvoice].Pfixedfreq;
-        NoteVoicePar[nvoice].fixedfreqET = adpars->VoicePar[nvoice].PfixedfreqET;
-
-        if (adpars->VoicePar[nvoice].PDetuneType)
-        {
-            NoteVoicePar[nvoice].Detune =
-                getDetune(adpars->VoicePar[nvoice].PDetuneType,
-                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
-            NoteVoicePar[nvoice].FineDetune =
-                getDetune(adpars->VoicePar[nvoice].PDetuneType, 0,
-                          adpars->VoicePar[nvoice].PDetune); // fine detune
-        }
-        else // use the Globalpars.detunetype if the detunetype is 0
-        {
-            NoteVoicePar[nvoice].Detune =
-                getDetune(adpars->GlobalPar.PDetuneType,
-                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
-            NoteVoicePar[nvoice].FineDetune =
-                getDetune(adpars->GlobalPar.PDetuneType, 0,
-                          adpars->VoicePar[nvoice].PDetune); // fine detune
-        }
-        if (adpars->VoicePar[nvoice].PFMDetuneType != 0)
-            NoteVoicePar[nvoice].FMDetune =
-                getDetune(adpars->VoicePar[nvoice].PFMDetuneType,
-                          adpars->VoicePar[nvoice].PFMCoarseDetune,
-                          adpars->VoicePar[nvoice].PFMDetune);
-        else
-            NoteVoicePar[nvoice].FMDetune =
-                getDetune(adpars->GlobalPar.PDetuneType,
-                          adpars->VoicePar[nvoice].PFMCoarseDetune,
-                          adpars->VoicePar[nvoice].PFMDetune);
 
         // Only generate oscillator for original voices. In sub voices we use
         // the parents' voices, so they are already generated.
@@ -723,61 +463,7 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
                 vc = adpars->VoicePar[nvoice].Pextoscil;
             if (!adpars->GlobalPar.Hrandgrouping)
                 adpars->VoicePar[vc].OscilSmp->newrandseed();
-
-            adpars->VoicePar[vc].OscilSmp->get(NoteVoicePar[nvoice].OscilSmp,
-                                               getVoiceBaseFreq(nvoice),
-                                               adpars->VoicePar[nvoice].Presonance);                                                       //(gf)Modif of the above line.
-
-            // I store the first elements to the last position for speedups
-            for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
-                NoteVoicePar[nvoice].OscilSmp[synth->oscilsize + i] =
-                    NoteVoicePar[nvoice].OscilSmp[i];
         }
-
-        NoteVoicePar[nvoice].FilterCenterPitch =
-            adpars->VoicePar[nvoice].VoiceFilter->getfreq()
-            + adpars->VoicePar[nvoice].PFilterVelocityScale
-            / 127.0f * 6.0f       //velocity sensing
-            * (velF(velocity,
-                    adpars->VoicePar[nvoice].PFilterVelocityScaleFunction) - 1);
-        NoteVoicePar[nvoice].filterbypass =
-            adpars->VoicePar[nvoice].Pfilterbypass;
-
-        NoteVoicePar[nvoice].FMVoice = adpars->VoicePar[nvoice].PFMVoice;
-
-        // Compute the Voice's modulator volume (incl. damping)
-        float fmvoldamp =
-            powf(440.0f / getVoiceBaseFreq(nvoice),
-                 adpars->VoicePar[nvoice].PFMVolumeDamp / 64.0f - 1.0f);
-
-        switch (NoteVoicePar[nvoice].FMEnabled)
-        {
-            case PHASE_MOD:
-            case PW_MOD:
-                fmvoldamp =
-                    powf(440.0f / getVoiceBaseFreq(nvoice),
-                         adpars->VoicePar[nvoice].PFMVolumeDamp / 64.0f);
-                NoteVoicePar[nvoice].FMVolume =
-                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
-                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
-                break;
-
-            case FREQ_MOD:
-                NoteVoicePar[nvoice].FMVolume =
-                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
-                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
-                break;
-
-            default:
-                if (fmvoldamp > 1.0f)
-                    fmvoldamp = 1.0f;
-                NoteVoicePar[nvoice].FMVolume =
-                    adpars->VoicePar[nvoice].PFMVolume / 127.0f * fmvoldamp;
-        }
-
-        // Voice's modulator velocity sensing
-        NoteVoicePar[nvoice].FMVolume *=
-            velF(velocity, adpars->VoicePar[nvoice].PFMVelocityScaleFunction);
 
         NoteVoicePar[nvoice].DelayTicks =
             int((expf(adpars->VoicePar[nvoice].PDelay / 127.0f
@@ -790,12 +476,6 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
 
     int nvoice, i;
 
-    NoteGlobalPar.Volume =
-        4.0f * powf(0.1f, 3.0f * (1.0f - adpars->GlobalPar.PVolume / 96.0f))  //-60 dB .. 0 dB
-        * velF(velocity, adpars->GlobalPar.PAmpVelocityScaleFunction); // velocity sensing
-    globalnewamplitude = NoteGlobalPar.Volume
-                         * NoteGlobalPar.AmpEnvelope->envout_dB()
-                         * NoteGlobalPar.AmpLfo->amplfoout();
     NoteGlobalPar.FilterQ = adpars->GlobalPar.GlobalFilter->getq();
     NoteGlobalPar.FilterFreqTracking =
         adpars->GlobalPar.GlobalFilter->getfreqtracking(basefreq);
@@ -812,25 +492,9 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
             continue;
 
         NoteVoicePar[nvoice].noisetype = adpars->VoicePar[nvoice].Type;
-        // Voice Amplitude Parameters Init
-        if (adpars->VoicePar[nvoice].PVolume == 0)
-            NoteVoicePar[nvoice].Volume = 0.0f;
-        else
-            NoteVoicePar[nvoice].Volume =
-                powf(0.1f, 3.0f * (1.0f - adpars->VoicePar[nvoice].PVolume / 127.0f)) // -60 dB .. 0 dB
-                * velF(velocity, adpars->VoicePar[nvoice].PAmpVelocityScaleFunction); // velocity
-
-        if (adpars->VoicePar[nvoice].PVolumeminus)
-            NoteVoicePar[nvoice].Volume = -NoteVoicePar[nvoice].Volume;
-
-        if (adpars->randomVoicePan(nvoice))
-        {
-            float t = synth->numRandom();
-            NoteVoicePar[nvoice].randpanL = cosf(t * HALFPI);
-            NoteVoicePar[nvoice].randpanR = cosf((1.0f - t) * HALFPI);
-        }
-        else
-            NoteVoicePar[nvoice].randpanL = NoteVoicePar[nvoice].randpanR = 0.7f;
+        float t = synth->numRandom();
+        NoteVoicePar[nvoice].randpanL = cosf(t * HALFPI);
+        NoteVoicePar[nvoice].randpanR = cosf((1.0f - t) * HALFPI);
 
         newamplitude[nvoice] = 1.0f;
         if (adpars->VoicePar[nvoice].PAmpEnvelopeEnabled
@@ -861,10 +525,6 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
 
                 if (!adpars->GlobalPar.Hrandgrouping)
                     adpars->VoicePar[vc].FMSmp->newrandseed();
-
-                for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
-                    NoteVoicePar[nvoice].FMSmp[synth->oscilsize + i] =
-                        NoteVoicePar[nvoice].FMSmp[i];
             }
         }
 
@@ -875,6 +535,12 @@ void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
             FMnewamplitude[nvoice] *=
                 NoteVoicePar[nvoice].FMAmpEnvelope->envout_dB();
     }
+
+    computeNoteParameters();
+
+    globalnewamplitude = NoteGlobalPar.Volume
+                         * NoteGlobalPar.AmpEnvelope->envout_dB()
+                         * NoteGlobalPar.AmpLfo->amplfoout();
 
     // End of the ADlegatonote function.
 }
@@ -1035,23 +701,14 @@ void ADnote::initParameters(void)
     NoteGlobalPar.FreqLfo = new LFO(adpars->GlobalPar.FreqLfo, basefreq, synth);
     NoteGlobalPar.AmpEnvelope = new Envelope(adpars->GlobalPar.AmpEnvelope, basefreq, synth);
     NoteGlobalPar.AmpLfo = new LFO(adpars->GlobalPar.AmpLfo, basefreq, synth);
-    NoteGlobalPar.Volume =
-        4.0f * powf(0.1f, 3.0f * (1.0f - adpars->GlobalPar.PVolume / 96.0f))  //-60 dB .. 0 dB
-        * velF(velocity, adpars->GlobalPar.PAmpVelocityScaleFunction); // velocity sensing
 
     NoteGlobalPar.AmpEnvelope->envout_dB(); // discard the first envelope output
-    globalnewamplitude = NoteGlobalPar.Volume
-                         * NoteGlobalPar.AmpEnvelope->envout_dB()
-                         * NoteGlobalPar.AmpLfo->amplfoout();
     NoteGlobalPar.GlobalFilterL = new Filter(adpars->GlobalPar.GlobalFilter, synth);
     if (stereo)
         NoteGlobalPar.GlobalFilterR = new Filter(adpars->GlobalPar.GlobalFilter, synth);
     NoteGlobalPar.FilterEnvelope =
         new Envelope(adpars->GlobalPar.FilterEnvelope, basefreq, synth);
     NoteGlobalPar.FilterLfo = new LFO(adpars->GlobalPar.FilterLfo, basefreq, synth);
-    NoteGlobalPar.FilterQ = adpars->GlobalPar.GlobalFilter->getq();
-    NoteGlobalPar.FilterFreqTracking =
-        adpars->GlobalPar.GlobalFilter->getfreqtracking(basefreq);
 
     // Forbids the Modulation Voice to be greater or equal than voice
     for (i = 0; i < NUM_VOICES; ++i)
@@ -1066,25 +723,9 @@ void ADnote::initParameters(void)
 
         NoteVoicePar[nvoice].noisetype = adpars->VoicePar[nvoice].Type;
 
-        // Voice Amplitude Parameters Init
-        if (adpars->VoicePar[nvoice].PVolume == 0)
-            NoteVoicePar[nvoice].Volume = 0.0f;
-        else
-            NoteVoicePar[nvoice].Volume =
-                powf(0.1f, 3.0f * (1.0f - adpars->VoicePar[nvoice].PVolume / 127.0f)) // -60 dB .. 0 dB
-                * velF(velocity, adpars->VoicePar[nvoice].PAmpVelocityScaleFunction); // velocity
-
-        if (adpars->VoicePar[nvoice].PVolumeminus)
-            NoteVoicePar[nvoice].Volume = -NoteVoicePar[nvoice].Volume;
-
-        if (adpars->randomVoicePan(nvoice))
-        {
-            float t = synth->numRandom();
-            NoteVoicePar[nvoice].randpanL = cosf(t * HALFPI);
-            NoteVoicePar[nvoice].randpanR = cosf((1.0f - t) * HALFPI);
-        }
-        else
-            NoteVoicePar[nvoice].randpanL = NoteVoicePar[nvoice].randpanR = 0.7f;
+        float t = synth->numRandom();
+        NoteVoicePar[nvoice].randpanL = cosf(t * HALFPI);
+        NoteVoicePar[nvoice].randpanR = cosf((1.0f - t) * HALFPI);
 
         newamplitude[nvoice] = 1.0f;
         if (adpars->VoicePar[nvoice].PAmpEnvelopeEnabled)
@@ -1129,9 +770,6 @@ void ADnote::initParameters(void)
             NoteVoicePar[nvoice].FilterLfo =
                 new LFO(adpars->VoicePar[nvoice].FilterLfo, basefreq, synth);
 
-        NoteVoicePar[nvoice].FilterFreqTracking =
-            adpars->VoicePar[nvoice].VoiceFilter->getfreqtracking(basefreq);
-
         // Voice Modulation Parameters Init
         if (NoteVoicePar[nvoice].FMEnabled != NONE
            && NoteVoicePar[nvoice].FMVoice < 0)
@@ -1142,12 +780,6 @@ void ADnote::initParameters(void)
             if (adpars->VoicePar[nvoice].PextFMoscil != -1)
                 vc = adpars->VoicePar[nvoice].PextFMoscil;
 
-            float freqtmp = 1.0f;
-            if (adpars->VoicePar[vc].POscilFM->Padaptiveharmonics != 0
-               || (NoteVoicePar[nvoice].FMEnabled == MORPH)
-               || (NoteVoicePar[nvoice].FMEnabled == RING_MOD))
-               freqtmp = getFMVoiceBaseFreq(nvoice);
-
             if (subVoiceNumber == -1) {
                 adpars->VoicePar[nvoice].FMSmp->newrandseed();
                 NoteVoicePar[nvoice].FMSmp =
@@ -1155,13 +787,6 @@ void ADnote::initParameters(void)
 
                 if (!adpars->GlobalPar.Hrandgrouping)
                     adpars->VoicePar[vc].FMSmp->newrandseed();
-
-                adpars->VoicePar[vc].FMSmp->
-                         get(NoteVoicePar[nvoice].FMSmp, freqtmp);
-
-                for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
-                    NoteVoicePar[nvoice].FMSmp[synth->oscilsize + i] =
-                        NoteVoicePar[nvoice].FMSmp[i];
             } else {
                 // If subvoice use oscillator from original voice.
                 NoteVoicePar[nvoice].FMSmp = origVoice->NoteVoicePar[nvoice].FMSmp;
@@ -1172,14 +797,7 @@ void ADnote::initParameters(void)
                     (oscposhi[nvoice][k] + adpars->VoicePar[vc].FMSmp->
                      getPhase()) % synth->oscilsize;
 
-            int oscposhiFM_add = (int)((adpars->VoicePar[nvoice].PFMoscilphase - 64.0f)
-                                         / 128.0f * synth->oscilsize_f
-                                         + synth->oscilsize_f * 4.0f);
-            for (int k = 0; k < unison_size[nvoice]; ++k)
-            {
-                oscposhiFM[nvoice][k] += oscposhiFM_add;
-                oscposhiFM[nvoice][k] %= synth->oscilsize;
-            }
+            NoteVoicePar[nvoice].FMphase_offset = 0;
         }
 
         if (adpars->VoicePar[nvoice].PFMFreqEnvelopeEnabled != 0)
@@ -1207,6 +825,325 @@ void ADnote::initParameters(void)
     }
 }
 
+void ADnote::computeNoteParameters(void)
+{
+    paramRNG.init(paramSeed);
+
+    NoteGlobalPar.Detune = getDetune(adpars->GlobalPar.PDetuneType,
+                                     adpars->GlobalPar.PCoarseDetune,
+                                     adpars->GlobalPar.PDetune);
+    bandwidthDetuneMultiplier = adpars->getBandwidthDetuneMultiplier();
+
+    NoteGlobalPar.FilterCenterPitch =
+        adpars->GlobalPar.GlobalFilter->getfreq() // center freq
+        + adpars->GlobalPar.PFilterVelocityScale / 127.0f * 6.0f
+        * (velF(velocity, adpars->GlobalPar.PFilterVelocityScaleFunction) - 1);
+
+    NoteGlobalPar.Volume =
+        4.0f * powf(0.1f, 3.0f * (1.0f - adpars->GlobalPar.PVolume / 96.0f))  //-60 dB .. 0 dB
+        * velF(velocity, adpars->GlobalPar.PAmpVelocityScaleFunction); // velocity sensing
+
+    NoteGlobalPar.FilterQ = adpars->GlobalPar.GlobalFilter->getq();
+    NoteGlobalPar.FilterFreqTracking =
+        adpars->GlobalPar.GlobalFilter->getfreqtracking(basefreq);
+
+    for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
+    {
+        if (!NoteVoicePar[nvoice].Enabled)
+            continue;
+
+        if (subVoiceNumber == -1) {
+            int BendAdj = adpars->VoicePar[nvoice].PBendAdjust - 64;
+            if (BendAdj % 24 == 0)
+                NoteVoicePar[nvoice].BendAdjust = BendAdj / 24;
+            else
+                NoteVoicePar[nvoice].BendAdjust = BendAdj / 24.0f;
+        } else {
+            // No bend adjustments for sub voices. Take from parent via
+            // detuneFromParent.
+            NoteVoicePar[nvoice].BendAdjust = 0.0f;
+        }
+
+        float offset_val = (adpars->VoicePar[nvoice].POffsetHz - 64)/64.0f;
+        NoteVoicePar[nvoice].OffsetHz =
+            15.0f*(offset_val * sqrtf(fabsf(offset_val)));
+
+        NoteVoicePar[nvoice].fixedfreq = adpars->VoicePar[nvoice].Pfixedfreq;
+        NoteVoicePar[nvoice].fixedfreqET = adpars->VoicePar[nvoice].PfixedfreqET;
+
+        // use the Globalpars.detunetype if the detunetype is 0
+        if (adpars->VoicePar[nvoice].PDetuneType)
+        {
+            NoteVoicePar[nvoice].Detune =
+                getDetune(adpars->VoicePar[nvoice].PDetuneType,
+                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
+            NoteVoicePar[nvoice].FineDetune =
+                getDetune(adpars->VoicePar[nvoice].PDetuneType, 0,
+                          adpars->VoicePar[nvoice].PDetune); // fine detune
+        }
+        else
+        {
+            NoteVoicePar[nvoice].Detune =
+                getDetune(adpars->GlobalPar.PDetuneType,
+                          adpars->VoicePar[nvoice].PCoarseDetune, 8192); // coarse detune
+            NoteVoicePar[nvoice].FineDetune =
+                getDetune(adpars->GlobalPar.PDetuneType, 0,
+                          adpars->VoicePar[nvoice].PDetune); // fine detune
+        }
+        if (adpars->VoicePar[nvoice].PFMDetuneType != 0)
+            NoteVoicePar[nvoice].FMDetune =
+                getDetune(adpars->VoicePar[nvoice].PFMDetuneType,
+                          adpars->VoicePar[nvoice].PFMCoarseDetune,
+                          adpars->VoicePar[nvoice].PFMDetune);
+        else
+            NoteVoicePar[nvoice].FMDetune =
+                getDetune(adpars->GlobalPar.PDetuneType, adpars->VoicePar[nvoice].
+                          PFMCoarseDetune, adpars->VoicePar[nvoice].PFMDetune);
+
+        NoteVoicePar[nvoice].FilterCenterPitch =
+            adpars->VoicePar[nvoice].VoiceFilter->getfreq()
+            + adpars->VoicePar[nvoice].PFilterVelocityScale
+            / 127.0f * 6.0f       //velocity sensing
+            * (velF(velocity,
+                    adpars->VoicePar[nvoice].PFilterVelocityScaleFunction) - 1);
+        if (NoteVoicePar[nvoice].VoiceFilterL != NULL)
+        {
+            NoteVoicePar[nvoice].VoiceFilterL->setq(adpars->VoicePar[nvoice].VoiceFilter->getq());
+            NoteVoicePar[nvoice].VoiceFilterR->setq(adpars->VoicePar[nvoice].VoiceFilter->getq());
+        }
+        NoteVoicePar[nvoice].filterbypass = adpars->VoicePar[nvoice].Pfilterbypass;
+
+        NoteVoicePar[nvoice].FMDetuneFromBaseOsc =
+            (adpars->VoicePar[nvoice].PFMDetuneFromBaseOsc != 0);
+        NoteVoicePar[nvoice].FMFreqFixed  = adpars->VoicePar[nvoice].PFMFixedFreq;
+
+        // Compute the Voice's modulator volume (incl. damping)
+        float fmvoldamp = powf(440.0f / getVoiceBaseFreq(nvoice),
+                               adpars->VoicePar[nvoice].PFMVolumeDamp
+                               / 64.0f - 1.0f);
+        switch (NoteVoicePar[nvoice].FMEnabled)
+        {
+            case PHASE_MOD:
+            case PW_MOD:
+                fmvoldamp = powf(440.0f / getVoiceBaseFreq(nvoice),
+                                 adpars->VoicePar[nvoice].PFMVolumeDamp / 64.0f);
+                NoteVoicePar[nvoice].FMVolume =
+                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
+                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
+                break;
+
+            case FREQ_MOD:
+                NoteVoicePar[nvoice].FMVolume =
+                    (expf(adpars->VoicePar[nvoice].PFMVolume / 127.0f
+                          * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
+                break;
+
+            default:
+                if (fmvoldamp > 1.0f)
+                    fmvoldamp = 1.0f;
+                NoteVoicePar[nvoice].FMVolume =
+                    adpars->VoicePar[nvoice].PFMVolume / 127.0f * fmvoldamp;
+        }
+
+        // Voice's modulator velocity sensing
+        NoteVoicePar[nvoice].FMVolume *=
+            velF(velocity, adpars->VoicePar[nvoice].PFMVelocityScaleFunction);
+
+        // Voice Amplitude Parameters Init
+        if (adpars->VoicePar[nvoice].PVolume == 0)
+            NoteVoicePar[nvoice].Volume = 0.0f;
+        else
+            NoteVoicePar[nvoice].Volume =
+                powf(0.1f, 3.0f * (1.0f - adpars->VoicePar[nvoice].PVolume / 127.0f)) // -60 dB .. 0 dB
+                * velF(velocity, adpars->VoicePar[nvoice].PAmpVelocityScaleFunction); // velocity
+
+        if (adpars->VoicePar[nvoice].PVolumeminus)
+            NoteVoicePar[nvoice].Volume = -NoteVoicePar[nvoice].Volume;
+
+        NoteVoicePar[nvoice].FilterFreqTracking =
+            adpars->VoicePar[nvoice].VoiceFilter->getfreqtracking(basefreq);
+
+        int unison = unison_size[nvoice];
+
+        if (subVoiceNumber == -1) {
+            int vc = nvoice;
+            if (adpars->VoicePar[nvoice].Pextoscil != -1)
+                vc = adpars->VoicePar[nvoice].Pextoscil;
+            adpars->VoicePar[vc].OscilSmp->get(NoteVoicePar[nvoice].OscilSmp,
+                                               getVoiceBaseFreq(nvoice),
+                                               adpars->VoicePar[nvoice].Presonance);
+
+            // I store the first elements to the last position for speedups
+            for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
+                NoteVoicePar[nvoice].OscilSmp[synth->oscilsize + i] = NoteVoicePar[nvoice].OscilSmp[i];
+
+        }
+
+        int new_phase_offset = (int)((adpars->VoicePar[nvoice].Poscilphase - 64.0f)
+                                    / 128.0f * synth->oscilsize + synth->oscilsize * 4);
+        int phase_offset_diff = new_phase_offset - NoteVoicePar[nvoice].phase_offset;
+        for (int k = 0; k < unison; ++k)
+            oscposhi[nvoice][k] = (oscposhi[nvoice][k] + phase_offset_diff) % synth->oscilsize;
+        NoteVoicePar[nvoice].phase_offset = new_phase_offset;
+
+        if (NoteVoicePar[nvoice].FMEnabled != NONE
+            && NoteVoicePar[nvoice].FMVoice < 0)
+        {
+            if (subVoiceNumber == -1) {
+                int vc = nvoice;
+                if (adpars->VoicePar[nvoice].PextFMoscil != -1)
+                    vc = adpars->VoicePar[nvoice].PextFMoscil;
+
+                float freqtmp = 1.0f;
+                if (adpars->VoicePar[vc].POscilFM->Padaptiveharmonics != 0
+                    || (NoteVoicePar[nvoice].FMEnabled == MORPH)
+                    || (NoteVoicePar[nvoice].FMEnabled == RING_MOD))
+                    freqtmp = getFMVoiceBaseFreq(nvoice);
+
+                adpars->VoicePar[vc].FMSmp->
+                         get(NoteVoicePar[nvoice].FMSmp, freqtmp);
+
+                for (int i = 0; i < OSCIL_SMP_EXTRA_SAMPLES; ++i)
+                    NoteVoicePar[nvoice].FMSmp[synth->oscilsize + i] =
+                        NoteVoicePar[nvoice].FMSmp[i];
+            }
+
+            int new_FMphase_offset = (int)((adpars->VoicePar[nvoice].PFMoscilphase - 64.0f)
+                                         / 128.0f * synth->oscilsize_f
+                                         + synth->oscilsize_f * 4.0f);
+            int FMphase_offset_diff = new_FMphase_offset - NoteVoicePar[nvoice].FMphase_offset;
+            for (int k = 0; k < unison_size[nvoice]; ++k)
+            {
+                oscposhiFM[nvoice][k] += FMphase_offset_diff;
+                oscposhiFM[nvoice][k] %= synth->oscilsize;
+            }
+            NoteVoicePar[nvoice].FMphase_offset = new_FMphase_offset;
+        }
+
+        bool is_pwm = NoteVoicePar[nvoice].FMEnabled == PW_MOD;
+
+        unison_stereo_spread[nvoice] =
+            adpars->VoicePar[nvoice].Unison_stereo_spread / 127.0f;
+        float unison_spread = adpars->getUnisonFrequencySpreadCents(nvoice);
+        float unison_real_spread = powf(2.0f, (unison_spread * 0.5f) / 1200.0f);
+        float unison_vibratto_a = adpars->VoicePar[nvoice].Unison_vibratto / 127.0f;                                  //0.0 .. 1.0
+
+        int true_unison = unison / (is_pwm ? 2 : 1);
+        switch (true_unison)
+        {
+            case 1: // if no unison, set the subvoice to the default note
+                unison_base_freq_rap[nvoice][0] = 1.0f;
+                break;
+
+            case 2:  // unison for 2 subvoices
+                {
+                    unison_base_freq_rap[nvoice][0] = 1.0f / unison_real_spread;
+                    unison_base_freq_rap[nvoice][1] = unison_real_spread;
+                }
+                break;
+
+            default: // unison for more than 2 subvoices
+                {
+                    float unison_values[unison];
+                    float min = -1e-6f, max = 1e-6f;
+                    for (int k = 0; k < true_unison; ++k)
+                    {
+                        float step = (k / (float) (true_unison - 1)) * 2.0f - 1.0f;  //this makes the unison spread more uniform
+                        float val  = step + (paramRNG.numRandom() * 2.0f - 1.0f) / (true_unison - 1);
+                        unison_values[k] = val;
+                        if (val > max)
+                            max = val;
+                        if (val < min)
+                            min = val;
+                    }
+                    float diff = max - min;
+                    for (int k = 0; k < true_unison; ++k)
+                    {
+                        unison_values[k] =
+                            (unison_values[k] - (max + min) * 0.5f) / diff;
+                            // the lowest value will be -1 and the highest will be 1
+                        unison_base_freq_rap[nvoice][k] =
+                            powf(2.0f, (unison_spread * unison_values[k]) / 1200.0f);
+                    }
+                }
+        }
+        if (is_pwm)
+            for (int i = true_unison - 1; i >= 0; i--)
+            {
+                unison_base_freq_rap[nvoice][2*i + 1] =
+                    unison_base_freq_rap[nvoice][i];
+                unison_base_freq_rap[nvoice][2*i] =
+                    unison_base_freq_rap[nvoice][i];
+            }
+
+        // unison vibrattos
+        if(unison > 2 || (!is_pwm && unison > 1))
+        {
+            for (int k = 0; k < unison; ++k) // reduce the frequency difference
+                                             // for larger vibrattos
+                unison_base_freq_rap[nvoice][k] =
+                    1.0f + (unison_base_freq_rap[nvoice][k] - 1.0f)
+                    * (1.0f - unison_vibratto_a);
+        }
+        unison_vibratto[nvoice].amplitude = (unison_real_spread - 1.0f) * unison_vibratto_a;
+
+        float increments_per_second = synth->samplerate_f / synth->sent_all_buffersize_f;
+        const float vib_speed = adpars->VoicePar[nvoice].Unison_vibratto_speed / 127.0f;
+        float vibratto_base_period  = 0.25f * powf(2.0f, (1.0f - vib_speed) * 4.0f);
+        for (int k = 0; k < unison; ++k)
+        {
+            // make period to vary randomly from 50% to 200% vibratto base period
+            float vibratto_period = vibratto_base_period * powf(2.0f, paramRNG.numRandom() * 2.0f - 1.0f);
+            float m = 4.0f / (vibratto_period * increments_per_second);
+            if (unison_vibratto[nvoice].step[k] < 0.0f)
+                m = -m;
+            unison_vibratto[nvoice].step[k] = m;
+
+            // Ugly, but the alternative is likely uglier.
+            if (is_pwm)
+                for (int i = 0; i < unison; i += 2)
+                    unison_vibratto[nvoice].step[i+1] =
+                        unison_vibratto[nvoice].step[i];
+        }
+
+        if (unison <= 2) // no vibratto for a single voice
+        {
+            if (is_pwm)
+            {
+                unison_vibratto[nvoice].step[1]     = 0.0f;
+            }
+            if (is_pwm || unison == 1)
+            {
+                unison_vibratto[nvoice].step[0] = 0.0f;
+                unison_vibratto[nvoice].amplitude = 0.0f;
+            }
+        }
+
+        // phase invert for unison
+        unison_invert_phase[nvoice][0] = false;
+        if (unison != 1)
+        {
+            int inv = adpars->VoicePar[nvoice].Unison_invert_phase;
+            switch(inv)
+            {
+                case 0:
+                    for (int k = 0; k < unison; ++k)
+                        unison_invert_phase[nvoice][k] = false;
+                    break;
+
+                case 1:
+                    for (int k = 0; k < unison; ++k)
+                        unison_invert_phase[nvoice][k] = (paramRNG.numRandom() > 0.5f);
+                    break;
+
+                default:
+                    for (int k = 0; k < unison; ++k)
+                        unison_invert_phase[nvoice][k] = (k % inv == 0) ? true : false;
+                    break;
+            }
+        }
+    }
+}
 
 // Get Voice's Modullator base frequency
 float ADnote::getFMVoiceBaseFreq(int nvoice)
@@ -1344,7 +1281,7 @@ float ADnote::getVoiceBaseFreq(int nvoice)
 
 
 // Computes all the parameters for each tick
-void ADnote::computeCurrentParameters(void)
+void ADnote::computeWorkingParameters(void)
 {
     float filterpitch, filterfreq;
     float globalpitch = 0.01f * (NoteGlobalPar.FreqEnvelope->envout()
@@ -2245,7 +2182,10 @@ int ADnote::noteout(float *outl, float *outr)
         memset(bypassr, 0, synth->sent_bufferbytes);
     }
 
-    computeCurrentParameters();
+    if (paramsUpdate.checkUpdated())
+        computeNoteParameters();
+
+    computeWorkingParameters();
 
     for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
     {

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -76,7 +76,8 @@ class ADnote
             unisonDetuneFactorFromParent = factor;
         }
         void computeUnisonFreqRap(int nvoice);
-        void computeCurrentParameters(void);
+        void computeNoteParameters(void);
+        void computeWorkingParameters(void);
         void initParameters(void);
         void initSubVoices(void);
         void killVoice(int nvoice);
@@ -199,6 +200,7 @@ class ADnote
             int    FMVoice;
             float *VoiceOut; // Voice Output used by other voices if use this as modullator
             float *FMSmp;    // Wave of the Voice. Shared by sub voices.
+            int    FMphase_offset;
             float  FMVolume;
             bool FMDetuneFromBaseOsc;  // Whether we inherit the base oscillator's detuning
             float  FMDetune; // in cents
@@ -208,6 +210,12 @@ class ADnote
 
         // Internal values of the note and of the voices
         float time; // time from the start of the note
+
+        RandomGen paramRNG; // A preseeded random number generator, reseeded
+                            // with a known seed every time parameters are
+                            // updated. This allows parameters to be changed
+                            // smoothly. New notes will get a new seed.
+        uint32_t paramSeed; // The seed for paramRNG.
 
         //pinking filter (Paul Kellet)
         float pinking[NUM_VOICES][14];
@@ -305,6 +313,8 @@ class ADnote
         // For sub voices: Pointer to the closest parent that has
         // phase/frequency modulation.
         float *parentFMmod;
+
+        Presets::PresetsUpdate paramsUpdate;
 
         SynthEngine *synth;
 };

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -32,6 +32,8 @@ using func::rap2dB;
 
 
 Envelope::Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth):
+    _envpars(envpars),
+    envUpdate(envpars),
     synth(_synth)
 {
     envpoints = envpars->Penvpoints;
@@ -42,54 +44,7 @@ Envelope::Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth)
     envstretch = powf(440.0f / basefreq, envpars->Penvstretch / 64.0f);
     linearenvelope = envpars->Plinearenvelope;
 
-    if (!envpars->Pfreemode)
-        envpars->converttofree();
-
-    float bufferdt = synth->sent_all_buffersize_f / synth->samplerate_f;
-
-    int mode = envpars->Envmode;
-
-    // for amplitude envelopes
-    if (mode == ENVMODE::amplitudeLin && linearenvelope == 0)
-        mode = ENVMODE::amplitudeLog; // change to log envelope
-    if (mode == ENVMODE::amplitudeLog && linearenvelope != 0)
-        mode = ENVMODE::amplitudeLin; // change to linear
-
-    for (int i = 0; i < MAX_ENVELOPE_POINTS; ++i)
-    {
-        float tmp = envpars->getdt(i) / 1000.0f * envstretch;
-        if (tmp > bufferdt)
-            envdt[i] = bufferdt / tmp;
-        else
-            envdt[i] = 2.0f; // any value larger than 1
-
-        switch (mode)
-        {
-            case 2:
-                envval[i] = (1.0f - envpars->Penvval[i] / 127.0f) * MIN_ENVELOPE_DB;
-                break;
-
-            case 3:
-                envval[i] =
-                    (powf(2.0f, 6.0f * fabsf(envpars->Penvval[i] - 64.0f) / 64.0f) - 1.0f) * 100.0f;
-                if (envpars->Penvval[i] < 64)
-                    envval[i] = -envval[i];
-                break;
-
-            case 4:
-                envval[i] = (envpars->Penvval[i] - 64.0f) / 64.0f * 6.0f; // 6 octaves (filtru)
-                break;
-
-            case 5:
-                envval[i] = (envpars->Penvval[i] - 64.0f) / 64.0f * 10.0f;
-                break;
-
-            default:
-                envval[i] = envpars->Penvval[i] / 127.0f;
-        }
-    }
-
-    envdt[0] = 1.0f;
+    recomputePoints();
 
     currentpoint = 1; // the envelope starts from 1
     keyreleased = 0;
@@ -110,10 +65,64 @@ void Envelope::releasekey(void)
         t = 0.0f;
 }
 
+void Envelope::recomputePoints()
+{
+    if (!_envpars->Pfreemode)
+        _envpars->converttofree();
+
+    int mode = _envpars->Envmode;
+
+    // for amplitude envelopes
+    if (mode == ENVMODE::amplitudeLin && linearenvelope == 0)
+        mode = ENVMODE::amplitudeLog; // change to log envelope
+    if (mode == ENVMODE::amplitudeLog && linearenvelope != 0)
+        mode = ENVMODE::amplitudeLin; // change to linear
+
+    float bufferdt = synth->sent_all_buffersize_f / synth->samplerate_f;
+
+    for (int i = 0; i < MAX_ENVELOPE_POINTS; ++i)
+    {
+        float tmp = _envpars->getdt(i) / 1000.0f * envstretch;
+        if (tmp > bufferdt)
+            envdt[i] = bufferdt / tmp;
+        else
+            envdt[i] = 2.0f; // any value larger than 1
+
+        switch (mode)
+        {
+            case 2:
+                envval[i] = (1.0f - _envpars->Penvval[i] / 127.0f) * MIN_ENVELOPE_DB;
+                break;
+
+            case 3:
+                envval[i] =
+                    (powf(2.0f, 6.0f * fabsf(_envpars->Penvval[i] - 64.0f) / 64.0f) - 1.0f) * 100.0f;
+                if (_envpars->Penvval[i] < 64)
+                    envval[i] = -envval[i];
+                break;
+
+            case 4:
+                envval[i] = (_envpars->Penvval[i] - 64.0f) / 64.0f * 6.0f; // 6 octaves (filtru)
+                break;
+
+            case 5:
+                envval[i] = (_envpars->Penvval[i] - 64.0f) / 64.0f * 10.0f;
+                break;
+
+            default:
+                envval[i] = _envpars->Penvval[i] / 127.0f;
+        }
+    }
+
+    envdt[0] = 1.0f;
+}
 
 // Envelope Output
 float Envelope::envout(void)
 {
+    if (envUpdate.checkUpdated())
+        recomputePoints();
+
     float out;
     if (envfinish)
     {   // if the envelope is finished
@@ -173,6 +182,9 @@ float Envelope::envout(void)
 // Envelope Output (dB)
 float Envelope::envout_dB(void)
 {
+    if (envUpdate.checkUpdated())
+        recomputePoints();
+
     float out;
     if (linearenvelope != 0)
         return envout();

--- a/src/Synth/Envelope.h
+++ b/src/Synth/Envelope.h
@@ -34,7 +34,7 @@ class SynthEngine;
 class Envelope
 {
     public:
-        Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth);
+        Envelope(EnvelopeParams *envpars, float basefreq_, SynthEngine *_synth);
         ~Envelope() { };
         void releasekey(void);
         void recomputePoints(void);
@@ -52,12 +52,12 @@ class Envelope
         float envstretch;
         int linearenvelope;
 
+        float basefreq;
         int currentpoint; // current envelope point (starts from 1)
         int forcedrelase;
         char keyreleased; // if the key was released
         char envfinish;
         float t;          // the time from the last point
-        float inct;       // the time increment
         float envoutval;  // used to do the forced release
 
         SynthEngine *synth;

--- a/src/Synth/Envelope.h
+++ b/src/Synth/Envelope.h
@@ -26,6 +26,7 @@
 #define ENVELOPE_H
 
 #include "globals.h"
+#include "Params/Presets.h"
 
 class EnvelopeParams;
 class SynthEngine;
@@ -36,11 +37,14 @@ class Envelope
         Envelope(EnvelopeParams *envpars, float basefreq, SynthEngine *_synth);
         ~Envelope() { };
         void releasekey(void);
+        void recomputePoints(void);
         float envout(void);
         float envout_dB(void);
         int finished(void) { return envfinish; };
 
     private:
+        EnvelopeParams *_envpars;
+        Presets::PresetsUpdate envUpdate;
         int envpoints;
         int envsustain;   // "-1" means disabled
         float envdt[MAX_ENVELOPE_POINTS];  // milliseconds

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -32,6 +32,7 @@
 
 LFO::LFO(LFOParams *_lfopars, float _basefreq, SynthEngine *_synth):
     lfopars(_lfopars),
+    lfoUpdate(lfopars),
     basefreq(_basefreq),
     synth(_synth)
 {
@@ -114,7 +115,7 @@ inline void LFO::RecomputeFreq(void)
 // LFO out
 float LFO::lfoout(void)
 {
-    if (lfopars->updated)
+    if (lfoUpdate.checkUpdated())
         Recompute();
 
     float out;

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -54,7 +54,7 @@ LFO::LFO(LFOParams *_lfopars, float _basefreq, SynthEngine *_synth):
         x = fmodf((((int)lfopars->Pstartphase - 64) / 127.0f + 1.0f + tmp), 1.0f);
     }
 
-    lfodelay = lfopars->Pdelay / 127.0f * 4.0f; // 0..4 sec
+    lfoelapsed = 0.0f;
     incrnd = nextincrnd = 1.0f;
 
     Recompute();
@@ -161,7 +161,8 @@ float LFO::lfoout(void)
         out *= lfointensity * (amp1 + x * (amp2 - amp1));
     else
         out *= lfointensity * amp2;
-    if (lfodelay < 0.00001f)
+    float lfodelay = lfopars->Pdelay / 127.0f * 4.0f; // 0..4 sec
+    if (lfoelapsed >= lfodelay)
     {
         if (!freqrndenabled)
             x += incx;
@@ -179,7 +180,7 @@ float LFO::lfoout(void)
             computenextincrnd();
         }
     } else
-        lfodelay -= synth->sent_all_buffersize_f / synth->samplerate_f;
+        lfoelapsed += synth->sent_all_buffersize_f / synth->samplerate_f;
 
     return out;
 }

--- a/src/Synth/LFO.h
+++ b/src/Synth/LFO.h
@@ -40,6 +40,7 @@ class LFO
         float amplfoout(void);
     private:
         LFOParams *lfopars;
+        Presets::PresetsUpdate lfoUpdate;
         void Recompute(void);
         void RecomputeFreq(void);
         void computenextincrnd(void);

--- a/src/Synth/LFO.h
+++ b/src/Synth/LFO.h
@@ -51,7 +51,7 @@ class LFO
         float lfointensity;
         float lfornd;
         float lfofreqrnd;
-        float lfodelay;
+        float lfoelapsed;
         char lfotype;
         int freqrndenabled;
 

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -1173,6 +1173,10 @@ void OscilGen::get(float *smps, float freqHz, int resonance)
 {
     int nyquist;
 
+    // randseed was drawn in ADnote::ADnote()
+    // see also comment at top of OscilGen::prepare()
+    harmonicPrng.init(randseed);
+
     if (oldbasepar != params->Pbasefuncpar
         || oldbasefunc != params->Pcurrentbasefunc
         || oldhmagtype != params->Phmagtype
@@ -1247,7 +1251,7 @@ void OscilGen::get(float *smps, float freqHz, int resonance)
         rnd = PI * powf((params->Prand - 64.0f) / 64.0f, 2.0f);
         for (int i = 1; i < nyquist - 1; ++i)
         {   // to Nyquist only for AntiAliasing
-            angle = rnd * i * prng.numRandom();
+            angle = rnd * i * harmonicPrng.numRandom();
             a = outoscilFFTfreqs.c[i];
             b = outoscilFFTfreqs.s[i];
             c = cosf(angle);
@@ -1260,10 +1264,6 @@ void OscilGen::get(float *smps, float freqHz, int resonance)
     // Harmonic Amplitude Randomness
     if (freqHz > 0.1 && !params->ADvsPAD)
     {
-        // randseed was drawn in ADnote::ADnote()
-        // see also comment at top of OscilGen::prepare()
-        harmonicPrng.init(randseed);
-
         float power = params->Pamprandpower / 127.0f;
         float normalize = 1.0f / (1.2f - power);
         switch (params->Pamprandtype)

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -56,7 +56,9 @@ class PADnote
 
     private:
         void fadein(float *smps);
+        void computeNoteParameters();
         void computecurrentparameters();
+        void setBaseFreq();
         bool finished_;
         PADnoteParameters *pars;
 
@@ -151,6 +153,8 @@ class PADnote
                 int midinote;
             } param;
         } Legato;
+
+        Presets::PresetsUpdate padSynthUpdate;
 
         SynthEngine *synth;
 };

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -183,7 +183,7 @@ void SUBnote::KillNote(void)
     }
 }
 
-void SUBnote::initNewFilters()
+int SUBnote::createNewFilters()
 {
     bool alreadyEnabled[MAX_SUB_HARMONICS];
     memset(alreadyEnabled, 0, sizeof(alreadyEnabled));
@@ -201,6 +201,9 @@ void SUBnote::initNewFilters()
         pos[numharmonics++] = n;
         alreadyEnabled[n] = true;
     }
+
+    if (numharmonics == origNumHarmonics)
+        return 0;
 
     bpfilter *newFilter = new bpfilter[numstages * numharmonics];
     if (lfilter != NULL)
@@ -220,7 +223,7 @@ void SUBnote::initNewFilters()
         rfilter = newFilter;
     }
 
-    initfilters(origNumHarmonics);
+    return numharmonics - origNumHarmonics;
 }
 
 void SUBnote::setBaseFreq()
@@ -832,7 +835,7 @@ float SUBnote::getHgain(int harmonic)
 
 void SUBnote::updatefilterbank(void)
 {
-    initNewFilters();
+    int createdFilters = createNewFilters();
 
     // moved from noteon
     // how much the amplitude is normalised (because the harmonics)
@@ -883,6 +886,7 @@ void SUBnote::updatefilterbank(void)
         }
     }
 
+    initfilters(numharmonics - createdFilters);
     computeallfiltercoefs();
 
     if (reduceamp < 0.001f)

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -55,6 +55,7 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     log_0_001(logf(0.001f)),
     log_0_0001(logf(0.0001f)),
     log_0_00001(logf(0.00001f)),
+    subNoteChange(parameters),
     synth(_synth),
     filterStep(0)
 {
@@ -74,57 +75,17 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     Legato.silent = besilent;
 
     NoteEnabled = true;
-    volume = powf(0.1f, 3.0f * (1.0f - pars->PVolume / 96.0f)); // -60 dB .. 0 dB
-    volume *= velF(velocity, pars->PAmpVelocityScaleFunction);
-    if (pars->randomPan())
-    {
-        float t = synth->numRandom();
-        randpanL = cosf(t * HALFPI);
-        randpanR = cosf((1.0f - t) * HALFPI);
-    }
-    else
-        randpanL = randpanR = 0.7f;
+
     numstages = pars->Pnumstages;
     stereo = pars->Pstereo;
     start = pars->Pstart;
     firsttick = 1;
 
-    if (pars->Pfixedfreq == 0)
-        basefreq = freq;
-    else
-    {
-        basefreq = 440.0f;
-        int fixedfreqET = pars->PfixedfreqET;
-        if (fixedfreqET)
-        {   // if the frequency varies according the keyboard note
-            float tmp =
-                (midinote - 69.0f) / 12.0f * powf(2.0f, (((fixedfreqET - 1) / 63.0f) - 1.0f));
-            if (fixedfreqET <= 64)
-                basefreq *= powf(2.0f, tmp);
-            else
-                basefreq *= powf(3.0f, tmp);
-        }
-    }
+    float t = synth->numRandom();
+    randpanL = cosf(t * HALFPI);
+    randpanR = cosf((1.0f - t) * HALFPI);
 
-    int BendAdj = pars->PBendAdjust - 64;
-    if (BendAdj % 24 == 0)
-        BendAdjust = BendAdj / 24;
-    else
-        BendAdjust = BendAdj / 24.0f;
-    float offset_val = (pars->POffsetHz - 64)/64.0f;
-    OffsetHz = 15.0f*(offset_val * sqrtf(fabsf(offset_val)));
-
-    float detune = getDetune(pars->PDetuneType, pars->PCoarseDetune, pars->PDetune);
-    basefreq *= powf(2.0f, detune / 1200.0f); // detune
-//    basefreq*=ctl->pitchwheel.relfreq;//pitch wheel
-
-    // global filter
-    GlobalFilterCenterPitch =
-        pars->GlobalFilter->getfreq()
-        + // center freq
-          (pars->PGlobalFilterVelocityScale / 127.0f * 6.0f)
-        * // velocity sensing
-          (velF(velocity, pars->PGlobalFilterVelocityScaleFunction) - 1);
+    setBaseFreq();
 
     // select only harmonics that desire to compute
     numharmonics = 0;
@@ -148,10 +109,13 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     if (stereo != 0)
         rfilter = new bpfilter[numstages * numharmonics];
 
-    initfilterbank();
-
     oldpitchwheel = 0;
     oldbandwidth = 64;
+
+    computeNoteParameters();
+
+    initfilters();
+
     if (pars->Pfixedfreq == 0)
         initparameters(basefreq);
     else
@@ -199,42 +163,7 @@ void SUBnote::SUBlegatonote(float freq, float velocity,
 
     portamento = portamento_;
 
-    volume = powf(0.1f, 3.0f * (1.0f - pars->PVolume / 96.0f)); // -60 dB .. 0 dB
-    volume *= velF(velocity, pars->PAmpVelocityScaleFunction);
-    if (pars->randomPan())
-    {
-        float t = synth->numRandom();
-        randpanL = cosf(t * HALFPI);
-        randpanR = cosf((1.0f - t) * HALFPI);
-    }
-    else
-        randpanL = randpanR = 0.7f;
-
-    if (pars->Pfixedfreq == 0)
-        basefreq = freq;
-    else
-    {
-        basefreq = 440.0f;
-        int fixedfreqET = pars->PfixedfreqET;
-        if (fixedfreqET != 0)
-        {   //if the frequency varies according the keyboard note
-            float tmp = (midinote - 69.0f) / 12.0f
-                              * (powf(2.0f, (fixedfreqET - 1) / 63.0f) - 1.0f);
-            if (fixedfreqET <= 64)
-                basefreq *= powf(2.0f, tmp);
-            else
-                basefreq *= powf(3.0f, tmp);
-        }
-    }
-    float detune = getDetune(pars->PDetuneType, pars->PCoarseDetune, pars->PDetune);
-    basefreq *= powf(2.0f, detune / 1200.0f); // detune
-
-    // global filter
-    GlobalFilterCenterPitch = pars->GlobalFilter->getfreq() + // center freq
-                              (pars->PGlobalFilterVelocityScale / 127.0f * 6.0f)
-                              // velocity sensing
-                              * (velF(velocity, pars->PGlobalFilterVelocityScaleFunction) - 1);
-
+    setBaseFreq();
 
     int legatonumharmonics = 0;
     for (int n = 0; n < MAX_SUB_HARMONICS; ++n)
@@ -256,23 +185,12 @@ void SUBnote::SUBlegatonote(float freq, float velocity,
         return;
     }
 
-    initfilterbank();
-
     oldpitchwheel = 0;
     oldbandwidth = 64;
 
-    if (pars->Pfixedfreq == 0)
-        freq = basefreq;
-    else
-        freq *= basefreq / 440.0f;
+    computeNoteParameters();
 
-    // Altered initparameters(...) content:
-    if (pars->PGlobalFilterEnabled)
-    {
-        globalfiltercenterq = pars->GlobalFilter->getq();
-        GlobalFilterFreqTracking = pars->GlobalFilter->getfreqtracking(basefreq);
-    }
-    // end of the altered initparameters function content.
+    initfilters();
 
     oldamplitude = newamplitude;
 
@@ -306,6 +224,62 @@ void SUBnote::KillNote(void)
     }
 }
 
+void SUBnote::setBaseFreq()
+{
+    if (pars->Pfixedfreq == 0)
+        basefreq = Legato.param.freq;
+    else
+    {
+        basefreq = 440.0f;
+        int fixedfreqET = pars->PfixedfreqET;
+        if (fixedfreqET)
+        {   // if the frequency varies according the keyboard note
+            float tmp =
+                (Legato.param.midinote - 69.0f) / 12.0f * powf(2.0f, (((fixedfreqET - 1) / 63.0f) - 1.0f));
+            if (fixedfreqET <= 64)
+                basefreq *= powf(2.0f, tmp);
+            else
+                basefreq *= powf(3.0f, tmp);
+        }
+    }
+}
+
+void SUBnote::computeNoteParameters()
+{
+    volume = powf(0.1f, 3.0f * (1.0f - pars->PVolume / 96.0f)); // -60 dB .. 0 dB
+    volume *= velF(Legato.param.vel, pars->PAmpVelocityScaleFunction);
+
+    setBaseFreq();
+
+    int BendAdj = pars->PBendAdjust - 64;
+    if (BendAdj % 24 == 0)
+        BendAdjust = BendAdj / 24;
+    else
+        BendAdjust = BendAdj / 24.0f;
+    float offset_val = (pars->POffsetHz - 64)/64.0f;
+    OffsetHz = 15.0f*(offset_val * sqrtf(fabsf(offset_val)));
+
+    float detune = getDetune(pars->PDetuneType, pars->PCoarseDetune, pars->PDetune);
+    basefreq *= powf(2.0f, detune / 1200.0f); // detune
+//    basefreq*=ctl->pitchwheel.relfreq;//pitch wheel
+
+    // global filter
+    GlobalFilterCenterPitch =
+        pars->GlobalFilter->getfreq()
+        + // center freq
+          (pars->PGlobalFilterVelocityScale / 127.0f * 6.0f)
+        * // velocity sensing
+          (velF(Legato.param.vel, pars->PGlobalFilterVelocityScaleFunction) - 1);
+
+    updatefilterbank();
+
+    if (pars->PGlobalFilterEnabled != 0)
+    {
+        globalfiltercenterq = pars->GlobalFilter->getq();
+        GlobalFilterFreqTracking = pars->GlobalFilter->getfreqtracking(basefreq);
+    }
+}
+
 // Compute the filters coefficients
 void SUBnote::computefiltercoefs(bpfilter &filter, float freq, float bw, float gain)
 {
@@ -332,7 +306,22 @@ void SUBnote::computefiltercoefs(bpfilter &filter, float freq, float bw, float g
 
 
 // Initialise the filters
-void SUBnote::initfilter(bpfilter &filter, float freq, float bw, float amp, float mag)
+void SUBnote::initfilters()
+{
+    for (int n = 0; n < numharmonics; ++n)
+    {
+        float hgain = getHgain(n);
+
+        for (int nph = 0; nph < numstages; ++nph)
+        {
+            initfilter(lfilter[nph + n * numstages], hgain);
+            if (stereo)
+                initfilter(rfilter[nph + n * numstages], hgain);
+        }
+    }
+}
+
+void SUBnote::initfilter(bpfilter &filter, float mag)
 {
     filter.xn1 = 0.0f;
     filter.xn2 = 0.0f;
@@ -349,21 +338,18 @@ void SUBnote::initfilter(bpfilter &filter, float freq, float bw, float amp, floa
         if (start == 1)
             a *= synth->numRandom();
         filter.yn1 = a * cosf(p);
-        filter.yn2 = a * cosf(p + freq * TWOPI / synth->samplerate_f);
+        filter.yn2 = a * cosf(p + filter.freq * TWOPI / synth->samplerate_f);
 
         // correct the error of computation the start amplitude
         // at very high frequencies
-        if (freq > synth->samplerate_f * 0.96f)
+        if (filter.freq > synth->samplerate_f * 0.96f)
         {
             filter.yn1 = 0.0f;
             filter.yn2 = 0.0f;
         }
     }
 
-    filter.amp = amp;
-    filter.freq = freq;
-    filter.bw = bw;
-    computefiltercoefs(filter, freq, bw, 1.0f);
+    computefiltercoefs(filter, filter.freq, filter.bw, 1.0f);
 }
 
 
@@ -480,12 +466,10 @@ void SUBnote::initparameters(float freq)
         BandWidthEnvelope = NULL;
     if (pars->PGlobalFilterEnabled != 0)
     {
-        globalfiltercenterq = pars->GlobalFilter->getq();
         GlobalFilterL = new Filter(pars->GlobalFilter, synth);
         if (stereo != 0)
             GlobalFilterR = new Filter(pars->GlobalFilter, synth);
         GlobalFilterEnvelope = new Envelope(pars->GlobalFilterEnvelope, freq, synth);
-        GlobalFilterFreqTracking = pars->GlobalFilter->getfreqtracking(basefreq);
     }
     computecurrentparameters();
 }
@@ -510,6 +494,68 @@ float SUBnote::computerolloff(float freq)
     return (1.0f - cosf(M_PI * (freq - upper_limit) / upper_width)) / 2.0f;
 }
 
+void SUBnote::computeallfiltercoefs()
+{
+    float envfreq = 1.0f;
+    float envbw = 1.0f;
+    float gain = 1.0f;
+
+    if (FreqEnvelope != NULL)
+    {
+        envfreq = FreqEnvelope->envout() / 1200;
+        envfreq = powf(2.0f, envfreq);
+    }
+
+    envfreq *= powf(ctl->pitchwheel.relfreq, BendAdjust); // pitch wheel
+
+    if (portamento != 0)
+    {   // portamento is used
+        envfreq *= ctl->portamento.freqrap;
+        if (ctl->portamento.used == 0)
+        {   // the portamento has finished
+            portamento = 0; // this note is no longer "portamented"
+        }
+    }
+
+    if (BandWidthEnvelope != NULL)
+    {
+        envbw = BandWidthEnvelope->envout();
+        envbw = powf(2.0f, envbw);
+    }
+    envbw *= ctl->bandwidth.relbw; // bandwidth controller
+
+    float tmpgain = 1.0f / sqrtf(envbw * envfreq);
+
+    for (int n = 0; n < numharmonics; ++n)
+    {
+        for (int nph = 0; nph < numstages; ++nph)
+        {
+            if (nph == 0)
+                gain = tmpgain;
+            else
+                gain = 1.0f;
+            computefiltercoefs( lfilter[nph + n * numstages],
+                                lfilter[nph + n *numstages].freq * envfreq,
+                                lfilter[nph + n * numstages].bw * envbw, gain);
+        }
+    }
+    if (stereo)
+        for (int n = 0; n < numharmonics; ++n)
+        {
+            for (int nph = 0; nph < numstages; ++nph)
+            {
+                if (nph == 0)
+                    gain = tmpgain;
+                else
+                    gain = 1.0f;
+                computefiltercoefs( rfilter[nph + n * numstages],
+                                    rfilter[nph + n * numstages].freq * envfreq,
+                                    rfilter[nph + n * numstages].bw * envbw, gain);
+            }
+        }
+    oldbandwidth = ctl->bandwidth.data;
+    oldpitchwheel = ctl->pitchwheel.data;
+}
 
 // Compute Parameters of SUBnote for each tick
 void SUBnote::computecurrentparameters(void)
@@ -533,67 +579,7 @@ void SUBnote::computecurrentparameters(void)
         || oldpitchwheel != ctl->pitchwheel.data
         || oldbandwidth != ctl->bandwidth.data
         || portamento != 0)
-    {
-        float envfreq = 1.0f;
-        float envbw = 1.0f;
-        float gain = 1.0f;
-
-        if (FreqEnvelope != NULL)
-        {
-            envfreq = FreqEnvelope->envout() / 1200;
-            envfreq = powf(2.0f, envfreq);
-        }
-
-        envfreq *= powf(ctl->pitchwheel.relfreq, BendAdjust); // pitch wheel
-
-        if (portamento != 0)
-        {   // portamento is used
-            envfreq *= ctl->portamento.freqrap;
-            if (ctl->portamento.used == 0)
-            {   // the portamento has finished
-                portamento = 0; // this note is no longer "portamented"
-            }
-        }
-
-        if (BandWidthEnvelope != NULL)
-        {
-            envbw = BandWidthEnvelope->envout();
-            envbw = powf(2.0f, envbw);
-        }
-        envbw *= ctl->bandwidth.relbw; // bandwidth controller
-
-        float tmpgain = 1.0f / sqrtf(envbw * envfreq);
-
-        for (int n = 0; n < numharmonics; ++n)
-        {
-            for (int nph = 0; nph < numstages; ++nph)
-            {
-                if (nph == 0)
-                    gain = tmpgain;
-                else
-                    gain = 1.0f;
-                computefiltercoefs( lfilter[nph + n * numstages],
-                                    lfilter[nph + n *numstages].freq * envfreq,
-                                    lfilter[nph + n * numstages].bw * envbw, gain);
-            }
-        }
-        if (stereo)
-            for (int n = 0; n < numharmonics; ++n)
-            {
-                for (int nph = 0; nph < numstages; ++nph)
-                {
-                    if (nph == 0)
-                        gain = tmpgain;
-                    else
-                        gain = 1.0f;
-                    computefiltercoefs( rfilter[nph + n * numstages],
-                                        rfilter[nph + n * numstages].freq * envfreq,
-                                        rfilter[nph + n * numstages].bw * envbw, gain);
-                }
-            }
-        oldbandwidth = ctl->bandwidth.data;
-        oldpitchwheel = ctl->pitchwheel.data;
-    }
+        computeallfiltercoefs();
     newamplitude = volume * AmpEnvelope->envout_dB() * 2.0f;
 
     // Filter
@@ -619,6 +605,9 @@ int SUBnote::noteout(float *outl, float *outr)
     memset(outr, 0, synth->sent_bufferbytes);
     if (!NoteEnabled)
         return 0;
+
+    if (subNoteChange.checkUpdated())
+        computeNoteParameters();
 
     // left channel
     for (int i = 0; i < synth->sent_buffersize; ++i)
@@ -814,7 +803,37 @@ void SUBnote::releasekey(void)
         GlobalFilterEnvelope->releasekey();
 }
 
-void SUBnote::initfilterbank(void)
+float SUBnote::getHgain(int harmonic)
+{
+    float hmagnew = 1.0f - pars->Phmag[pos[harmonic]] / 127.0f;
+    float hgain;
+
+    switch (pars->Phmagtype)
+    {
+        case 1:
+            hgain = expf(hmagnew * log_0_01);
+            break;
+
+        case 2:
+            hgain = expf(hmagnew * log_0_001);
+            break;
+
+        case 3:
+            hgain = expf(hmagnew * log_0_0001);
+            break;
+
+        case 4:
+            hgain = expf(hmagnew * log_0_00001);
+            break;
+
+        default:
+            hgain = 1.0f - hmagnew;
+    }
+
+    return hgain;
+}
+
+void SUBnote::updatefilterbank(void)
 {
     // moved from noteon
     // how much the amplitude is normalised (because the harmonics)
@@ -841,30 +860,8 @@ void SUBnote::initfilterbank(void)
         // try to keep same amplitude on all freqs and bw. (empirically)
         float gain = sqrtf(1500.0f / (bw * freq));
 
-        float hmagnew = 1.0f - pars->Phmag[pos[n]] / 127.0f;
-        float hgain;
+        float hgain = getHgain(n);
 
-        switch (pars->Phmagtype)
-        {
-            case 1:
-                hgain = expf(hmagnew * log_0_01);
-                break;
-
-            case 2:
-                hgain = expf(hmagnew * log_0_001);
-                break;
-
-            case 3:
-                hgain = expf(hmagnew * log_0_0001);
-                break;
-
-            case 4:
-                hgain = expf(hmagnew * log_0_00001);
-                break;
-
-            default:
-                hgain = 1.0f - hmagnew;
-        }
         gain *= hgain;
         reduceamp += hgain;
 
@@ -873,11 +870,21 @@ void SUBnote::initfilterbank(void)
             float amp = 1.0f;
             if (nph == 0)
                 amp = gain;
-            initfilter(lfilter[nph + n * numstages], freq + OffsetHz, bw, amp, hgain);
+            bpfilter *filter = &lfilter[nph + n * numstages];
+            filter->amp = amp;
+            filter->freq = freq + OffsetHz;
+            filter->bw = bw;
             if (stereo)
-                initfilter(rfilter[nph + n * numstages], freq + OffsetHz, bw, amp, hgain);
+            {
+                filter = &rfilter[nph + n * numstages];
+                filter->amp = amp;
+                filter->freq = freq + OffsetHz;
+                filter->bw = bw;
+            }
         }
     }
+
+    computeallfiltercoefs();
 
     if (reduceamp < 0.001f)
         reduceamp = 1.0f;

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -58,7 +58,7 @@ class SUBnote
         void computecurrentparameters(void);
         void initparameters(float freq);
         void KillNote(void);
-        void initfilterbank(void);
+        void updatefilterbank(void);
 
         SUBnoteParameters *pars;
 
@@ -107,11 +107,16 @@ class SUBnote
             float yn2;   // filter internal values
         };
 
-        void initfilter(bpfilter &filter, float freq, float bw, float amp, float mag);
+        void initfilters();
+        void initfilter(bpfilter &filter, float mag);
         float computerolloff(float freq);
+        void computeallfiltercoefs();
         void computefiltercoefs(bpfilter &filter, float freq, float bw, float gain);
+        void computeNoteParameters();
+        void setBaseFreq();
         void filter(bpfilter &filter, float *smps);
         void filterVarRun(bpfilter &filter, float *smps);
+        float getHgain(int harmonic);
 
         bpfilter *lfilter;
         bpfilter *rfilter;
@@ -153,6 +158,8 @@ class SUBnote
         const float log_0_001;   // logf(0.001);
         const float log_0_0001;  // logf(0.0001);
         const float log_0_00001; // logf(0.00001);
+
+        Presets::PresetsUpdate subNoteChange;
 
         SynthEngine *synth;
         int filterStep;

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -106,7 +106,9 @@ class SUBnote
             float yn2;   // filter internal values
         };
 
-        void initNewFilters();
+        // Returns the number of new filters created
+        int createNewFilters();
+
         void initfilters(int startIndex);
         void initfilter(bpfilter &filter, float mag);
         float computerolloff(float freq);

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -66,7 +66,6 @@ class SUBnote
         int pos[MAX_SUB_HARMONICS]; // chart of non-zero harmonic locations
         int numstages; // number of stages of filters
         int numharmonics; // number of harmonics (after the too higher hamonics are removed)
-        int firstnumharmonics; // To keep track of the first note's numharmonics value, useful in legato mode.
         int start; // how the harmonics start
         float basefreq;
         float BendAdjust;
@@ -107,7 +106,8 @@ class SUBnote
             float yn2;   // filter internal values
         };
 
-        void initfilters();
+        void initNewFilters();
+        void initfilters(int startIndex);
         void initfilter(bpfilter &filter, float mag);
         float computerolloff(float freq);
         void computeallfiltercoefs();


### PR DESCRIPTION
This is the followup to [the thread on the mailinglist](https://www.freelists.org/post/yoshimi/Instant-control-feedback), and implements instant audio feedback for nearly all parameters in Yoshimi. Those that don't give feedback are:

* PADsynth oscillator change
  * It's way too expensive to regenerate the oscillator on every change. It would be solvable with a queue and delay approach, but this is very different so I won't implement this now
* Most parameters that add, remove, replace or rearrange whole elements in the audio chain. This covers
  * All controls that enable something (enable an engine, enable filter, enable envelope, etc)
  * Changing the number of stages in a filter, or the type of filter (except the filter inside the oscillator window, this one isn't a real filter and gives live feedback)
  * Changing the number of unison voices
  * Changing modulation type
  * Changing the voice or modulation source
  * Changing the number of formants or sequence size in the formant filter

Possibly I've missed some corner cases in the list. The exceptions above were omitted from live feedback primarily because they allocate new structures, and reallocating on the fly is something I would like to avoid, at least in the first iteration.

The code is relatively finished, and I have done quite a bit of testing on it (@abrolag's GhostTrain track was a big help in pushing Yoshimi and finding bugs!), but it's a big piece of code, so any testing from others is appreciated!

There are also some unresolved questions which I'd like feedback on:

1. Is the list of exceptions to live feedback ok for now? The way I see it, we are making it incrementally better
2. There was some talk on the mailing list about keeping an option around to disable live feedback for specific patches. However, from the responses it didn't seem like anyone is relying on the non-live feedback, and although I supported it then, I've found that adding it has several drawbacks:
   * It's a lot of work to add it, because we need to make almost all parameter access conditional
   * For the same reason, it will reduce performance
   * The non-live feedback in the old version was inconsistent, with some parameters being live, and some not (I know about at least LFO parameters being live), and fixing this would be even more effort
* So my vote would be to make it live only for now, as this seems by far the most useful. The only use case I can see for non live-feedback is if someone relies on changing something via MIDI learn, and then have it change only on the *next* note, not the current one. Which is a pretty esoteric use case. But what do you think?