### PR TITLE
Fix notes always having zero filter gain until the knob is moved.

### DIFF
--- a/src/DSP/Filter.cpp
+++ b/src/DSP/Filter.cpp
@@ -53,6 +53,8 @@ Filter::Filter(FilterParams *pars_, SynthEngine *_synth):
             filter = new AnalogFilter(Ftype, 1000.0f, pars->getq(), Fstages, synth);
             break;
     }
+
+    updateCurrentParameters();
 }
 
 


### PR DESCRIPTION
Here is another fix @abrolag. Found while playing around with filters. It only affects filters which use the gain knob, which is a bit more uncommon, so I didn't spot it earlier.