### PR TITLE
Several more fixes to ADnote legato

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -451,6 +451,8 @@ void Part::NoteOn(int note, int velocity, bool renote)
         {
             partnote[posb].status = KEY_PLAYING;
             partnote[posb].note = note;
+            partnote[posb].keyATtype = PART::aftertouchType::off;
+            partnote[posb].keyATvalue = 0;
         }
 
         // compute the velocity offset

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -371,7 +371,7 @@ ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
             ADnote *parentVoice = (origVoice != NULL) ? origVoice : this;
             for (int k = 0; k < orig.unison_size[i]; ++k)
             {
-                subFMVoice[i][k] = new ADnote(*orig.subVoice[i][k], parentVoice, parentFMmod);
+                subFMVoice[i][k] = new ADnote(*orig.subFMVoice[i][k], parentVoice, parentFMmod);
             }
         }
         else

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -61,7 +61,7 @@ ADnote::ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_,
     forFM(false),
     portamento(portamento_),
     subVoiceNumber(-1),
-    origVoice(NULL),
+    origVoice(this),
     parentFMmod(NULL),
     paramsUpdate(adpars),
     synth(_synth)
@@ -118,7 +118,7 @@ ADnote::ADnote(const ADnote &orig, ADnote *origVoice_, float *parentFMmod_) :
     pangainL(orig.pangainL),
     pangainR(orig.pangainR),
     subVoiceNumber(orig.subVoiceNumber),
-    origVoice(origVoice_),
+    origVoice((origVoice_ != NULL) ? origVoice_ : this),
     parentFMmod(parentFMmod_),
     paramsUpdate(adpars),
     synth(orig.synth)
@@ -353,10 +353,9 @@ ADnote::ADnote(const ADnote &orig, ADnote *origVoice_, float *parentFMmod_) :
         if (orig.subVoice[i] != NULL)
         {
             subVoice[i] = new ADnote*[orig.unison_size[i]];
-            ADnote *parentVoice = (origVoice != NULL) ? origVoice : this;
             for (int k = 0; k < orig.unison_size[i]; ++k)
             {
-                subVoice[i][k] = new ADnote(*orig.subVoice[i][k], parentVoice, freqbasedmod[i] ? tmpmod_unison[k] : parentFMmod);
+                subVoice[i][k] = new ADnote(*orig.subVoice[i][k], origVoice, freqbasedmod[i] ? tmpmod_unison[k] : parentFMmod);
             }
         }
         else
@@ -365,10 +364,9 @@ ADnote::ADnote(const ADnote &orig, ADnote *origVoice_, float *parentFMmod_) :
         if (orig.subFMVoice[i] != NULL)
         {
             subFMVoice[i] = new ADnote*[orig.unison_size[i]];
-            ADnote *parentVoice = (origVoice != NULL) ? origVoice : this;
             for (int k = 0; k < orig.unison_size[i]; ++k)
             {
-                subFMVoice[i][k] = new ADnote(*orig.subFMVoice[i][k], parentVoice, parentFMmod);
+                subFMVoice[i][k] = new ADnote(*orig.subFMVoice[i][k], origVoice, parentFMmod);
             }
         }
         else
