### PR TITLE
Various fixes

### DIFF
--- a/src/Misc/NumericFuncs.h
+++ b/src/Misc/NumericFuncs.h
@@ -81,14 +81,14 @@ inline unsigned int nearestPowerOf2(unsigned int x, unsigned int min, unsigned i
 
 inline unsigned int bitFindHigh(unsigned int value)
 {
-    int bit = 32;
-    while (bit >= 0)
-    {
-        bit --;
-        if ((value >> bit) == 1)
-            return bit;
-    }
-    return 0xff;
+    if (value == 0)
+        return 0xff;
+
+    int bit = sizeof(unsigned int) * 8 - 1;
+    while (!(value & (1 << bit)))
+        --bit;
+
+    return bit;
 }
 
 

--- a/src/UI/PADnoteUI.fl
+++ b/src/UI/PADnoteUI.fl
@@ -193,7 +193,7 @@ this->pars=pars;} {}
         {
             float nhr = pars->getNhr(i);
             int kx = (int)(lx / (float)maxharmonic * nhr);
-            if (kx < 0 || kx > lx)
+            if (kx < 0 || kx >= lx)
                 continue;
             spectrum[kx] = spc[i - 1] / max + 1e-9;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -601,6 +601,8 @@ int main(int argc, char *argv[])
     bExitSuccess = true;
 
 bail_out:
+    // firstSynth is freed in the for loop below, so save this for later
+    int exitType = firstSynth->getRuntime().exitType;
     for (it = synthInstances.begin(); it != synthInstances.end(); ++it)
     {
         SynthEngine *_synth = it->first;
@@ -627,12 +629,11 @@ bail_out:
         tcsetattr(0, TCSANOW, &oldTerm);
     if (bExitSuccess)
     {
-        int type = firstSynth->getRuntime().exitType;
-        if (type == FORCED_EXIT)
+        if (exitType == FORCED_EXIT)
             std::cout << "\nExit was forced :(" << std::endl;
         else
             std::cout << "\nGoodbye - Play again soon?"<< std::endl;
-        exit(type);
+        exit(exitType);
     }
     else
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Summary of changes:
- Fixes a use-after-free during program exit
- Fixes an out-of-bounds array access in `PADnoteUI.fl`
- Stops `bitFindHigh()` right-shifting by a negative number of bits, and changes the method used somewhat
- Fixes a minor bug, and a couple of nested loops that didn't need to be, in the unison vibrato logic, and refactors the surrounding code somewhat.

I've been sitting on these commits for a bit too long. I originally intended to keep the bug fixes separate from changes to the code structure, but a bit of refactoring ended up in two of the commits anyway.

Observable behaviour should be the same, with two caveats:
- `bitFindHigh()` will scan bits >31 if `sizeof(unsigned int) > 4`, though if nothing sets those bits the effect is the same. Bitwise not or left-shifting is the most likely reason for the higher-order bits getting set inadvertently, but assuming a 32-bit `unsigned int` in such cases would probably cause other bugs anyway (bitmasks wouldn't compare equal to zero when expected to, etc.). If a 32-bit type is specifically desired, using uint32_t from the `cstdint` header probably makes more sense. Technically not every platform supports every exact-size type (if an architecture has 16-bit registers but no 8-bit registers, or 64-bit registers and no 32-bit registers, etc.), but practically all do and C/C++ portability is a *very* deep rabbit hole. After writing all that I'm kind of tempted to just keep bit 31 as the hardcoded starting point, but as I said, relying on `bitFindHigh()` ignoring bits >31 is probably a bad idea in the first place.
- The "pick a random sign for step" logic actually does so, rather than inadvertently reading from uninitialized memory, which is kind of like getting a random number, except for when it formats your hard drive instead. All the other stuff I changed shouldn't do anything other than improving efficiency (and even then, a smart enough optimizer might do the same thing).

As I mused some months back when I wrote the commit message for the `bitFindHigh()` fix, using compiler intrinsics would improve the performance of the function dramatically (at least on hardware with the corresponding opcode, but that includes basically everything except some embedded architectures nowadays; the bit-scan-reverse instruction has been part of the x86 instruction set since the 80386), but `bitFindHigh()` is probably not performance-critical at the moment, so actual improvement would probably be minimal.