### PR TITLE
Fix legato

### DIFF
--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -58,6 +58,37 @@ AnalogFilter::AnalogFilter(unsigned char Ftype, float Ffreq, float Fq, unsigned 
 }
 
 
+AnalogFilter::AnalogFilter(const AnalogFilter &orig) :
+    type(orig.type),
+    stages(orig.stages),
+    freq(orig.freq),
+    q(orig.q),
+    gain(orig.gain),
+    order(orig.order),
+    needsinterpolation(orig.needsinterpolation),
+    firsttime(orig.firsttime),
+    abovenq(orig.abovenq),
+    oldabovenq(orig.oldabovenq),
+    synth(orig.synth)
+{
+    outgain = orig.outgain;
+
+    memcpy(x, orig.x, sizeof(x));
+    memcpy(y, orig.y, sizeof(y));
+    memcpy(oldx, orig.oldx, sizeof(oldx));
+    memcpy(oldy, orig.oldy, sizeof(oldy));
+    memcpy(c, orig.c, sizeof(c));
+    memcpy(d, orig.d, sizeof(d));
+    memcpy(oldc, orig.oldc, sizeof(oldc));
+    memcpy(oldd, orig.oldd, sizeof(oldd));
+    memcpy(xd, orig.xd, sizeof(xd));
+    memcpy(yd, orig.yd, sizeof(yd));
+
+    // No need to memcpy as this is always memcpy'd to before use
+    tmpismp = (float*)fftwf_malloc(synth->bufferbytes);
+}
+
+
 AnalogFilter::~AnalogFilter()
 {
     if (tmpismp)

--- a/src/DSP/AnalogFilter.h
+++ b/src/DSP/AnalogFilter.h
@@ -35,7 +35,9 @@ class AnalogFilter : public Filter_
     public:
         AnalogFilter(unsigned char Ftype, float Ffreq, float Fq,
                      unsigned char Fstages, SynthEngine *_synth);
+        AnalogFilter(const AnalogFilter &orig);
         ~AnalogFilter();
+        Filter_* clone() { return new AnalogFilter(*this); };
         void filterout(float *smp);
         void setfreq(float frequency);
         void setfreq_and_q(float frequency, float q_);

--- a/src/DSP/Filter.h
+++ b/src/DSP/Filter.h
@@ -38,6 +38,14 @@ class Filter
 {
     public:
         Filter(FilterParams *pars_, SynthEngine *_synth);
+        Filter(const Filter &orig) :
+            pars(orig.pars),
+            parsUpdate(orig.parsUpdate),
+            category(orig.category),
+            synth(orig.synth)
+        {
+            filter = orig.filter->clone();
+        };
         ~Filter();
         void filterout(float *smp);
         void setfreq(float frequency);

--- a/src/DSP/Filter_.h
+++ b/src/DSP/Filter_.h
@@ -32,6 +32,7 @@ class Filter_
     public:
         Filter_() { };
         virtual ~Filter_() { };
+        virtual Filter_* clone() = 0;
         virtual void filterout(float *smp) = 0;
         virtual void setfreq(float frequency) = 0;
         virtual void setfreq_and_q(float frequency, float q_) = 0;

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -74,6 +74,37 @@ FormantFilter::FormantFilter(FilterParams *pars_, SynthEngine *_synth):
 }
 
 
+FormantFilter::FormantFilter(const FormantFilter &orig) :
+    pars(orig.pars),
+    parsUpdate(orig.parsUpdate),
+    sequencesize(orig.sequencesize),
+    numformants(orig.numformants),
+    firsttime(orig.firsttime),
+    oldinput(orig.oldinput),
+    slowinput(orig.slowinput),
+    Qfactor(orig.Qfactor),
+    formantslowness(orig.formantslowness),
+    oldQfactor(orig.oldQfactor),
+    vowelclearness(orig.vowelclearness),
+    sequencestretch(orig.sequencestretch),
+    synth(orig.synth)
+{
+    outgain = orig.outgain;
+
+    memcpy(formantpar, orig.formantpar, sizeof(formantpar));
+    memcpy(currentformants, orig.currentformants, sizeof(currentformants));
+    memcpy(sequence, orig.sequence, sizeof(sequence));
+    memcpy(oldformantamp, orig.oldformantamp, sizeof(oldformantamp));
+
+    for (int i = 0; i < numformants; ++i)
+        formant[i] = new AnalogFilter(*orig.formant[i]);
+
+    // These don't hold persistent state and don't need a memcpy
+    inbuffer = (float*)fftwf_malloc(synth->bufferbytes);
+    tmpbuf = (float*)fftwf_malloc(synth->bufferbytes);
+}
+
+
 FormantFilter::~FormantFilter()
 {
     for (int i = 0; i < numformants; ++i)

--- a/src/DSP/FormantFilter.h
+++ b/src/DSP/FormantFilter.h
@@ -36,7 +36,9 @@ class FormantFilter : public Filter_
 {
     public:
         FormantFilter(FilterParams *pars_, SynthEngine *_synth);
+        FormantFilter(const FormantFilter &orig);
         ~FormantFilter();
+        Filter_* clone() { return new FormantFilter(*this); };
         void filterout(float *smp);
         void setfreq(float frequency);
         void setfreq_and_q(float frequency, float q_);

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -52,6 +52,27 @@ SVFilter::SVFilter(unsigned char Ftype, float Ffreq, float Fq,
 }
 
 
+SVFilter::SVFilter(const SVFilter &orig) :
+    par(orig.par),
+    ipar(orig.ipar),
+    type(orig.type),
+    stages(orig.stages),
+    freq(orig.freq),
+    q(orig.q),
+    abovenq(orig.abovenq),
+    oldabovenq(orig.oldabovenq),
+    needsinterpolation(orig.needsinterpolation),
+    firsttime(orig.firsttime),
+    synth(orig.synth)
+{
+    outgain = orig.outgain;
+
+    memcpy(st, orig.st, sizeof(st));
+
+    tmpismp = (float*)fftwf_malloc(synth->bufferbytes);
+}
+
+
 SVFilter::~SVFilter()
 {
     if (tmpismp)

--- a/src/DSP/SVFilter.h
+++ b/src/DSP/SVFilter.h
@@ -34,7 +34,9 @@ class SVFilter : public Filter_
 {
     public:
         SVFilter(unsigned char Ftype, float Ffreq, float Fq, unsigned char Fstages, SynthEngine *_synth);
+        SVFilter(const SVFilter &orig);
         ~SVFilter();
+        Filter_* clone() { return new SVFilter(*this); };
         void filterout(float *smp);
         void setfreq(float frequency);
         void setfreq_and_q(float frequency, float q_);

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -3374,7 +3374,6 @@ void InterChange::commandPart(CommandBlock *getData)
         case PART::control::drumMode:
             if (write)
             {
-                part->legatoFading = 0;
                 part->Pdrummode = value_bool;
                 synth->setPartMap(npart);
             }

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -138,7 +138,6 @@ void Part::defaults(void)
     Pvelrand = 0;
     PbreathControl = 2;
     Peffnum = 0;
-    legatoFading = 0;
     setDestination(1);
     busy = false;
     defaultsinstrument();
@@ -269,19 +268,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
 {
     if (note < Pminkey || note > Pmaxkey)
         return;
-    /*
-     * In legato mode we only ever hear the newest
-     * note played, so it is acceptable to lose
-     * intemediate ones while going through a
-     * legato fade between held and newest note.
-     *
-     * The newer legato logic should work fine even
-     * during an existing fade; the existing fade
-     * just skips to the end, which is probably
-     * better than ignoring the NoteOn entirely.
-     */
-    if (Pkeymode > PART_MONO && legatoFading > 0)
-        return;
+
     // Legato and MonoMem used vars:
     int posb = POLIPHONY - 1;     // Just a dummy initial value.
     bool legatomodevalid = false; // true when legato mode is determined applicable.
@@ -429,7 +416,6 @@ void Part::NoteOn(int note, int velocity, bool renote)
             ctl->portamento.noteusing = pos;
         oldfreq = notebasefreq;
         lastpos = pos; // Keep a trace of used pos.
-        legatoFading = 0; // just to be sure
         if (doinglegato)
         {
             // Do Legato note
@@ -728,8 +714,6 @@ void Part::NoteOff(int note) //release the key
     int i;
     // This note is released, so we remove it from the list.
     monomemnotes.remove(note);
-    if (monomemnotes.empty())
-        legatoFading = 0;
 
     for ( i = POLIPHONY - 1; i >= 0; i--)
     {   //first note in, is first out if there are same note multiple times
@@ -815,7 +799,6 @@ void Part::SetController(unsigned int type, int par)
             setVolume(Pvolume);
             setPan(Ppanning);
             Pkeymode &= MIDI_NOT_LEGATO; // clear temporary legato mode
-            legatoFading = 0;
 
             for (int item = 0; item < NUM_KIT_ITEMS; ++item)
             {

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1024,7 +1024,7 @@ void Part::ComputePartSmps(void)
             if (adnote)
             {
                 noteplay++;
-                if (adnote->ready)
+                if (adnote->ready())
                 {
                     adnote->noteout(tmpoutl, tmpoutr);
                     for (int i = 0; i < synth->sent_buffersize; ++i)
@@ -1043,7 +1043,7 @@ void Part::ComputePartSmps(void)
             if (subnote)
             {
                 noteplay++;
-                if (subnote->ready)
+                if (subnote->ready())
                 {
                     subnote->noteout(tmpoutl, tmpoutr);
                     for (int i = 0; i < synth->sent_buffersize; ++i)
@@ -1062,7 +1062,7 @@ void Part::ComputePartSmps(void)
             if (padnote)
             {
                 noteplay++;
-                if (padnote->ready)
+                if (padnote->ready())
                 {
                     padnote->noteout(tmpoutl, tmpoutr);
                     for (int i = 0 ; i < synth->sent_buffersize; ++i)

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -464,11 +464,11 @@ void Part::NoteOn(int note, int velocity, bool renote)
                     && (partnote[pos].kititem[0].padnote)
                     && (partnote[posb].kititem[0].padnote))
                 {
+                    if (!portamento)
+                        partnote[posb].kititem[0].padnote->
+                            legatoFadeOut(*partnote[pos].kititem[0].padnote);
                     partnote[pos].kititem[0].padnote->
-                        PADlegatonote(notebasefreq, vel, portamento, note, true);
-                    partnote[posb].kititem[0].padnote->
-                        PADlegatonote(notebasefreq, vel, portamento, note, true);
-                    legatoFading |= 4;
+                        legatoFadeIn(notebasefreq, vel, portamento, note);
                 }
 
             }
@@ -525,11 +525,11 @@ void Part::NoteOn(int note, int velocity, bool renote)
                         && (partnote[pos].kititem[ci].padnote)
                         && (partnote[posb].kititem[ci].padnote))
                     {
+                        if (!portamento)
+                            partnote[posb].kititem[ci].padnote->
+                                legatoFadeOut(*partnote[pos].kititem[ci].padnote);
                         partnote[pos].kititem[ci].padnote->
-                            PADlegatonote(notebasefreq, vel, portamento, note, true);
-                        partnote[posb].kititem[ci].padnote->
-                            PADlegatonote(notebasefreq, vel, portamento, note, true);
-                        legatoFading |= 4;
+                            legatoFadeIn(notebasefreq, vel, portamento, note);
                     }
 
                     if ((kit[item].adpars)
@@ -588,8 +588,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
                         new SUBnote(*partnote[pos].kititem[0].subnote);
                 if (kit[0].Ppadenabled)
                     partnote[posb].kititem[0].padnote =
-                        new PADnote(kit[0].padpars, ctl, notebasefreq, vel,
-                                    portamento, note, true, synth);
+                        new PADnote(*partnote[pos].kititem[0].padnote);
                 if (kit[0].Padenabled || kit[0].Psubenabled || kit[0].Ppadenabled)
                     partnote[posb].itemsplaying++;
             }
@@ -700,8 +699,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
                             new SUBnote(*partnote[pos].kititem[ci].subnote);
                     if (kit[item].padpars && kit[item].Ppadenabled)
                         partnote[posb].kititem[ci].padnote =
-                            new PADnote(kit[item].padpars, ctl, notebasefreq,
-                                        vel, portamento, note, true, synth);
+                            new PADnote(*partnote[pos].kititem[ci].padnote);
 
                     if (kit[item].adpars || kit[item].subpars)
                         partnote[posb].itemsplaying++;

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -453,11 +453,11 @@ void Part::NoteOn(int note, int velocity, bool renote)
                     && (partnote[pos].kititem[0].subnote)
                     && (partnote[posb].kititem[0].subnote))
                 {
+                    if (!portamento)
+                        partnote[posb].kititem[0].subnote->
+                            legatoFadeOut(*partnote[pos].kititem[0].subnote);
                     partnote[pos].kititem[0].subnote->
-                        SUBlegatonote(notebasefreq, vel, portamento, note, true);
-                    partnote[posb].kititem[0].subnote->
-                        SUBlegatonote(notebasefreq, vel, portamento, note, true);
-                    legatoFading |= 2;
+                        legatoFadeIn(notebasefreq, vel, portamento, note);
                 }
 
                 if ((kit[0].Ppadenabled)
@@ -514,11 +514,11 @@ void Part::NoteOn(int note, int velocity, bool renote)
                         && (partnote[pos].kititem[ci].subnote)
                         && (partnote[posb].kititem[ci].subnote))
                     {
+                        if (!portamento)
+                            partnote[posb].kititem[ci].subnote->
+                                legatoFadeOut(*partnote[pos].kititem[ci].subnote);
                         partnote[pos].kititem[ci].subnote->
-                            SUBlegatonote(notebasefreq, vel, portamento, note, true);
-                        partnote[posb].kititem[ci].subnote->
-                            SUBlegatonote(notebasefreq, vel, portamento, note, true);
-                        legatoFading |= 2;
+                            legatoFadeIn(notebasefreq, vel, portamento, note);
                     }
                     if ((kit[item].Ppadenabled)
                         && (kit[item].padpars)
@@ -585,8 +585,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
                         new ADnote(*partnote[pos].kititem[0].adnote);
                 if (kit[0].Psubenabled)
                     partnote[posb].kititem[0].subnote =
-                        new SUBnote(kit[0].subpars, ctl, notebasefreq, vel,
-                                    portamento, note, true, synth);
+                        new SUBnote(*partnote[pos].kititem[0].subnote);
                 if (kit[0].Ppadenabled)
                     partnote[posb].kititem[0].padnote =
                         new PADnote(kit[0].padpars, ctl, notebasefreq, vel,
@@ -698,8 +697,7 @@ void Part::NoteOn(int note, int velocity, bool renote)
                     }
                     if (kit[item].subpars && kit[item].Psubenabled)
                         partnote[posb].kititem[ci].subnote =
-                            new SUBnote(kit[item].subpars, ctl, notebasefreq,
-                                        vel, portamento, note, true, synth);
+                            new SUBnote(*partnote[pos].kititem[ci].subnote);
                     if (kit[item].padpars && kit[item].Ppadenabled)
                         partnote[posb].kititem[ci].padnote =
                             new PADnote(kit[item].padpars, ctl, notebasefreq,

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -564,15 +564,15 @@ void Part::NoteOn(int note, int velocity, bool renote)
             if (kit[0].Padenabled)
                 partnote[pos].kititem[0].adnote =
                     new ADnote(kit[0].adpars, ctl, notebasefreq, vel,
-                                portamento, note, false, synth); // not silent
+                                portamento, note, synth);
             if (kit[0].Psubenabled)
                 partnote[pos].kititem[0].subnote =
                     new SUBnote(kit[0].subpars, ctl, notebasefreq, vel,
-                                portamento, note, false, synth);
+                                portamento, note, synth);
             if (kit[0].Ppadenabled)
                 partnote[pos].kititem[0].padnote =
                     new PADnote(kit[0].padpars, ctl, notebasefreq, vel,
-                                portamento, note, false, synth);
+                                portamento, note, synth);
             if (kit[0].Padenabled || kit[0].Psubenabled || kit[0].Ppadenabled)
                 partnote[pos].itemsplaying++;
 
@@ -669,17 +669,17 @@ void Part::NoteOn(int note, int velocity, bool renote)
                 {
                     partnote[pos].kititem[ci].adnote =
                         new ADnote(kit[item].adpars, ctl, notebasefreq, vel,
-                                    portamento, note, false, synth); // not silent
+                                    portamento, note, synth);
                 }
                 if (kit[item].subpars && kit[item].Psubenabled)
                     partnote[pos].kititem[ci].subnote =
                         new SUBnote(kit[item].subpars, ctl, notebasefreq, vel,
-                                    portamento, note, false, synth);
+                                    portamento, note, synth);
 
                 if (kit[item].padpars && kit[item].Ppadenabled)
                     partnote[pos].kititem[ci].padnote =
                         new PADnote(kit[item].padpars, ctl, notebasefreq, vel,
-                                    portamento, note, false, synth);
+                                    portamento, note, synth);
 
                 // Spawn another note (but silent) if legatomodevalid==true
                 if (legatomodevalid)

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -112,7 +112,6 @@ class Part
         float         TransVolume;
         float         Ppanning;
         float         TransPanning;
-        unsigned char legatoFading;
         char Penabled; // this *must* be signed
         unsigned char Pminkey;
         unsigned char Pmaxkey;

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -232,8 +232,17 @@ bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
 
     oscilsize_f = oscilsize = Runtime.Oscilsize;
     halfoscilsize_f = halfoscilsize = oscilsize / 2;
-    fadeStep = 10.0f / samplerate; // 100mS fade
-    ControlStep = (127.0f / samplerate) * 5.0f; // 200mS for 0 to 127
+    // distance / duration / second = distance / (duration * second)
+    // While some might prefer to write this as the latter, when distance and
+    // duration are constants the latter incurs two roundings while the former
+    // brings the constants together, allowing constant-folding. -ffast-math
+    // produces the same assembly in both cases, and we normally compile with it
+    // enabled, but it's probably a bad habit to rely on non-IEEE float math too
+    // much. If we were doing integer division, even -ffast-math wouldn't save
+    // us, and the rounding behaviour would actually be important.
+    fadeStep = 1.0f / 0.1f / samplerate_f; // 100ms for 0 to 1
+    fadeStepShort = 1.0f / 0.005f / samplerate_f; // 5ms for 0 to 1
+    ControlStep = 127.0f / 0.2f / samplerate_f; // 200ms for 0 to 127
 
     if (oscilsize < (buffersize / 2))
     {

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -724,7 +724,6 @@ void SynthEngine::SetController(unsigned char chan, int CCtype, short int par)
     //std::cout << "  min " << minPart<< "  max " << maxPart << "  Rec " << int(part[npart]->Prcvchn) << "  Chan " << int(chan) <<std::endl;
     for (npart = minPart; npart < maxPart; ++ npart)
     {   // Send the controller to all part assigned to the channel
-        part[npart]->legatoFading = 0;
         if (chan == part[npart]->Prcvchn)
         {
             if (CCtype == part[npart]->PbreathControl) // breath
@@ -1001,7 +1000,6 @@ int SynthEngine::setProgramFromBank(CommandBlock *getData, bool notinplace)
 bool SynthEngine::setProgram(string fname, int npart)
 {
     bool ok = true;
-    part[npart]->legatoFading = 0;
     if (!part[npart]->loadXMLinstrument(fname))
         ok = false;
     return ok;
@@ -2343,7 +2341,6 @@ void SynthEngine::ShutUp(void)
 
     for (int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
     {
-        part[npart]->legatoFading = 0;
         part[npart]->cleanup();
         VUpeak.values.parts[npart] = -1.0f;
         VUpeak.values.partsR[npart] = -1.0f;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -164,7 +164,11 @@ class SynthEngine
 
         Part *part[NUM_MIDI_PARTS];
         unsigned int fadeAll;
+        // Per sample change in gain calculated whenever samplerate changes (which
+        // is currently only on init). fadeStep is used in SynthEngine, while
+        // fadeStepShort is used directly by notes, currently only for legato.
         float fadeStep;
+        float fadeStepShort;
         float fadeLevel;
 
         // parameters

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -610,7 +610,7 @@ void PADnoteParameters::applyparameters()
         samplemax = 1;
 
     // prepare a BIG FFT stuff
-    FFTwrapper *fft = new FFTwrapper(samplesize);
+    FFTwrapper fft = FFTwrapper(samplesize);
     FFTFREQS fftfreqs;
     FFTwrapper::newFFTFREQS(&fftfreqs, samplesize / 2);
 
@@ -641,7 +641,7 @@ void PADnoteParameters::applyparameters()
             fftfreqs.c[i] = spectrum[i] * cosf(phase);
             fftfreqs.s[i] = spectrum[i] * sinf(phase);
         }
-        fft->freqs2smps(&fftfreqs, newsample.smp);
+        fft.freqs2smps(&fftfreqs, newsample.smp);
         // that's all; here is the only ifft for the whole sample; no windows are used ;-)
 
         // normalize(rms)
@@ -666,7 +666,6 @@ void PADnoteParameters::applyparameters()
         sample[nsample].basefreq = basefreq * basefreqadjust;
         newsample.smp = NULL;
     }
-    delete fft;
     FFTwrapper::deleteFFTFREQS(&fftfreqs);
 
     // delete the additional samples that might exists and are not useful

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -25,6 +25,8 @@
 
 */
 
+#include <memory>
+
 #include "Misc/XMLwrapper.h"
 #include "DSP/FFTwrapper.h"
 #include "Synth/OscilGen.h"
@@ -586,7 +588,9 @@ void PADnoteParameters::applyparameters()
 {
     const int samplesize = (((int)1) << (Pquality.samplesize + 14));
     int spectrumsize = samplesize / 2;
-    float spectrum[spectrumsize];
+    // spectrumsize can be quite large (up to 2MiB) and this is not a hot
+    // function, so allocate this on the heap
+    std::unique_ptr<float[]> spectrum(new float[spectrumsize]);
     int profilesize = 512;
     float profile[profilesize];
 
@@ -623,11 +627,11 @@ void PADnoteParameters::applyparameters()
         float basefreqadjust = powf(2.0f, tmp);
 
         if (Pmode == 0)
-            generatespectrum_bandwidthMode(spectrum, spectrumsize,
+            generatespectrum_bandwidthMode(&spectrum[0], spectrumsize,
                                            basefreq * basefreqadjust, profile,
                                            profilesize, bwadjust);
         else
-            generatespectrum_otherModes(spectrum, spectrumsize,
+            generatespectrum_otherModes(&spectrum[0], spectrumsize,
                                         basefreq * basefreqadjust);
 
         const int extra_samples = 5; // the last samples contains the first

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -67,7 +67,6 @@ ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
     paramsUpdate(adpars),
     synth(_synth)
 {
-    Legato.silent = besilent;
     construct();
 }
 
@@ -90,8 +89,296 @@ ADnote::ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmo
     paramsUpdate(adpars),
     synth(orig->synth)
 {
-    Legato.silent = orig->Legato.silent;
     construct();
+}
+
+// Copy constructor, currently only exists for legato
+ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
+    // Is ready used for synchronization? Everything that can
+    // currently access it runs on the same thread, and it needs to be
+    // accessed atomically if this is the case. It only gets set in
+    // one place: at the end of construct()
+    ready(orig.ready),
+    adpars(orig.adpars), // Probably okay for legato?
+    stereo(orig.stereo),
+    midinote(orig.midinote),
+    velocity(orig.velocity),
+    basefreq(orig.basefreq),
+    NoteEnabled(orig.NoteEnabled),
+    ctl(orig.ctl),
+    NoteGlobalPar(orig.NoteGlobalPar),
+    time(orig.time), // This is incremented, but never actually used for some reason
+    paramRNG(orig.paramRNG),
+    paramSeed(orig.paramSeed),
+    detuneFromParent(orig.detuneFromParent),
+    unisonDetuneFactorFromParent(orig.unisonDetuneFactorFromParent),
+    forFM(orig.forFM),
+    max_unison(orig.max_unison),
+    globaloldamplitude(orig.globaloldamplitude),
+    globalnewamplitude(orig.globalnewamplitude),
+    portamento(orig.portamento),
+    bandwidthDetuneMultiplier(orig.bandwidthDetuneMultiplier),
+    legatoFade(0.0f), // Silent by default
+    legatoFadeStep(0.0f), // Legato disabled
+    pangainL(orig.pangainL),
+    pangainR(orig.pangainR),
+    subVoiceNumber(orig.subVoiceNumber),
+    origVoice(parent),
+    parentFMmod(parentFMmod_),
+    paramsUpdate(adpars),
+    synth(orig.synth)
+{
+    auto &oldgpar = orig.NoteGlobalPar;
+    NoteGlobalPar.FreqEnvelope = new Envelope(*oldgpar.FreqEnvelope);
+    NoteGlobalPar.FreqLfo = new LFO(*oldgpar.FreqLfo);
+    NoteGlobalPar.AmpEnvelope = new Envelope(*oldgpar.AmpEnvelope);
+    NoteGlobalPar.AmpLfo = new LFO(*oldgpar.AmpLfo);
+    NoteGlobalPar.FilterEnvelope = new Envelope(*oldgpar.FilterEnvelope);
+    NoteGlobalPar.FilterLfo = new LFO(*oldgpar.FilterLfo);
+
+    NoteGlobalPar.GlobalFilterL = new Filter(*oldgpar.GlobalFilterL);
+    if (stereo)
+        NoteGlobalPar.GlobalFilterR = new Filter(*oldgpar.GlobalFilterR);
+
+    // These are all arrays, so sizeof is correct
+    memcpy(pinking, orig.pinking, sizeof(pinking));
+    memcpy(unison_size, orig.unison_size, sizeof(unison_size));
+    memcpy(unison_stereo_spread, orig.unison_stereo_spread,
+        sizeof(unison_stereo_spread));
+    memcpy(freqbasedmod, orig.freqbasedmod, sizeof(freqbasedmod));
+    memcpy(firsttick, orig.firsttick, sizeof(firsttick));
+
+    tmpwave_unison = new float*[max_unison];
+    tmpmod_unison = new float*[max_unison];
+
+    for (int i = 0; i < max_unison; ++i)
+    {
+        tmpwave_unison[i] = (float*)fftwf_malloc(synth->bufferbytes);
+        tmpmod_unison[i] = (float*)fftwf_malloc(synth->bufferbytes);
+    }
+
+    if (parent != NULL && parent->origVoice != NULL)
+        origVoice = parent->origVoice;
+
+    for (int i = 0; i < NUM_VOICES; ++i)
+    {
+        auto &oldvpar = orig.NoteVoicePar[i];
+        auto &vpar = NoteVoicePar[i];
+
+        vpar.OscilSmp = NULL;
+        vpar.FMSmp = NULL;
+        vpar.VoiceOut = NULL;
+        vpar.FMEnabled = oldvpar.FMEnabled;
+
+        // The above vars are checked in killNote() even when the voice is
+        // disabled, so short-circuit only after they are set
+        vpar.Enabled = oldvpar.Enabled;
+        if (!vpar.Enabled)
+            continue;
+
+        // First, copy over everything that isn't behind a pointer
+        vpar.Voice = oldvpar.Voice;
+        vpar.noisetype = oldvpar.noisetype;
+        vpar.filterbypass = oldvpar.filterbypass;
+        vpar.DelayTicks = oldvpar.DelayTicks;
+        vpar.phase_offset = oldvpar.phase_offset;
+
+        vpar.fixedfreq = oldvpar.fixedfreq;
+        vpar.fixedfreqET = oldvpar.fixedfreqET;
+
+        vpar.Detune = oldvpar.Detune;
+        vpar.FineDetune = oldvpar.FineDetune;
+        vpar.BendAdjust = oldvpar.BendAdjust;
+        vpar.OffsetHz = oldvpar.OffsetHz;
+
+        vpar.Volume = oldvpar.Volume;
+        vpar.Panning = oldvpar.Panning;
+        vpar.randpanL = oldvpar.randpanL;
+        vpar.randpanR = oldvpar.randpanR;
+
+        vpar.Punch = oldvpar.Punch;
+
+        vpar.FilterCenterPitch = oldvpar.FilterCenterPitch;
+        vpar.FilterFreqTracking = oldvpar.FilterFreqTracking;
+        vpar.FMFreqFixed = oldvpar.FMFreqFixed;
+        vpar.FMVoice = oldvpar.FMVoice;
+        vpar.FMphase_offset = oldvpar.FMphase_offset;
+        vpar.FMVolume = oldvpar.FMVolume;
+        vpar.FMDetuneFromBaseOsc = oldvpar.FMDetuneFromBaseOsc;
+        vpar.FMDetune = oldvpar.FMDetune;
+
+        // Now handle allocations
+        if (subVoiceNumber == -1)
+        {
+            size_t size = synth->oscilsize + OSCIL_SMP_EXTRA_SAMPLES;
+
+            if (oldvpar.OscilSmp != NULL)
+            {
+                vpar.OscilSmp = new float[size];
+                memcpy(vpar.OscilSmp, oldvpar.OscilSmp, size * sizeof(float));
+            }
+
+            if (oldvpar.FMSmp != NULL)
+            {
+                vpar.FMSmp = (float*)fftwf_malloc(size * sizeof(float));
+                memcpy(vpar.FMSmp, oldvpar.FMSmp, size * sizeof(float));
+            }
+        } else {
+            vpar.OscilSmp = origVoice->NoteVoicePar[i].OscilSmp;
+        }
+
+        vpar.FreqEnvelope = oldvpar.FreqEnvelope != NULL ?
+            new Envelope(*oldvpar.FreqEnvelope) :
+            NULL;
+        vpar.FreqLfo = oldvpar.FreqLfo != NULL ?
+            new LFO(*oldvpar.FreqLfo) :
+            NULL;
+
+        vpar.AmpEnvelope = oldvpar.AmpEnvelope != NULL ?
+            new Envelope(*oldvpar.AmpEnvelope) :
+            NULL;
+        vpar.AmpLfo = oldvpar.AmpLfo != NULL ?
+            new LFO(*oldvpar.AmpLfo) :
+            NULL;
+
+        if (adpars->VoicePar[i].PFilterEnabled)
+        {
+            vpar.VoiceFilterL = new Filter(*oldvpar.VoiceFilterL);
+            vpar.VoiceFilterR = new Filter(*oldvpar.VoiceFilterR);
+        }
+        else
+        {
+            vpar.VoiceFilterL = NULL;
+            vpar.VoiceFilterR = NULL;
+        }
+
+        vpar.FilterEnvelope = oldvpar.FilterEnvelope != NULL ?
+            new Envelope(*oldvpar.FilterEnvelope) :
+            NULL;
+        vpar.FilterLfo = oldvpar.FilterLfo != NULL ?
+            new LFO(*oldvpar.FilterLfo) :
+            NULL;
+
+        vpar.FMFreqEnvelope = oldvpar.FMFreqEnvelope != NULL ?
+            new Envelope(*oldvpar.FMFreqEnvelope) :
+            NULL;
+        vpar.FMAmpEnvelope = oldvpar.FMAmpEnvelope != NULL ?
+            new Envelope(*oldvpar.FMAmpEnvelope) :
+            NULL;
+
+        if (oldvpar.VoiceOut != NULL) {
+            vpar.VoiceOut = (float*)fftwf_malloc(synth->bufferbytes);
+            // Not sure the memcpy is necessary
+            memcpy(vpar.VoiceOut, oldvpar.VoiceOut, synth->bufferbytes);
+        }
+        // NoteVoicePar done
+
+        int unison = adpars->VoicePar[i].Unison_size;
+
+        oscfreqhi[i] = new int[unison];
+        memcpy(oscfreqhi[i], orig.oscfreqhi[i], unison * sizeof(int));
+
+        oscfreqlo[i] = new float[unison];
+        memcpy(oscfreqlo[i], orig.oscfreqlo[i], unison * sizeof(float));
+
+        oscfreqhiFM[i] = new unsigned int[unison];
+        memcpy(oscfreqhiFM[i], orig.oscfreqhiFM[i], unison * sizeof(unsigned int));
+
+        oscfreqloFM[i] = new float[unison];
+        memcpy(oscfreqloFM[i], orig.oscfreqloFM[i], unison * sizeof(float));
+
+        oscposhi[i] = new int[unison];
+        memcpy(oscposhi[i], orig.oscposhi[i], unison * sizeof(int));
+
+        oscposlo[i] = new float[unison];
+        memcpy(oscposlo[i], orig.oscposlo[i], unison * sizeof(float));
+
+        oscposhiFM[i] = new unsigned int[unison];
+        memcpy(oscposhiFM[i], orig.oscposhiFM[i], unison * sizeof(unsigned int));
+
+        oscposloFM[i] = new float[unison];
+        memcpy(oscposloFM[i], orig.oscposloFM[i], unison * sizeof(float));
+
+
+        unison_base_freq_rap[i] = new float[unison];
+        memcpy(unison_base_freq_rap[i], orig.unison_base_freq_rap[i],
+            unison * sizeof(float));
+
+        unison_freq_rap[i] = new float[unison];
+        memcpy(unison_freq_rap[i], orig.unison_freq_rap[i],
+            unison * sizeof(float));
+
+        unison_invert_phase[i] = new bool[unison];
+        memcpy(unison_invert_phase[i], orig.unison_invert_phase[i],
+            unison * sizeof(bool));
+
+        unison_vibratto[i].amplitude = orig.unison_vibratto[i].amplitude;
+
+        unison_vibratto[i].step = new float[unison];
+        memcpy(unison_vibratto[i].step,
+            orig.unison_vibratto[i].step, unison * sizeof(float));
+
+        unison_vibratto[i].position = new float[unison];
+        memcpy(unison_vibratto[i].position,
+            orig.unison_vibratto[i].position, unison * sizeof(float));
+
+
+        FMoldsmp[i] = new float[unison];
+        memcpy(FMoldsmp[i], orig.unison_vibratto[i].position,
+            unison * sizeof(float));
+
+        if (parentFMmod != NULL)
+        {
+            if (NoteVoicePar[i].FMEnabled == FREQ_MOD)
+            {
+                FMFMoldsmpModded[i] = new float[unison];
+                memcpy(FMFMoldsmpModded[i], orig.FMFMoldsmpModded[i],
+                    unison * sizeof(float));
+
+                FMFMoldsmpOrig[i] = new float[unison];
+                memcpy(FMFMoldsmpOrig[i], orig.FMFMoldsmpOrig[i],
+                    unison * sizeof(float));
+            }
+
+            if (forFM)
+            {
+                oscFMoldsmpModded[i] = new float[unison];
+                memcpy(oscFMoldsmpModded[i], orig.oscFMoldsmpModded[i],
+                    unison * sizeof(float));
+
+                oscFMoldsmpOrig[i] = new float[unison];
+                memcpy(oscFMoldsmpOrig[i], orig.oscFMoldsmpOrig[i],
+                    unison * sizeof(float));
+            }
+        }
+
+        oldamplitude[i] = orig.oldamplitude[i];
+        newamplitude[i] = orig.newamplitude[i];
+        FMoldamplitude[i] = orig.FMoldamplitude[i];
+        FMnewamplitude[i] = orig.FMnewamplitude[i];
+
+        if (orig.subVoice[i] != NULL)
+        {
+            subVoice[i] = new ADnote*[orig.unison_size[i]];
+            for (int k = 0; k < orig.unison_size[i]; ++k)
+            {
+                subVoice[i][k] = new ADnote(*orig.subVoice[i][k], this, freqbasedmod[i] ? tmpmod_unison[k] : parentFMmod);
+            }
+        }
+        else
+            subVoice[i] = NULL;
+
+        if (orig.subFMVoice[i] != NULL)
+        {
+            subFMVoice[i] = new ADnote*[orig.unison_size[i]];
+            for (int k = 0; k < orig.unison_size[i]; ++k)
+            {
+                subFMVoice[i][k] = new ADnote(*orig.subVoice[i][k], this, parentFMmod);
+            }
+        }
+        else
+            subFMVoice[i] = NULL;
+    }
 }
 
 void ADnote::construct()
@@ -100,16 +387,8 @@ void ADnote::construct()
         velocity = 1.0f;
 
     // Initialise some legato-specific vars
-    Legato.msg = LM_Norm;
-    Legato.fade.length = int(synth->samplerate_f * 0.005f); // 0.005 seems ok.
-    if (Legato.fade.length < 1)  // (if something's fishy)
-        Legato.fade.length = 1;
-    Legato.fade.step = (1.0f / Legato.fade.length);
-    Legato.decounter = -10;
-    Legato.param.freq = basefreq;
-    Legato.param.vel = velocity;
-    Legato.param.portamento = portamento;
-    Legato.param.midinote = midinote;
+    legatoFade = 1.0f; // Full volume
+    legatoFadeStep = 0.0f; // Legato disabled
 
     paramSeed = synth->randomINT();
 
@@ -405,166 +684,140 @@ void ADnote::initSubVoices(void)
     }
 }
 
-
-// ADlegatonote: This function is (mostly) a copy of ADnote(...) and
-// initParameters() stuck together with some lines removed so that it
-// only alter the already playing note (to perform legato). It is
-// possible I left stuff that is not required for this.
-void ADnote::ADlegatonote(float freq_, float velocity_, int portamento_,
-                          int midinote_, bool externcall)
+void ADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_)
 {
     basefreq = freq_;
     velocity = velocity_;
     if (velocity > 1.0)
-        velocity = 1.0f;
+        velocity = 1.0;
     portamento = portamento_;
     midinote = midinote_;
 
-    // Manage legato stuff
-    if (externcall) {
-        Legato.msg = LM_Norm;
-        for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
-            if (NoteVoicePar[nvoice].Enabled) {
-                if (subVoice[nvoice] != NULL)
-                    for (int k = 0; k < unison_size[nvoice]; ++k) {
-                        subVoice[nvoice][k]->ADlegatonote(getVoiceBaseFreq(nvoice),
-                                                          velocity_, portamento_,
-                                                          midinote_, externcall);
-                    }
-                if (subFMVoice[nvoice] != NULL)
-                    for (int k = 0; k < unison_size[nvoice]; ++k) {
-                        subFMVoice[nvoice][k]->ADlegatonote(getFMVoiceBaseFreq(nvoice),
-                                                            velocity_, portamento_,
-                                                            midinote_, externcall);
-                    }
-            }
-        }
-    }
-    if (Legato.msg != LM_CatchUp)
+    if (!portamento) // Do not crossfade portamento
     {
-        Legato.lastfreq = Legato.param.freq;
-        Legato.param.freq = freq_;
-        Legato.param.vel = velocity_;
-        Legato.param.portamento = portamento_;
-        Legato.param.midinote = midinote_;
-        if (Legato.msg == LM_Norm)
-        {
-            if (Legato.silent)
-            {
-                Legato.fade.m = 0.0f;
-                Legato.msg = LM_FadeIn;
-            }
-            else
-            {
-                Legato.fade.m = 1.0f;
-                Legato.msg = LM_FadeOut;
-                return;
-            }
-        }
-        if (Legato.msg == LM_ToNorm)
-            Legato.msg = LM_Norm;
-    }
-
-    for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
-    {
-        if (NoteVoicePar[nvoice].Enabled == 0)
-            continue; //(gf) Stay the same as first note in legato.
-
-        // Only generate oscillator for original voices. In sub voices we use
-        // the parents' voices, so they are already generated.
-        if (subVoiceNumber == -1) {
-            // Get the voice's oscil or external's voice oscil
-            int vc = nvoice;
-            if (adpars->VoicePar[nvoice].Pextoscil != -1)
-                vc = adpars->VoicePar[nvoice].Pextoscil;
-            if (!adpars->GlobalPar.Hrandgrouping)
-                adpars->VoicePar[vc].OscilSmp->newrandseed();
-        }
-
-        NoteVoicePar[nvoice].DelayTicks =
-            int((expf(adpars->VoicePar[nvoice].PDelay / 127.0f
-                         * logf(50.0f)) - 1.0f) / synth->sent_all_buffersize_f / 10.0f
-                         * synth->samplerate_f);
-    }
-
-    ///////////////
-    // Altered content of initParameters():
-
-    int nvoice, i;
-
-    NoteGlobalPar.FilterQ = adpars->GlobalPar.GlobalFilter->getq();
-    NoteGlobalPar.FilterFreqTracking =
-        adpars->GlobalPar.GlobalFilter->getfreqtracking(basefreq);
-
-    // Forbids the Modulation Voice to be greater or equal than voice
-    for (i = 0; i < NUM_VOICES; ++i)
-        if (NoteVoicePar[i].FMVoice >= i)
-            NoteVoicePar[i].FMVoice = -1;
-
-    // Voice Parameter init
-    for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
-    {
-        if (!NoteVoicePar[nvoice].Enabled)
-            continue;
-
-        NoteVoicePar[nvoice].noisetype = adpars->VoicePar[nvoice].Type;
-        float t = synth->numRandom();
-        NoteVoicePar[nvoice].randpanL = cosf(t * HALFPI);
-        NoteVoicePar[nvoice].randpanR = cosf((1.0f - t) * HALFPI);
-
-        newamplitude[nvoice] = 1.0f;
-        if (adpars->VoicePar[nvoice].PAmpEnvelopeEnabled
-           && NoteVoicePar[nvoice].AmpEnvelope)
-            newamplitude[nvoice] *= NoteVoicePar[nvoice].AmpEnvelope->envout_dB();
-
-        if (adpars->VoicePar[nvoice].PAmpLfoEnabled
-             && NoteVoicePar[nvoice].AmpLfo)
-            newamplitude[nvoice] *= NoteVoicePar[nvoice].AmpLfo->amplfoout();
-
-        NoteVoicePar[nvoice].FilterFreqTracking =
-            adpars->VoicePar[nvoice].VoiceFilter->getfreqtracking(basefreq);
-
-        // Voice Modulation Parameters Init
-        if (NoteVoicePar[nvoice].FMEnabled != NONE
-            && NoteVoicePar[nvoice].FMVoice < 0)
-        {
-            // Only generate modulator oscillator for original voices. In sub
-            // voices we use the parents' voices, so they are already generated.
-            if (subVoiceNumber == -1) {
-                adpars->VoicePar[nvoice].FMSmp->newrandseed();
-
-                //Perform Anti-aliasing only on MORPH or RING MODULATION
-
-                int vc = nvoice;
-                if (adpars->VoicePar[nvoice].PextFMoscil != -1)
-                    vc = adpars->VoicePar[nvoice].PextFMoscil;
-
-                if (!adpars->GlobalPar.Hrandgrouping)
-                    adpars->VoicePar[vc].FMSmp->newrandseed();
-            }
-        }
+        legatoFade = 0.0f; // Start silent
+        legatoFadeStep = 1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, positive steps
     }
 
     computeNoteParameters();
+}
 
-    for (nvoice = 0; nvoice < NUM_VOICES; ++nvoice)
+// This exists purely to avoid boilerplate. It might be useful
+// elsewhere, but converting the relevant code to be more
+// RAII-friendly would probably be more worthwhile.
+template<class T> inline void copyOrAssign(T *lhs, const T *rhs)
+{
+        if (rhs != NULL)
+        {
+            if (lhs != NULL)
+                *lhs = *rhs;
+            else
+                lhs = new T(*rhs);
+        }
+        else
+        {
+            delete lhs;
+            lhs = NULL;
+        }
+}
+
+void ADnote::legatoFadeOut(const ADnote &orig)
+{
+    basefreq = orig.basefreq;
+    velocity = orig.velocity;
+    portamento = orig.portamento;
+    midinote = orig.midinote;
+
+    auto &gpar = NoteGlobalPar;
+    auto &oldgpar = orig.NoteGlobalPar;
+
+    // These should never be null
+    *gpar.FreqEnvelope = *oldgpar.FreqEnvelope;
+    *gpar.FreqLfo = *oldgpar.FreqLfo;
+    *gpar.AmpEnvelope = *oldgpar.AmpEnvelope;
+    *gpar.AmpLfo = *oldgpar.AmpLfo;
+    *gpar.FilterEnvelope = *oldgpar.FilterEnvelope;
+    *gpar.FilterLfo = *oldgpar.FilterLfo;
+
+    gpar.Fadein_adjustment = oldgpar.Fadein_adjustment;
+    gpar.Punch = oldgpar.Punch;
+
+    paramSeed = orig.paramSeed;
+
+    globalnewamplitude = orig.globalnewamplitude;
+    globaloldamplitude = orig.globaloldamplitude;
+
+    // Supporting virtual copy assignment would be hairy
+    // so we have to use the copy constructor here
+    delete gpar.GlobalFilterL;
+    gpar.GlobalFilterL = new Filter(*oldgpar.GlobalFilterL);
+    if (stereo)
     {
-        if (!NoteVoicePar[nvoice].Enabled)
-            continue;
-
-        FMnewamplitude[nvoice] = NoteVoicePar[nvoice].FMVolume * ctl->fmamp.relamp;
-
-        if (adpars->VoicePar[nvoice].PFMAmpEnvelopeEnabled
-           && NoteVoicePar[nvoice].FMAmpEnvelope != NULL)
-            FMnewamplitude[nvoice] *=
-                NoteVoicePar[nvoice].FMAmpEnvelope->envout_dB();
+        delete gpar.GlobalFilterR;
+        gpar.GlobalFilterR = new Filter(*oldgpar.GlobalFilterR);
     }
 
-    globalnewamplitude = NoteGlobalPar.Volume
-                         * NoteGlobalPar.AmpEnvelope->envout_dB()
-                         * NoteGlobalPar.AmpLfo->amplfoout();
+    memcpy(pinking, orig.pinking, sizeof(pinking));
+    memcpy(firsttick, orig.firsttick, sizeof(firsttick));
 
-    // End of the ADlegatonote function.
+    memcpy(oldamplitude, orig.oldamplitude, sizeof(oldamplitude));
+    memcpy(newamplitude, orig.newamplitude, sizeof(newamplitude));
+    memcpy(FMoldamplitude, orig.FMoldamplitude, sizeof(FMoldamplitude));
+    memcpy(FMnewamplitude, orig.FMnewamplitude, sizeof(FMnewamplitude));
+
+    for (int i = 0; i < NUM_VOICES; ++i)
+    {
+        auto &vpar = NoteVoicePar[i];
+        auto &oldvpar = orig.NoteVoicePar[i];
+
+        vpar.Enabled = oldvpar.Enabled;
+        if (!vpar.Enabled)
+            continue;
+
+        vpar.DelayTicks = oldvpar.DelayTicks;
+        vpar.Punch = oldvpar.Punch;
+        vpar.phase_offset = oldvpar.phase_offset;
+
+        int unison = adpars->VoicePar[i].Unison_size;
+        memcpy(oscposhi[i], orig.oscposhi[i], unison * sizeof(int));
+        memcpy(oscposlo[i], orig.oscposlo[i], unison * sizeof(float));
+        memcpy(oscposhiFM[i], orig.oscposhiFM[i], unison * sizeof(int));
+        memcpy(oscposloFM[i], orig.oscposloFM[i], unison * sizeof(float));
+
+        copyOrAssign(vpar.FreqLfo, oldvpar.FreqLfo);
+        copyOrAssign(vpar.FreqEnvelope, oldvpar.FreqEnvelope);
+
+        copyOrAssign(vpar.AmpLfo, oldvpar.AmpLfo);
+        copyOrAssign(vpar.AmpEnvelope, oldvpar.AmpEnvelope);
+
+        delete vpar.VoiceFilterL;
+        vpar.VoiceFilterL = NULL;
+        if (oldvpar.VoiceFilterL != NULL)
+            vpar.VoiceFilterL = new Filter(*oldvpar.VoiceFilterL);
+        delete vpar.VoiceFilterR;
+        vpar.VoiceFilterR = NULL;
+        if (oldvpar.VoiceFilterR != NULL)
+            vpar.VoiceFilterR = new Filter(*oldvpar.VoiceFilterR);
+
+        copyOrAssign(vpar.FilterLfo, oldvpar.FilterLfo);
+        copyOrAssign(vpar.FilterEnvelope, oldvpar.FilterEnvelope);
+
+        copyOrAssign(vpar.FMFreqEnvelope, oldvpar.FMFreqEnvelope);
+        copyOrAssign(vpar.FMAmpEnvelope, oldvpar.FMAmpEnvelope);
+
+        if (vpar.Enabled)
+        {
+            if (subVoice[i] != NULL)
+                for (int k = 0; k < unison_size[i]; ++k)
+                    subVoice[i][k]->legatoFadeOut(*orig.subVoice[i][k]);
+            else if (subFMVoice[i] != NULL)
+                for (int k = 0; k < unison_size[i]; ++k)
+                    subFMVoice[i][k]->legatoFadeOut(*orig.subFMVoice[i][k]);
+        }
+    }
+
+    legatoFade = 1.0f; // Start at full volume
+    legatoFadeStep = -1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, negative steps
 }
 
 
@@ -2223,6 +2476,8 @@ int ADnote::noteout(float *outl, float *outr)
 
     if (!NoteEnabled)
         return 0;
+    if (legatoFade == 0.0f && legatoFadeStep == 0.0f)
+        return 1; // No need to process more, but don't kill the note
 
     if (subVoiceNumber == -1) {
         memset(bypassl, 0, synth->sent_bufferbytes);
@@ -2502,92 +2757,31 @@ int ADnote::noteout(float *outl, float *outr)
             }
         }
 
-        // Apply legato-specific sound signal modifications
-        if (Legato.silent)    // Silencer
-            if (Legato.msg != LM_FadeIn)
-            {
-                memset(outl, 0, synth->sent_bufferbytes);
-                memset(outr, 0, synth->sent_bufferbytes);
-            }
-        switch(Legato.msg)
+        // Apply legato fading if any
+        if (legatoFadeStep != 0.0f)
         {
-            case LM_CatchUp:  // Continue the catch-up...
-                if (Legato.decounter == -10)
-                    Legato.decounter = Legato.fade.length;
-                for (i = 0; i < synth->sent_buffersize; ++i)
-                { // Yea, could be done without the loop...
-                    Legato.decounter--;
-                    if (Legato.decounter < 1)
-                    {
-                        synth->part[synth->legatoPart]->legatoFading &= 6;
-                        // Catching-up done, we can finally set
-                        // the note to the actual parameters.
-                        Legato.decounter = -10;
-                        Legato.msg = LM_ToNorm;
-                        ADlegatonote(Legato.param.freq,
-                                     Legato.param.vel,
-                                     Legato.param.portamento,
-                                     Legato.param.midinote,
-                                     false);
-                        break;
-                    }
-                }
-                break;
-
-            case LM_FadeIn:  // Fade-in
-                if (Legato.decounter == -10)
-                    Legato.decounter = Legato.fade.length;
-                Legato.silent = false;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+            for (int i = 0; i < synth->sent_buffersize; ++i)
+            {
+                legatoFade += legatoFadeStep;
+                if (legatoFade <= 0.0f)
                 {
-                    Legato.decounter--;
-                    if (Legato.decounter < 1)
-                    {
-                        Legato.decounter = -10;
-                        Legato.msg = LM_Norm;
-                        break;
-                    }
-                    Legato.fade.m += Legato.fade.step;
-                    outl[i] *= Legato.fade.m;
-                    outr[i] *= Legato.fade.m;
+                    legatoFade = 0.0f;
+                    legatoFadeStep = 0.0f;
+                    memset(outl + i, 0, (synth->sent_buffersize - i) * sizeof(float));
+                    memset(outr + i, 0, (synth->sent_buffersize - i) * sizeof(float));
+                    break;
                 }
-                break;
-
-            case LM_FadeOut:  // Fade-out, then set the catch-up
-                if (Legato.decounter == -10)
-                    Legato.decounter = Legato.fade.length;
-                for (i = 0; i < synth->sent_buffersize; ++i)
+                else if (legatoFade >= 1.0f)
                 {
-                    Legato.decounter--;
-                    if (Legato.decounter < 1)
-                    {
-                        for (int j = i; j < synth->sent_buffersize; j++)
-                            outl[j] = outr[j] = 0.0f;
-                        Legato.decounter = -10;
-                        Legato.silent = true;
-                        // Fading-out done, now set the catch-up :
-                        Legato.decounter = Legato.fade.length;
-                        Legato.msg = LM_CatchUp;
-                        float catchupfreq =
-                            Legato.param.freq * (Legato.param.freq / Legato.lastfreq);
-                        // This freq should make this now silent note to catch-up
-                        //  (or should I say resync ?) with the heard note for the
-                        // same length it stayed at the previous freq during the fadeout.
-                        ADlegatonote(catchupfreq, Legato.param.vel, Legato.param.portamento,
-                                     Legato.param.midinote, false);
-                        break;
-                    }
-                    Legato.fade.m -= Legato.fade.step;
-                    outl[i] *= Legato.fade.m;
-                    outr[i] *= Legato.fade.m;
+                    legatoFade = 1.0f;
+                    legatoFadeStep = 0.0f;
+                    break;
                 }
-                break;
-
-            default:
-                break;
+                outl[i] *= legatoFade;
+                outr[i] *= legatoFade;
+            }
         }
     }
-
 
     // Check if the global amplitude is finished.
     // If it does, disable the note

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -50,7 +50,6 @@ using std::isgreater;
 
 ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
                float velocity_, int portamento_, int midinote_, SynthEngine *_synth) :
-    ready(0),
     adpars(adpars_),
     stereo(adpars->GlobalPar.PStereo),
     midinote(midinote_),
@@ -72,7 +71,6 @@ ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
 
 ADnote::ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmod_,
                bool forFM_) :
-    ready(0),
     adpars(orig->adpars),
     stereo(adpars->GlobalPar.PStereo),
     midinote(orig->midinote),
@@ -94,11 +92,6 @@ ADnote::ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmo
 
 // Copy constructor, currently only exists for legato
 ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
-    // Is ready used for synchronization? Everything that can
-    // currently access it runs on the same thread, and it needs to be
-    // accessed atomically if this is the case. It only gets set in
-    // one place: at the end of construct()
-    ready(orig.ready),
     adpars(orig.adpars), // Probably okay for legato?
     stereo(orig.stereo),
     midinote(orig.midinote),
@@ -647,8 +640,6 @@ void ADnote::construct()
     globalnewamplitude = NoteGlobalPar.Volume
                          * NoteGlobalPar.AmpEnvelope->envout_dB()
                          * NoteGlobalPar.AmpLfo->amplfoout();
-
-    ready = 1;
 }
 
 void ADnote::initSubVoices(void)
@@ -2476,8 +2467,6 @@ int ADnote::noteout(float *outl, float *outr)
 
     if (!NoteEnabled)
         return 0;
-    if (legatoFade == 0.0f && legatoFadeStep == 0.0f)
-        return 1; // No need to process more, but don't kill the note
 
     if (subVoiceNumber == -1) {
         memset(bypassl, 0, synth->sent_bufferbytes);

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -49,7 +49,7 @@ using std::isgreater;
 
 
 ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
-               float velocity_, int portamento_, int midinote_, bool besilent, SynthEngine *_synth) :
+               float velocity_, int portamento_, int midinote_, SynthEngine *_synth) :
     ready(0),
     adpars(adpars_),
     stereo(adpars->GlobalPar.PStereo),

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -688,9 +688,27 @@ void ADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mid
     {
         legatoFade = 0.0f; // Start silent
         legatoFadeStep = synth->fadeStepShort; // Positive steps
-    }
 
-    computeNoteParameters();
+        // Re-randomize harmonics, but only if we're not doing portamento
+        if (subVoiceNumber == -1)
+            for (int i = 0; i < NUM_VOICES; ++i)
+            {
+                adpars->VoicePar[i].OscilSmp->newrandseed();
+                auto &extoscil = adpars->VoicePar[i].Pextoscil;
+                if (extoscil != -1 && !adpars->GlobalPar.Hrandgrouping)
+                    adpars->VoicePar[extoscil].OscilSmp->newrandseed();
+            }
+
+        // This recalculates certain things like harmonic phase/amplitude randomness,
+        // which we probably don't want with portamento. This may not even be
+        // desirable with plain legato, but it at least makes some sense in that
+        // case. Portamento should be a smooth change in pitch, with no change in
+        // timbre, or at least a gradual one. It may be desirable to have base
+        // frequency sensitive things like filter scaling and envelope stretching
+        // take portamento into account, but to do this properly would require more
+        // than just recalculating based on basefreq.
+        computeNoteParameters();
+    }
 }
 
 // This exists purely to avoid boilerplate. It might be useful

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -687,7 +687,7 @@ void ADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mid
     if (!portamento) // Do not crossfade portamento
     {
         legatoFade = 0.0f; // Start silent
-        legatoFadeStep = 1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, positive steps
+        legatoFadeStep = synth->fadeStepShort; // Positive steps
     }
 
     computeNoteParameters();
@@ -808,7 +808,7 @@ void ADnote::legatoFadeOut(const ADnote &orig)
     }
 
     legatoFade = 1.0f; // Start at full volume
-    legatoFadeStep = -1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, negative steps
+    legatoFadeStep = -synth->fadeStepShort; // Negative steps
 }
 
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -60,7 +60,11 @@ class ADnote
 
         int noteout(float *outl, float *outr);
         void releasekey();