@@ -655,7 +653,7 @@ void ADnote::initSubVoices(void)
             subVoice[nvoice] = new ADnote*[unison_size[nvoice]];
             for (int k = 0; k < unison_size[nvoice]; ++k) {
                 float *freqmod = freqbasedmod[nvoice] ? tmpmod_unison[k] : parentFMmod;
-                subVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                subVoice[nvoice][k] = new ADnote(origVoice,
                                                  getVoiceBaseFreq(nvoice),
                                                  NoteVoicePar[nvoice].Voice,
                                                  freqmod, forFM);
@@ -667,7 +665,7 @@ void ADnote::initSubVoices(void)
             bool voiceForFM = NoteVoicePar[nvoice].FMEnabled == FREQ_MOD;
             subFMVoice[nvoice] = new ADnote*[unison_size[nvoice]];
             for (int k = 0; k < unison_size[nvoice]; ++k) {
-                subFMVoice[nvoice][k] = new ADnote((origVoice != NULL) ? origVoice : this,
+                subFMVoice[nvoice][k] = new ADnote(origVoice,
                                                    getFMVoiceBaseFreq(nvoice),
                                                    NoteVoicePar[nvoice].FMVoice,
                                                    parentFMmod, voiceForFM);

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -269,7 +269,7 @@ ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
         }
         // NoteVoicePar done
 
-        int unison = adpars->VoicePar[i].Unison_size;
+        int unison = unison_size[i];
 
         oscfreqhi[i] = new int[unison];
         memcpy(oscfreqhi[i], orig.oscfreqhi[i], unison * sizeof(int));

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -91,7 +91,7 @@ ADnote::ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmo
 }
 
 // Copy constructor, currently only exists for legato
-ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
+ADnote::ADnote(const ADnote &orig, ADnote *origVoice_, float *parentFMmod_) :
     adpars(orig.adpars), // Probably okay for legato?
     stereo(orig.stereo),
     midinote(orig.midinote),
@@ -118,7 +118,7 @@ ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
     pangainL(orig.pangainL),
     pangainR(orig.pangainR),
     subVoiceNumber(orig.subVoiceNumber),
-    origVoice(parent),
+    origVoice(origVoice_),
     parentFMmod(parentFMmod_),
     paramsUpdate(adpars),
     synth(orig.synth)
@@ -151,9 +151,6 @@ ADnote::ADnote(const ADnote &orig, ADnote *parent, float *parentFMmod_) :
         tmpwave_unison[i] = (float*)fftwf_malloc(synth->bufferbytes);
         tmpmod_unison[i] = (float*)fftwf_malloc(synth->bufferbytes);
     }
-
-    if (parent != NULL && parent->origVoice != NULL)
-        origVoice = parent->origVoice;
 
     for (int i = 0; i < NUM_VOICES; ++i)
     {

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -51,7 +51,7 @@ class ADnote
     public:
         ADnote(ADnoteParameters *adpars_, Controller *ctl_, float freq_, float velocity_,
                int portamento_, int midinote_, SynthEngine *_synth);
-        ADnote(ADnote *parent, float freq_, int subVoiceNumber_, float *parentFMmod_,
+        ADnote(ADnote *orig, float freq_, int subVoiceNumber_, float *parentFMmod_,
                bool forFM_);
         ADnote(const ADnote &orig, ADnote *origVoice_ = NULL, float *parentFMmod_ = NULL);
         ~ADnote();

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -53,7 +53,7 @@ class ADnote
                int portamento_, int midinote_, SynthEngine *_synth);
         ADnote(ADnote *parent, float freq_, int subVoiceNumber_, float *parentFMmod_,
                bool forFM_);
-        ADnote(const ADnote &orig, ADnote *parent = NULL, float *parentFMmod = NULL);
+        ADnote(const ADnote &orig, ADnote *origVoice_ = NULL, float *parentFMmod_ = NULL);
         ~ADnote();
 
         void construct();


### PR DESCRIPTION
I found a couple of pretty major bugs with my earlier reimplementation of legato (5984640b43c89f83a16242078563721c8d7ba7c7, b2524a649c55dfae6bf89257e9a3f72872e5244c), fixed one bug introduced by Will that only affected legato notes (c3403300b1ec2060fc421860a4ddf1e5d1961886), cleaned up Kristian's fix-that-actually-wasn't (22313e686f59b84b838be6885faeaf616642d8ac), then improved the `origVoice` logic further after a realization I had while looking over Kristian's commit (c1a25a032c6c85afc34a9fc17ef5f009937f53ba).

I also renamed one of the args in one of the ADnote constructors in the header to be consistent with its name in the source file (1cd472df73e652ae904f47a1a537934d28033ce1). It doesn't deserve its own PR, so it ends up here.