### PR TITLE
Fix volume knob on individual voices not working after being zero.

### DIFF
--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -2208,15 +2208,6 @@ int ADnote::noteout(float *outl, float *outr)
         if (!NoteVoicePar[nvoice].Enabled || NoteVoicePar[nvoice].DelayTicks > 0)
             continue;
 
-        if (NoteVoicePar[nvoice].Volume == 0.0f
-            && NoteVoicePar[nvoice].VoiceOut == NULL) {
-
-            // If the voice is muted and we are not producing sound for any sub
-            // voices, then save the cycles.
-            killVoice(nvoice);
-            continue;
-        }
-
         if (NoteVoicePar[nvoice].FMEnabled != NONE)
             computeVoiceModulator(nvoice, NoteVoicePar[nvoice].FMEnabled);
 


### PR DESCRIPTION
When it hits zero, the voice is killed, but this is no longer
desirable after we got live controller feedback. So we lose a small
optimization, but gain the ability to use the volume knob freely with
for example MIDI learn.