-        int finished() const;
+        bool finished() const
+        {
+            return NoteStatus == NOTE_DISABLED ||
+                (NoteStatus != NOTE_KEEPALIVE && legatoFade == 0.0f);
+        }
         void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
         void legatoFadeOut(const ADnote &syncwith);
 
@@ -119,7 +123,11 @@ class ADnote
         float velocity;
         float basefreq;
 
-        bool NoteEnabled;
+        enum {
+            NOTE_DISABLED,
+            NOTE_ENABLED,
+            NOTE_KEEPALIVE
+        } NoteStatus;
         Controller *ctl;
 
         // Global parameters
@@ -306,11 +314,5 @@ class ADnote
 
         SynthEngine *synth;
 };
-
-
-inline int ADnote::finished() const // Check if the note is finished
-{
-    return (NoteEnabled) ? 0 : 1;
-}
 
 #endif

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -53,6 +53,7 @@ class ADnote
                int portamento_, int midinote_, bool besilent, SynthEngine *_synth);
         ADnote(ADnote *parent, float freq_, int subVoiceNumber_, float *parentFMmod_,
                bool forFM_);
+        ADnote(const ADnote &orig, ADnote *parent = NULL, float *parentFMmod = NULL);
         ~ADnote();
 
         void construct();
@@ -60,8 +61,8 @@ class ADnote
         int noteout(float *outl, float *outr);
         void releasekey();
         int finished() const;
