### PR TITLE
Some ADsynth fixes

### DIFF
--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1898,7 +1898,19 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
         computeVoiceModulatorLinearInterpolation(nvoice);
     }
 
-    // Amplitude interpolation
+    if (freqbasedmod[nvoice])
+    {
+        applyAmplitudeOnVoiceModulator(nvoice);
+        normalizeVoiceModulatorFrequencyModulation(nvoice, FMmode);
+
+        // Ring and morph modulation do not need normalization, and they take
+        // amplitude into account themselves.
+    }
+}
+
+void ADnote::applyAmplitudeOnVoiceModulator(int nvoice)
+{
+   // Amplitude interpolation
     if (aboveAmplitudeThreshold(FMoldamplitude[nvoice], FMnewamplitude[nvoice]))
     {
         for (int k = 0; k < unison_size[nvoice]; ++k)
@@ -1919,9 +1931,6 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
                 tw[i] *= FMnewamplitude[nvoice];
         }
     }
-
-    if (freqbasedmod[nvoice])
-        normalizeVoiceModulatorFrequencyModulation(nvoice, FMmode);
 }
 
 // Normalize the modulator for phase/frequency modulation

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1879,14 +1879,6 @@ void ADnote::computeVoiceModulator(int nvoice, int FMmode)
             // if are using stereo. See same section in computeVoiceOscillator.
             memcpy(tmpmod_unison[k], smps, synth->bufferbytes);
         }
-    } else if (NoteVoicePar[nvoice].FMVoice >= 0) {
-        // if I use VoiceOut[] as modulator
-        for (int k = 0; k < unison_size[nvoice]; ++k) {
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
-            // For historical/compatibility reasons we do not reduce volume here
-            // if are using stereo. See same section in computeVoiceOscillator.
-            memcpy(tmpmod_unison[k], smps, synth->bufferbytes);
-        }
     }
     else if (parentFMmod != NULL) {
         if (NoteVoicePar[nvoice].FMEnabled == FREQ_MOD) {
@@ -2402,19 +2394,6 @@ void ADnote::computeVoiceOscillator(int nvoice)
             // Sub voices use VoiceOut, so just pass NULL.
             subVoice[nvoice][k]->noteout(NULL, NULL);
             const float *smps = subVoice[nvoice][k]->NoteVoicePar[subVoiceNumber].VoiceOut;
-            float *tw = tmpwave_unison[k];
-            if (stereo) {
-                // Reduce volume due to stereo being combined to mono.
-                for (int i = 0; i < synth->buffersize; ++i) {
-                    tw[i] = smps[i] * 0.5f;
-                }
-            } else {
-                memcpy(tw, smps, synth->bufferbytes);
-            }
-        }
-    } else if (NoteVoicePar[nvoice].Voice >= 0) {
-        for (int k = 0; k < unison_size[nvoice]; ++k) {
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].Voice].VoiceOut;
             float *tw = tmpwave_unison[k];
             if (stereo) {
                 // Reduce volume due to stereo being combined to mono.

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -97,6 +97,7 @@ class ADnote
         void applyVoiceOscillatorRingModulation(int nvoice);
         void computeVoiceModulator(int nvoice, int FMmode);
         void computeVoiceModulatorLinearInterpolation(int nvoice);
+        void applyAmplitudeOnVoiceModulator(int nvoice);
         void normalizeVoiceModulatorFrequencyModulation(int nvoice, int FMmode);
         void computeVoiceModulatorFrequencyModulation(int nvoice, int FMmode);
         void computeVoiceModulatorForFMFrequencyModulation(int nvoice);


### PR DESCRIPTION
```
commit 4e87c4f3297c7fc01c0ab7a1e3523ca63f2a5037
Author: Kristian Amlie <kristian@amlie.name>
Date:   Fri Apr 10 12:42:48 2020 +0200

    Get rid of dead code.
    
    This code is never hit anymore after f2a9311b3315 was committed.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>

commit ca81eb01850b83d1bd7272ebe05e36b047f1ab36
Author: Kristian Amlie <kristian@amlie.name>
Date:   Fri Apr 10 12:18:48 2020 +0200

    Fix incorrect application of amplitude for Ring and Morph modulation.
    
    This has been broken for a while (5c03380247f7), it's kind of
    surprising that no one has discovered it before. The amplitude should
    not be applied to Ring and Morph modulation because they apply it
    themselves in their respective "apply" functions. Not only is it
    applied twice, but also incorrectly.
    
    Fixed by simply skipping amplitude for these modulations and letting
    it happen in the mentioned "apply" functions.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>
```