### PR TITLE
Remove redundant code

### DIFF
--- a/src/CLI/CmdInterpreter.cpp
+++ b/src/CLI/CmdInterpreter.cpp
@@ -2439,8 +2439,7 @@ int CmdInterpreter::commandGroup(Parser& input)
     bool full = (input.matchnMove(1, "location"));
 
     int count = 0;
-    if (!instrumentGroup.empty())
-        instrumentGroup.clear();
+    instrumentGroup.clear();
     do {
         ++ count;
         line = textMsgBuffer.fetch(readControl(synth, 0, BANK::control::findInstrumentName, TOPLEVEL::section::bank, UNUSED, UNUSED, UNUSED, value - 1));

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -269,7 +269,6 @@ YoshimiLV2Plugin::YoshimiLV2Plugin(SynthEngine *synth, double sampleRate, const 
     _pIdleThread(0),
     _lv2_desc(desc)
 {
-    flatbankprgs.clear();
     _uridMap.handle = NULL;
     _uridMap.map = NULL;
     const LV2_Feature *f = NULL;

--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -81,13 +81,6 @@ Bank::Bank(SynthEngine *_synth) :
     BanksVersion = 2;
     InstrumentsInBanks = 0,
     BanksInRoots = 0;
-    roots.clear();
-}
-
-
-Bank::~Bank()
-{
-    roots.clear();
 }
 
 
@@ -95,8 +88,6 @@ string Bank::getBankFileTitle(size_t root, size_t bank)
 {
     return synth->makeUniqueName("Root " + asString(root) + ", Bank " + asString(bank) + " - " + getBankPath(root, bank));
 }
-
-
 
 
 string Bank::getRootFileTitle(size_t root)

--- a/src/Misc/Bank.h
+++ b/src/Misc/Bank.h
@@ -99,7 +99,6 @@ class Bank
 
     public:
         Bank(SynthEngine *_synth);
-        ~Bank();
         int getType(unsigned int ninstrument, size_t bank, size_t root);
         string getname(unsigned int ninstrument, size_t bank, size_t root);
         string getnamenumbered(unsigned int ninstrument, size_t bank, size_t root);

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -285,8 +285,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
     }
     else // Poly mode is On, so just make sure the list is empty.
     {
-        if (!monomemnotes.empty())
-            monomemnotes.clear();
+        monomemnotes.clear();
     }
     lastnote = note;
     int pos = -1;
@@ -708,8 +707,7 @@ void Part::NoteOff(int note) //release the key
 {
     int i;
     // This note is released, so we remove it from the list.
-    if (!monomemnotes.empty())
-        monomemnotes.remove(note);
+    monomemnotes.remove(note);
     if (monomemnotes.empty())
         legatoFading = 0;
 

--- a/src/MusicIO/AlsaEngine.cpp
+++ b/src/MusicIO/AlsaEngine.cpp
@@ -174,7 +174,7 @@ bool AlsaEngine::openMidi(void)
             return true;
     }
     std::string found = "";
-    if (!midilist.empty() && midilist != "default")
+    if (midilist != "default")
     {
         while (!midilist.empty())
         {


### PR DESCRIPTION
This removes several redundant pieces of code:
- Several checks that a container is not empty before emptying it
- A check that a list is not empty before calling `remove()` on it
- Several calls to `clear()` on members inside their class's constructor or destructor
- A check that a string does not equal `""` before a while loop with an identical condition

Calling `clear()` on an empty container is a no-op. Calling `remove()` on an empty list is a no-op. When an object is constructed, members not present in the member initializer list are default-constructed, which in the case of containers means a valid and empty container. When an object is destroyed, its members' destructors are also called, which in the case of containers clears the container.