-        void ADlegatonote(float freq_, float velocity_, int portamento_,
-                          int midinote_, bool externcall);
+        void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
+        void legatoFadeOut(const ADnote &syncwith);
         char ready;
 
     private:
@@ -281,25 +282,8 @@ class ADnote
         float bandwidthDetuneMultiplier; // how the fine detunes are made bigger or smaller
 
         // Legato vars
-        struct {
-            bool silent;
-            float lastfreq;
-            LegatoMsg msg;
-            int decounter;
-            struct {
-                // Fade In/Out vars
-                int length;
-                float m;
-                float step;
-            } fade;
-            struct {
-                // Note parameters
-                float freq;
-                float vel;
-                int portamento;
-                int midinote;
-            } param;
-        } Legato;
+        float legatoFade;
+        float legatoFadeStep;
 
         float pangainL;
         float pangainR;

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -50,7 +50,7 @@ class ADnote
 {
     public:
         ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_, float velocity_,
-               int portamento_, int midinote_, bool besilent, SynthEngine *_synth);
+               int portamento_, int midinote_, SynthEngine *_synth);
         ADnote(ADnote *parent, float freq_, int subVoiceNumber_, float *parentFMmod_,
                bool forFM_);
         ADnote(const ADnote &orig, ADnote *parent = NULL, float *parentFMmod = NULL);

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -63,7 +63,10 @@ class ADnote
         int finished() const;
         void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
         void legatoFadeOut(const ADnote &syncwith);
