### PR TITLE
Exclude repository configuration from release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 /src/Splash/SplashPngHex -diff
 /src/Splash/splash_screen.h -diff
+.git*           export-ignore
+.travis.yml     export-ignore


### PR DESCRIPTION
for the Debian packaging, the release-tarballs are imported as-is into a git-repository.

Since the [Debian git-repository](https://salsa.debian.org/multimedia-team/yoshimi) is substantially different from your (upstream) repository, it doesn't make much sense to include (your) repository-configuration files.
This includes:
-  `.gitignore`
- `.gitattributes`
- CI-configuration
- ...

this PR adds `export-ignore` rules to `.gitattributes` to make sure that those files won't be part of files generated with `git archive` (such as the release-tarballs generated by github)