-        char ready;
+
+        // Whether the note has samples to output.
+        // Currently only used for dormant legato notes.
+        bool ready() { return legatoFade != 0.0f || legatoFadeStep != 0.0f; };
 
     private:
 

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -45,7 +45,6 @@ using synth::aboveAmplitudeThreshold;
 
 PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
     float velocity, int portamento_, int midinote_, SynthEngine *_synth) :
-    ready(false),
     finished_(false),
     pars(parameters),
     firsttime(true),
@@ -121,8 +120,6 @@ PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
         poshi_r = poshi_l;
     poslo = 0.0f;
 
-    ready = true; ///sa il pun pe asta doar cand e chiar gata
-
     if (parameters->sample[nsample].smp == NULL)
     {
         finished_ = true;
@@ -133,7 +130,6 @@ PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
 
 // Copy constructor, currently only used for legato
 PADnote::PADnote(const PADnote &orig) :
-    ready(1),
     finished_(orig.finished_),
     pars(orig.pars),
     poshi_l(orig.poshi_l),
@@ -497,7 +493,7 @@ int PADnote::noteout(float *outl,float *outr)
 
     computecurrentparameters();
     float *smps = pars->sample[nsample].smp;
-    if (smps == NULL || (legatoFade == 0.0f && legatoFadeStep == 0.0f))
+    if (smps == NULL)
     {
         memset(outl, 0, synth->sent_buffersize * sizeof(float));
         memset(outr, 0, synth->sent_buffersize * sizeof(float));

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -44,7 +44,7 @@ using synth::aboveAmplitudeThreshold;
 
 
 PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
-    float velocity, int portamento_, int midinote, bool besilent, SynthEngine *_synth) :
+    float velocity, int portamento_, int midinote_, bool besilent, SynthEngine *_synth) :
     ready(false),
     finished_(false),
     pars(parameters),
@@ -52,27 +52,17 @@ PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
     released(false),
     nsample(0),
     portamento(portamento_),
+    midinote(midinote_),
     ctl(ctl_),
+    legatoFade(1.0f), // Full volume
+    legatoFadeStep(0.0f), // Legato disabled
     padSynthUpdate(parameters),
     synth(_synth)
 
 {
-    // Initialise some legato-specific vars
-    Legato.msg = LM_Norm;
-    Legato.fade.length = int(synth->samplerate_f * 0.005f); // 0.005 seems ok.
-    if (Legato.fade.length < 1)
-        Legato.fade.length = 1; // (if something's fishy)
-    Legato.fade.step = (1.0 / Legato.fade.length);
-    Legato.decounter = -10;
-    Legato.param.freq = freq;
-    Legato.param.vel = velocity;
-    Legato.param.portamento = portamento_;
-    Legato.param.midinote = midinote;
-    Legato.silent = besilent;
-
     this->velocity = velocity;
 
-    setBaseFreq();
+    setBaseFreq(freq);
 
     realfreq = basefreq;
 
@@ -141,67 +131,139 @@ PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
 }
 
 
-// PADlegatonote: This function is (mostly) a copy of PADnote(...)
-// with some lines removed so that it only alter the already playing
-// note (to perform legato). It is possible I left stuff that is not
-// required for this.
-void PADnote::PADlegatonote(float freq, float velocity,
-                            int portamento_, int midinote, bool externcall)
+// Copy constructor, currently only used for legato
+PADnote::PADnote(const PADnote &orig) :
+    ready(1),
+    finished_(orig.finished_),
+    pars(orig.pars),
+    poshi_l(orig.poshi_l),
+    poshi_r(orig.poshi_r),
+    poslo(orig.poslo),
+    basefreq(orig.basefreq),
+    BendAdjust(orig.BendAdjust),
+    OffsetHz(orig.OffsetHz),
+    firsttime(orig.firsttime),
+    released(orig.released),
+    nsample(orig.nsample),
+    portamento(orig.portamento),
+    ctl(orig.ctl),
+    globaloldamplitude(orig.globaloldamplitude),
+    globalnewamplitude(orig.globalnewamplitude),
+    velocity(orig.velocity),
+    realfreq(orig.realfreq),
+    randpanL(orig.randpanL),
+    randpanR(orig.randpanR),
+    legatoFade(0.0f), // Silent by default
+    legatoFadeStep(0.0f), // Legato disabled
+    padSynthUpdate(pars),
+    synth(orig.synth)
 {
-    PADnoteParameters *parameters = pars;
-    // Controller *ctl_=ctl; (an original comment)
+    auto &gpar = NoteGlobalPar;
+    auto &oldgpar = orig.NoteGlobalPar;
 
-    // Manage legato stuff
-    if (externcall)
-        Legato.msg = LM_Norm;
-    if (Legato.msg != LM_CatchUp)
-    {
-        Legato.lastfreq = Legato.param.freq;
-        Legato.param.freq = freq;
-        Legato.param.vel = velocity;
-        Legato.param.portamento = portamento_;
-        Legato.param.midinote = midinote;
-        if (Legato.msg == LM_Norm)
-        {
-            if (Legato.silent)
-            {
-                Legato.fade.m = 0.0;
-                Legato.msg = LM_FadeIn;
-            }
-            else
-            {
-                Legato.fade.m = 1.0;
-                Legato.msg = LM_FadeOut;
-                return;
-            }
-        }
-        if (Legato.msg == LM_ToNorm)
-            Legato.msg = LM_Norm;
-    }
+    gpar.Detune = oldgpar.Detune;
+    gpar.Volume = oldgpar.Volume;
+    gpar.Panning = oldgpar.Panning;
 
-    portamento = portamento_;
-    this->velocity = velocity;
-    finished_ = false;
+    gpar.Fadein_adjustment = oldgpar.Fadein_adjustment;
+    gpar.Punch = oldgpar.Punch;
 
-    setBaseFreq();
+    gpar.FilterCenterPitch = oldgpar.FilterCenterPitch;
+    gpar.FilterQ = oldgpar.FilterQ;
+    gpar.FilterFreqTracking = oldgpar.FilterFreqTracking;
 
-    released = false;
-    realfreq = basefreq;
+    // These are never null
+    gpar.FreqEnvelope = new Envelope(*oldgpar.FreqEnvelope);
+    gpar.FreqLfo = new LFO(*oldgpar.FreqLfo);
+    gpar.AmpEnvelope = new Envelope(*oldgpar.AmpEnvelope);
+    gpar.AmpLfo = new LFO(*oldgpar.AmpLfo);
 
-    NoteGlobalPar.AmpEnvelope->envout_dB(); // discard the first envelope output
+    gpar.GlobalFilterL = new Filter(*oldgpar.GlobalFilterL);
+    gpar.GlobalFilterR = new Filter(*oldgpar.GlobalFilterR);
 
-    computeNoteParameters();
+    gpar.FilterEnvelope = new Envelope(*oldgpar.FilterEnvelope);
+    gpar.FilterLfo = new LFO(*oldgpar.FilterLfo);
+}
 
-    globaloldamplitude =
-        globalnewamplitude =
-            NoteGlobalPar.Volume * NoteGlobalPar.AmpEnvelope->envout_dB()
-                * NoteGlobalPar.AmpLfo->amplfoout();
 
-    if (parameters->sample[nsample].smp == NULL)
+void PADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_)
+{
+    if (pars->sample[nsample].smp == NULL)
     {
         finished_ = true;
         return;
     }
+
+    velocity = velocity_;
+    portamento = portamento_;
+    midinote = midinote_;
+
+    setBaseFreq(freq_);
+
+    computeNoteParameters();
+
+    globalnewamplitude = NoteGlobalPar.Volume
+        * NoteGlobalPar.AmpEnvelope->envout_dB()
+        * NoteGlobalPar.AmpLfo->amplfoout();
+    globaloldamplitude = globalnewamplitude;
+
+    if (!portamento) // Do not crossfade portamento
+    {
+        legatoFade = 0.0f; // Start silent
+        legatoFadeStep = 1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, positive steps
+    }
+}
+
+
+void PADnote::legatoFadeOut(const PADnote &orig)
+{
+    velocity = orig.velocity;
+    portamento = orig.portamento;
+    midinote = orig.midinote;
+
+    poshi_l = orig.poshi_l;
+    poshi_r = orig.poshi_r;
+    poslo = orig.poslo;
+    basefreq = orig.basefreq;
+    BendAdjust = orig.BendAdjust;
+    OffsetHz = orig.OffsetHz;
+    firsttime = orig.firsttime;
+    released = orig.released;
+    nsample = orig.nsample;
+    portamento = orig.portamento;
+    globaloldamplitude = orig.globaloldamplitude;
+    globalnewamplitude = orig.globalnewamplitude;
+    realfreq = orig.realfreq;
+    randpanL = orig.randpanL;
+    randpanR = orig.randpanR;
+
+    auto &gpar = NoteGlobalPar;
+    auto &oldgpar = orig.NoteGlobalPar;
+
+    gpar.Detune = oldgpar.Detune;
+    gpar.Volume = oldgpar.Volume;
+    gpar.Panning = oldgpar.Panning;
+
+    gpar.Fadein_adjustment = oldgpar.Fadein_adjustment;
+    gpar.Punch = oldgpar.Punch;
+
+    *gpar.FreqEnvelope = *oldgpar.FreqEnvelope;
+    *gpar.FreqLfo = *oldgpar.FreqLfo;
+    *gpar.AmpEnvelope = *oldgpar.AmpEnvelope;
+    *gpar.AmpLfo = *oldgpar.AmpLfo;
+
+    *gpar.FilterEnvelope = *oldgpar.FilterEnvelope;
+    *gpar.FilterLfo = *oldgpar.FilterLfo;
+
+    // Supporting virtual copy assignment would be hairy
+    // so we have to use the copy constructor here
+    delete gpar.GlobalFilterL;
+    gpar.GlobalFilterL = new Filter(*oldgpar.GlobalFilterL);
+    delete gpar.GlobalFilterR;
+    gpar.GlobalFilterR = new Filter(*oldgpar.GlobalFilterR);
+
+    legatoFade = 1.0f; // Start at full volume
+    legatoFadeStep = -1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, negative steps
 }
 
 
@@ -218,17 +280,17 @@ PADnote::~PADnote()
 }
 
 
-void PADnote::setBaseFreq()
+void PADnote::setBaseFreq(float basefreq_)
 {
     if (pars->Pfixedfreq == 0)
-        basefreq = Legato.param.freq;
+        basefreq = basefreq_;
     else
     {
         basefreq = 440.0f;
         int fixedfreqET = pars->PfixedfreqET;
         if (fixedfreqET != 0)
         {   // if the frequency varies according the keyboard note
-            float tmp = (Legato.param.midinote - 69.0f) / 12.0f
+            float tmp = (midinote - 69.0f) / 12.0f
                               * (powf(2.0f, (fixedfreqET - 1) / 63.0f) - 1.0f);
             if (fixedfreqET <= 64)
                 basefreq *= powf(2.0f, tmp);
@@ -263,7 +325,7 @@ inline void PADnote::fadein(float *smps)
 
 void PADnote::computeNoteParameters()
 {
-    setBaseFreq();
+    setBaseFreq(basefreq);
 
     int BendAdj = pars->PBendAdjust - 64;
     if (BendAdj % 24 == 0)
@@ -435,7 +497,7 @@ int PADnote::noteout(float *outl,float *outr)
 
     computecurrentparameters();
     float *smps = pars->sample[nsample].smp;
-    if (smps == NULL)
+    if (smps == NULL || (legatoFade == 0.0f && legatoFadeStep == 0.0f))
     {
         memset(outl, 0, synth->sent_buffersize * sizeof(float));
         memset(outr, 0, synth->sent_buffersize * sizeof(float));
@@ -509,91 +571,29 @@ int PADnote::noteout(float *outl,float *outr)
         }
     }
 
-    // Apply legato-specific sound signal modifications
-    if (Legato.silent)
-    { // Silencer
-        if (Legato.msg != LM_FadeIn)
-        {
-            memset(outl, 0, synth->sent_bufferbytes);
-            memset(outr, 0, synth->sent_bufferbytes);
-        }
-    }
-    switch (Legato.msg)
+    // Apply legato fading if any
+    if (legatoFadeStep != 0.0f)
     {
-        case LM_CatchUp : // Continue the catch-up...
-            if (Legato.decounter == -10)
-                Legato.decounter = Legato.fade.length;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
-            {   //Yea, could be done without the loop...
-                Legato.decounter--;
-                if (Legato.decounter < 1)
-                {
-                    synth->part[synth->legatoPart]->legatoFading &= 3;
-                    // Catching-up done, we can finally set
-                    // the note to the actual parameters.
-                    Legato.decounter = -10;
-                    Legato.msg = LM_ToNorm;
-                    PADlegatonote(Legato.param.freq, Legato.param.vel,
-                                  Legato.param.portamento, Legato.param.midinote,
-                                  false);
-                    break;
-                }
-            }
-            break;
-
-        case LM_FadeIn : // Fade-in
-            if (Legato.decounter == -10)
-                Legato.decounter = Legato.fade.length;
-            Legato.silent = false;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+        for (int i = 0; i < synth->sent_buffersize; ++i)
+        {
+            legatoFade += legatoFadeStep;
+            if (legatoFade <= 0.0f)
             {
-                Legato.decounter--;
-                if (Legato.decounter < 1)
-                {
-                    Legato.decounter = -10;
-                    Legato.msg = LM_Norm;
-                    break;
-                }
-                Legato.fade.m += Legato.fade.step;
-                outl[i] *= Legato.fade.m;
-                outr[i] *= Legato.fade.m;
+                legatoFade = 0.0f;
+                legatoFadeStep = 0.0f;
+                memset(outl + i, 0, (synth->sent_buffersize - i) * sizeof(float));
+                memset(outr + i, 0, (synth->sent_buffersize - i) * sizeof(float));
+                break;
             }
-            break;
-
-        case LM_FadeOut : // Fade-out, then set the catch-up
-            if (Legato.decounter == -10)
-                Legato.decounter = Legato.fade.length;
-            for (int i = 0; i < synth->sent_buffersize; ++i)
+            else if (legatoFade >= 1.0f)
             {
-                Legato.decounter--;
-                if (Legato.decounter < 1)
-                {
-                    for (int j = i; j < synth->sent_buffersize; ++j)
-                        outl[j] = outr[j] = 0.0;
-                    Legato.decounter = -10;
-                    Legato.silent = true;
-                    // Fading-out done, now set the catch-up :
-                    Legato.decounter = Legato.fade.length;
-                    Legato.msg = LM_CatchUp;
-                    float catchupfreq =
-                        Legato.param.freq * (Legato.param.freq / Legato.lastfreq);
-                        // This freq should make this now silent note to catch-up
-                        // (or should I say resync ?) with the heard note for
-                        // the same length it stayed at the previous freq during
-                        // the fadeout.
-                    PADlegatonote(catchupfreq, Legato.param.vel,
-                                  Legato.param.portamento, Legato.param.midinote,
-                                  false);
-                    break;
-                }
-                Legato.fade.m -= Legato.fade.step;
-                outl[i] *= Legato.fade.m;
-                outr[i] *= Legato.fade.m;
+                legatoFade = 1.0f;
+                legatoFadeStep = 0.0f;
+                break;
             }
-            break;
-
-        default :
-            break;
+            outl[i] *= legatoFade;
+            outr[i] *= legatoFade;
+        }
     }
 
     // Check if the global amplitude is finished.

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -44,7 +44,7 @@ using synth::aboveAmplitudeThreshold;
 
 
 PADnote::PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
-    float velocity, int portamento_, int midinote_, bool besilent, SynthEngine *_synth) :
+    float velocity, int portamento_, int midinote_, SynthEngine *_synth) :
     ready(false),
     finished_(false),
     pars(parameters),

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -206,7 +206,7 @@ void PADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mi
     if (!portamento) // Do not crossfade portamento
     {
         legatoFade = 0.0f; // Start silent
-        legatoFadeStep = 1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, positive steps
+        legatoFadeStep = synth->fadeStepShort; // Positive steps
     }
 }
 
@@ -259,7 +259,7 @@ void PADnote::legatoFadeOut(const PADnote &orig)
     gpar.GlobalFilterR = new Filter(*oldgpar.GlobalFilterR);
 
     legatoFade = 1.0f; // Start at full volume
-    legatoFadeStep = -1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, negative steps
+    legatoFadeStep = -synth->fadeStepShort; // Negative steps
 }
 
 

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -196,8 +196,6 @@ void PADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mi
 
     setBaseFreq(freq_);
 
-    computeNoteParameters();
-
     globalnewamplitude = NoteGlobalPar.Volume
         * NoteGlobalPar.AmpEnvelope->envout_dB()
         * NoteGlobalPar.AmpLfo->amplfoout();
@@ -207,6 +205,8 @@ void PADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mi
     {
         legatoFade = 0.0f; // Start silent
         legatoFadeStep = synth->fadeStepShort; // Positive steps
+
+        computeNoteParameters();
     }
 }
 

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -51,7 +51,11 @@ class PADnote
         void legatoFadeOut(const PADnote &orig);
 
         int noteout(float *outl,float *outr);
-        bool finished(void) { return finished_; };
+        bool finished() const
+        {
+            return NoteStatus == NOTE_DISABLED ||
+                (NoteStatus != NOTE_KEEPALIVE && legatoFade == 0.0f);
+        }
         void releasekey(void);
 
         // Whether the note has samples to output.
@@ -63,7 +67,11 @@ class PADnote
         void computeNoteParameters();
         void computecurrentparameters();
         void setBaseFreq(float basefreq_);
-        bool finished_;
+        enum {
+            NOTE_DISABLED,
+            NOTE_ENABLED,
+            NOTE_KEEPALIVE
+        } NoteStatus;
         PADnoteParameters *pars;
 
         int poshi_l;

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -43,11 +43,12 @@ class PADnote
 {
     public:
         PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
-                float velocity, int portamento_, int midinote, bool besilent, SynthEngine *_synth);
+                float velocity, int portamento_, int midinote_, bool besilent, SynthEngine *_synth);
+        PADnote(const PADnote &orig);
         ~PADnote();
 
-        void PADlegatonote(float freq, float velocity,
-                           int portamento_, int midinote, bool externcall);
+        void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
+        void legatoFadeOut(const PADnote &orig);
 
         int noteout(float *outl,float *outr);
         bool finished(void) { return finished_; };
@@ -59,7 +60,7 @@ class PADnote
         void fadein(float *smps);
         void computeNoteParameters();
         void computecurrentparameters();
-        void setBaseFreq();
+        void setBaseFreq(float basefreq_);
         bool finished_;
         PADnoteParameters *pars;
 
@@ -73,7 +74,7 @@ class PADnote
         bool firsttime;
         bool released;
 
-        int nsample, portamento;
+        int nsample, portamento, midinote;
 
         int Compute_Linear(float *outl, float *outr, int freqhi,
                            float freqlo);
@@ -134,26 +135,8 @@ class PADnote
         float randpanR;
 
         // Legato vars
-        struct {
-            bool silent;
-            float lastfreq;
-            LegatoMsg msg;
-            int decounter;
-            struct {
-                // Fade In/Out vars
-                int length;
-                float m;
-                float step;
-            } fade;
-
-            struct {
-                // Note parameters
-                float freq;
-                float vel;
-                int portamento;
-                int midinote;
-            } param;
-        } Legato;
+        float legatoFade;
+        float legatoFadeStep;
 
         Presets::PresetsUpdate padSynthUpdate;
 

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -54,7 +54,9 @@ class PADnote
         bool finished(void) { return finished_; };
         void releasekey(void);
 
-        bool ready;
+        // Whether the note has samples to output.
+        // Currently only used for dormant legato notes.
+        bool ready() { return legatoFade != 0.0f || legatoFadeStep != 0.0f; };
 
     private:
         void fadein(float *smps);

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -43,7 +43,7 @@ class PADnote
 {
     public:
         PADnote(PADnoteParameters *parameters, Controller *ctl_, float freq,
-                float velocity, int portamento_, int midinote_, bool besilent, SynthEngine *_synth);
+                float velocity, int portamento_, int midinote_, SynthEngine *_synth);
         PADnote(const PADnote &orig);
         ~PADnote();
 

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -190,7 +190,7 @@ void SUBnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mi
     if (!portamento) // Do not crossfade portamento
     {
         legatoFade = 0.0f; // Start silent
-        legatoFadeStep = 1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, positive steps
+        legatoFadeStep = synth->fadeStepShort; // Positive steps
 
         // I'm not sure if these are necessary or even beneficial
         oldpitchwheel = 0;
@@ -260,7 +260,7 @@ void SUBnote::legatoFadeOut(const SUBnote &orig)
         numharmonics * sizeof(float));
 
     legatoFade = 1.0f; // Start at full volume
-    legatoFadeStep = -1.0f / (synth->samplerate_f * 0.005f); // 5ms fade, negative steps
+    legatoFadeStep = -synth->fadeStepShort; // Negative steps
 }
 
 

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -45,7 +45,7 @@ using synth::aboveAmplitudeThreshold;
 
 
 SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
-                 float velocity_, int portamento_, int midinote_, bool besilent, SynthEngine *_synth) :
+                 float velocity_, int portamento_, int midinote_, SynthEngine *_synth) :
     pars(parameters),
     velocity(velocity_ > 1.0f ? 1.0f : velocity_),
     portamento(portamento_),

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -70,9 +70,6 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     synth(_synth),
     filterStep(0)
 {
-    // This probably isn't correct, see the ADnote copy constructor
-    ready = 0;
-
     // Initialise some legato-specific vars
     legatoFade = 1.0f; // Full volume
     legatoFadeStep = 0.0f; // Legato disabled
@@ -106,13 +103,11 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     computecurrentparameters();
 
     oldamplitude = newamplitude;
-    ready = 1;
 }
 
 
 // Copy constructor, currently only exists for legato
 SUBnote::SUBnote(const SUBnote &orig) :
-    ready(1),
     pars(orig.pars),
     stereo(orig.stereo),
     numstages(orig.numstages),
@@ -714,8 +709,6 @@ int SUBnote::noteout(float *outl, float *outr)
     memset(outr, 0, synth->sent_bufferbytes);
     if (!NoteEnabled)
         return 0;
-    if (legatoFade == 0.0f && legatoFadeStep == 0.0f)
-        return 1; // No need to process more, but don't kill the note
 
     if (subNoteChange.checkUpdated())
     {

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -44,6 +44,18 @@ using synth::interpolateAmplitude;
 using synth::aboveAmplitudeThreshold;
 
 
+// These have little reason to exist, as GCC actually performs constant folding
+// on logf even on -O0 and Clang (currently, as of 9.0.1) constant-folds these
+// on -O1 and above. These used to be members of SUBnote initialized on note
+// construction. Thankfully constant folding would still occur, but it wasn't
+// ideal. Older compilers might generate library calls, so there might still be
+// some justification for this.
+const float LOG_0_01 = logf(0.01f);
+const float LOG_0_001 = logf(0.001f);
+const float LOG_0_0001 = logf(0.0001f);
+const float LOG_0_00001 = logf(0.00001f);
+
+
 SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
                  float velocity_, int portamento_, int midinote_, SynthEngine *_synth) :
     pars(parameters),
@@ -54,10 +66,6 @@ SUBnote::SUBnote(SUBnoteParameters *parameters, Controller *ctl_, float freq,
     GlobalFilterR(NULL),
     GlobalFilterEnvelope(NULL),
     ctl(ctl_),
-    log_0_01(logf(0.01f)),
-    log_0_001(logf(0.001f)),
-    log_0_0001(logf(0.0001f)),
-    log_0_00001(logf(0.00001f)),
     subNoteChange(parameters),
     synth(_synth),
     filterStep(0)
@@ -138,10 +146,6 @@ SUBnote::SUBnote(const SUBnote &orig) :
     globalfiltercenterq(orig.globalfiltercenterq),
     legatoFade(0.0f), // Silent by default
     legatoFadeStep(0.0f), // Legato disabled
-    log_0_01(logf(0.01f)), //TODO: make these static
-    log_0_001(logf(0.001f)),
-    log_0_0001(logf(0.0001f)),
-    log_0_00001(logf(0.00001f)),
     subNoteChange(pars),
     synth(orig.synth),
     filterStep(orig.filterStep)
@@ -863,19 +867,19 @@ float SUBnote::getHgain(int harmonic)
     switch (pars->Phmagtype)
     {
         case 1:
-            hgain = expf(hmagnew * log_0_01);
+            hgain = expf(hmagnew * LOG_0_01);
             break;
 
         case 2:
-            hgain = expf(hmagnew * log_0_001);
+            hgain = expf(hmagnew * LOG_0_001);
             break;
 
         case 3:
-            hgain = expf(hmagnew * log_0_0001);
+            hgain = expf(hmagnew * LOG_0_0001);
             break;
 
         case 4:
-            hgain = expf(hmagnew * log_0_00001);
+            hgain = expf(hmagnew * LOG_0_00001);
             break;
 
         default:

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -52,7 +52,11 @@ class SUBnote
         int noteout(float *outl,float *outr); // note output, return 0 if the
                                               // note is finished
         void releasekey(void);
-        bool finished(void) { return !NoteEnabled; }
+        bool finished() const
+        {
+            return NoteStatus == NOTE_DISABLED ||
+                (NoteStatus != NOTE_KEEPALIVE && legatoFade == 0.0f);
+        }
 
         // Whether the note has samples to output.
         // Currently only used for dormant legato notes.
@@ -89,7 +93,11 @@ class SUBnote
         Envelope *GlobalFilterEnvelope;
 
         // internal values
-        bool NoteEnabled;
+        enum {
+            NOTE_DISABLED,
+            NOTE_ENABLED,
+            NOTE_KEEPALIVE
+        } NoteStatus;
         int firsttick;
         float volume;
         float oldamplitude;

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -142,11 +142,6 @@ class SUBnote
         float legatoFade;
         float legatoFadeStep;
 
-        const float log_0_01;    // logf(0.01);
-        const float log_0_001;   // logf(0.001);
-        const float log_0_0001;  // logf(0.0001);
-        const float log_0_00001; // logf(0.00001);
-
         Presets::PresetsUpdate subNoteChange;
 
         SynthEngine *synth;

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -54,7 +54,9 @@ class SUBnote
         void releasekey(void);
         bool finished(void) { return !NoteEnabled; }
 
-        bool ready; // if I can get the sampledata
+        // Whether the note has samples to output.
+        // Currently only used for dormant legato notes.
+        bool ready() { return legatoFade != 0.0f || legatoFadeStep != 0.0f; };
 
     private:
         void computecurrentparameters(void);

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -41,12 +41,13 @@ class SUBnote
 {
     public:
         SUBnote(SUBnoteParameters *parameters, Controller *ctl_,
-                float freq, float velocity, int portamento_,
-                int midinote, bool besilent, SynthEngine *_synth);
+                float freq_, float velocity_, int portamento_,
+                int midinote_, bool besilent, SynthEngine *_synth);
+        SUBnote(const SUBnote &rhs);
         ~SUBnote();
 
-        void SUBlegatonote(float freq, float velocity,
-                           int portamento_, int midinote, bool externcall);
+        void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
+        void legatoFadeOut(const SUBnote &syncwith);
 
         int noteout(float *outl,float *outr); // note output, return 0 if the
                                               // note is finished
@@ -69,6 +70,9 @@ class SUBnote
         int numharmonics; // number of harmonics (after the too higher hamonics are removed)
         int start; // how the harmonics start
         float basefreq;
+        float velocity;
+        int portamento;
+        int midinote;
         float BendAdjust;
         float OffsetHz;
         float randpanL;
@@ -85,7 +89,6 @@ class SUBnote
         // internal values
         bool NoteEnabled;
         int firsttick;
-        int portamento;
         float volume;
         float oldamplitude;
         float newamplitude;
@@ -116,7 +119,7 @@ class SUBnote
         void computeallfiltercoefs();
         void computefiltercoefs(bpfilter &filter, float freq, float bw, float gain);
         void computeNoteParameters();
-        void setBaseFreq();
+        void setBaseFreq(float basefreq_);
         void filter(bpfilter &filter, float *smps);
         void filterVarRun(bpfilter &filter, float *smps);
         float getHgain(int harmonic);
@@ -136,26 +139,8 @@ class SUBnote
         float globalfiltercenterq;
 
         // Legato vars
-        struct {
-            bool silent;
-            float lastfreq;
-            LegatoMsg msg;
-            int decounter;
-            struct {
-                // Fade In/Out vars
-                int length;
-                float m;
-                float step;
-            } fade;
-
-            struct {
-                // Note parameters
-                float freq;
-                float vel;
-                int portamento;
-                int midinote;
-            } param;
-        } Legato;
+        float legatoFade;
+        float legatoFadeStep;
 
         const float log_0_01;    // logf(0.01);
         const float log_0_001;   // logf(0.001);

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -42,7 +42,7 @@ class SUBnote
     public:
         SUBnote(SUBnoteParameters *parameters, Controller *ctl_,
                 float freq_, float velocity_, int portamento_,
-                int midinote_, bool besilent, SynthEngine *_synth);
+                int midinote_, SynthEngine *_synth);
         SUBnote(const SUBnote &rhs);
         ~SUBnote();
 


### PR DESCRIPTION
Currently, legato is all kinds of broken (see #51). Crossfading is attempted, but doesn't work correctly and actually causes the kind of harsh transients it attempts to prevent. The current method is overengineered, doing much more work than necessary, and it is fragile enough that trying to play a new note before the crossfade is completed (admittedly it only lasts 5ms) is actually prevented entirely.

This fixes all of that. Legato is entirely reimplemented for all three synth engines, and seems to work fine after testing. Legato with or without portamento should result in a smooth transition in all cases, regardless of the synth engines used.

Portamento no longer triggers harmonic re-randomization in ADSynth, which was one source of glitchy sound, but regular legato still does, as crossfading works now and the change in timbre is probably desired in this case. I chose this behaviour based on the assumption that a plain legato transition is still effectively a new note with no attack, while portamento is equivalent to pitch bend, just controlled in a different way. It may be desirable to be able to disable harmonic re-randomization for plain legato notes, or possibly enable a smooth transition from one timbre to another during portamento.

This works by reimplementing legato as simply setting the parameters of the playing note to the new ones in the NoteOn MIDI message, setting it to start fading in from 0 gain, and cloning the note to another, which is then set to fade out at the same rate.

Like the old method, each note played in legato mode while no others are being played spawns an extra note which is silent by default and gets used as one half of the crossfade. Unlike the old method, the silent note does not perform any computation while it is silent, as it resyncs by copying the relevant internal parameters from the audible note when starting a crossfade. Also unlike the old method, the duplicate note which starts silent (kept track of by `posb` in `Misc/Part.cpp`) is only used for fading out, rather than the last note to fade out being used to fade in and vice versa. As the `posb` note is now a perfect clone of the `posa` note right before a crossfade begins, there is no need for the extra complexity. Portamento does not use posb at all as the smooth change in frequency does not create anything that needs a crossfade to smooth over.

One limitation that I have not yet been able to work around is due to the way PADSynth works. PADSynth generates multiple wavetables of a fixed number of samples but with different base frequencies. It does this so that the tables can be read at the appropriate sample rate for the desired "real frequency" of the note without worrying about aliasing when high frequencies are shifted above the Nyquist limit. Without some form of precomputation like this, the table would have to be low-pass filtered at runtime before being resampled. This might actually be a more desirable method to use in some respects, but there are good reasons to do it this way, too.

PADSynth using multiple wavetables in this way is a problem because there is no connection or possible "splice point" between any pair of tables, so the table a note uses can't be changed seamlessly while the note is playing. I did some experimenting by making PADSynth generate all the tables using the same randomized set of phases for each table rather than randomizing separately for each table, but I quickly found (with the help of the export feature so I could look at the tables directly in an audio editor) that the fact the amplitudes were different for each table made the waveform in each table too different from that of every other even with the phases matched, no matter where you decided to splice them after resampling. It seems obvious in hindsight, but it was still interesting to explore.

The best way to solve the PADSynth issue is probably to crossfade when doing portamento on a `PADnote`, but this would need special logic to do right. The existing portamento logic depends on `basefreq`, so the frequency doesn't match between the halves of the crossfade if you just enable crossfading for PADSynth portamento and turn on portamento for the fading-out note too. A proper fix would likely work in `PADnote` itself, and take into account the possibility of moving across multiple tables in one slide. In fact, a proper fix should probably work for pitch bend as well as portamento.

As I have it currently, portamento just keeps the same wavetable, just as when pitch bend is used. When shifting up a lot in pitch (more than half an octave or so, but it depends heavily on the high-frequency content of the oscillator used to generate the tables) aliasing is audible, and when shifting down a lot in pitch the sound is effectively low-pass filtered.

See https://github.com/Yoshimi/yoshimi/issues/51#issuecomment-598765371 for a detailed description of the previous legato implementation and its bugs.

Closes #51