### PR TITLE
Fix slider value bugs and add new dynamic tooltips

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,13 @@
 yoshimi 1.7.1 M
 
+2020-7-16 Jesper
+* Added dynamic tooltips for AddSynth phase offset sliders,
+  waveform editor per-harmonic phase offset and magnitude
+  sliders, and SubSynth per-harmonic magnitude sliders.
+* Changed direction of per-harmonic phase offset slider in
+  the waveform editor to make it consistent with other phase
+  offset controls.
+
 2020-7-14 Will
 * Manual correction NRPN History MSB
 

--- a/src/UI/ADnoteUI.fl
+++ b/src/UI/ADnoteUI.fl
@@ -568,8 +568,9 @@ send_data(TOPLEVEL::action::forceUpdate, ADDVOICE::control::modulatorFrequencyAs
                   label Phase
                   callback {//
                     send_data(TOPLEVEL::action::forceUpdate, ADDVOICE::control::modulatorOscillatorPhase, o->value(), TOPLEVEL::type::Integer);}
-                  xywh {659 401 75 12} type {Horz Knob} box THIN_DOWN_BOX labelsize 10 align 1 minimum -64 maximum 63 step 1
+                  tooltip {Phase offset} xywh {659 401 75 12} type {Horz Knob} box THIN_DOWN_BOX labelsize 10 align 1 minimum -64 maximum 63 step 1
                   code0 {o->value(64-pars->VoicePar[nvoice].PFMoscilphase);}
+                  code1 {o->setValueType(VC_PhaseOffset); o->useCustomTip(true);}
                   class mwheel_slider_rev
                 }
                 Fl_Choice ExtModOsc {
@@ -812,8 +813,9 @@ Oscillator}
                   label Phase
                   callback {//
                 send_data(TOPLEVEL::action::forceUpdate, ADDVOICE::control::voiceOscillatorPhase, o->value(), TOPLEVEL::type::Integer);}
-                  xywh {10 568 70 12} type {Horz Knob} box THIN_DOWN_BOX labelsize 10 align 1 minimum -64 maximum 63 step 1
+                  tooltip {Phase offset} xywh {10 568 70 12} type {Horz Knob} box THIN_DOWN_BOX labelsize 10 align 1 minimum -64 maximum 63 step 1
                   code0 {o->value(64-pars->VoicePar[nvoice].Poscilphase);}
+                  code1 {o->setValueType(VC_PhaseOffset); o->useCustomTip(true);}
                   class mwheel_slider_rev
                 }
               }

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -849,7 +849,7 @@ string convert_value(ValueType type, float val)
             return variable_prec_units(f, "cents", 3);
 
         case VC_SubBandwidthRel:
-	    f = powf(100.0f, (63 - (int)val) / 64.0f);
+	    f = powf(100.0f, val / 64.0f);
             return variable_prec_units(f, "x", 3);
 
         case VC_SubBandwidthScale:

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -582,6 +582,12 @@ string convert_value(ValueType type, float val)
         case VC_PhaseOffset:
             return(custom_value_units(val / 64.0f * 90.0f,"°",1));
 
+        case VC_WaveHarmonicMagnitude: {
+            const string unit = val > 0 ? "% (inverted)" : "%";
+            const int denom = val >= 0 ? 64 : -63;
+            return(custom_value_units(val / denom * 100.0f,unit,1));
+        }
+
         case VC_GlobalFineDetune:
             return(custom_value_units((val-64),"cents",1));
 

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -852,6 +852,9 @@ string convert_value(ValueType type, float val)
 	    f = powf(100.0f, val / 64.0f);
             return variable_prec_units(f, "x", 3);
 
+        case VC_SubHarmonicMagnitude:
+            return custom_value_units(val / 127.0f * 100.0f, "%", 1);
+
         case VC_SubBandwidthScale:
             if ((int)val == 0)
                 return "Constant";

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -579,6 +579,9 @@ string convert_value(ValueType type, float val)
         case VC_percent64_127:
             return(custom_value_units((val-64) / 63.0f * 100.0f+0.05f,"%",1));
 
+        case VC_PhaseOffset:
+            return(custom_value_units(val / 64.0f * 90.0f,"°",1));
+
         case VC_GlobalFineDetune:
             return(custom_value_units((val-64),"cents",1));
 

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -82,6 +82,7 @@ enum ValueType {
     VC_SubBandwidth,
     VC_SubBandwidthScale,
     VC_SubBandwidthRel,
+    VC_SubHarmonicMagnitude,
     VC_FXSysSend,
     VC_FXEchoVol,
     VC_FXEchoDelay,

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -36,6 +36,7 @@ enum ValueType {
     VC_percent128,
     VC_percent255,
     VC_percent64_127,
+    VC_PhaseOffset,
     VC_GlobalFineDetune,
     VC_MasterVolume,
     VC_LFOfreq,

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -37,6 +37,7 @@ enum ValueType {
     VC_percent255,
     VC_percent64_127,
     VC_PhaseOffset,
+    VC_WaveHarmonicMagnitude,
     VC_GlobalFineDetune,
     VC_MasterVolume,
     VC_LFOfreq,

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -183,14 +183,30 @@ class PSlider {: {public mwheel_slider}
   Function {PSlider(int x,int y, int w, int h, const char *label=0):mwheel_slider(x,y,w,h,label)} {} {
     code {;} {}
   }
+  Function {update_selection_color(int new_value)} {return_type void
+  } {
+    code {
+    const int default_val = 63; // Turn into member variable if needed
+    selection_color(new_value == default_val ? 0 : 222);
+  } {private}
+  }
+  Function {value()} {return_type double} {code {return mwheel_slider::value();} {}}
+  Function {value(double val)} {return_type int
+  } {
+    code {
+    update_selection_color((int) val);
+    return mwheel_slider::value(val);} {}
+  }
   Function {handle(int event)} {return_type int
   } {
     code {int X=x(),Y=y(),W=w(),H=h();
 
-    if ((!Fl::event_buttons())|| (event==0)||(Fl::event_shift()==0))
-        return(mwheel_slider::handle(event));
+    int rval = 1;
 
-    if (!Fl::event_inside(X,Y,W,H))
+    if ((!Fl::event_buttons())|| (event==0)||(Fl::event_shift()==0))
+        rval = mwheel_slider::handle(event);
+
+    else if (!Fl::event_inside(X,Y,W,H))
     {
         if (event==FL_DRAG)
         {
@@ -198,11 +214,10 @@ class PSlider {: {public mwheel_slider}
             mwheel_slider::handle(FL_LEAVE);
             deactivate();
             activate();
-            return(1);
         }
         else
         {
-            return(mwheel_slider::handle(event));
+            rval = mwheel_slider::handle(event);
         }
     }
     else
@@ -210,7 +225,8 @@ class PSlider {: {public mwheel_slider}
         mwheel_slider::handle(FL_PUSH);
     }
 
-    return(1);} {}
+    update_selection_color((int) value());
+    return rval;} {}
   }
 }
 
@@ -338,15 +354,9 @@ class Oscilharmonic {: {public Fl_Group}
         else
             x = 127 - (int)o->value();
 
-        if (x==64)
-            o->selection_color(0);
-        else
-            o->selection_color(222);
-
         send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicAmplitude, n, x, TOPLEVEL::type::Integer);}
-        xywh {0 1 15 122} type {Vert Knob} box FLAT_BOX selection_color 222 maximum 127 step 1 value 64
+        xywh {0 1 15 122} type {Vert Knob} box FLAT_BOX maximum 127 step 1 value 64
         code0 {o->value(127-oscil->Phmag[n]);}
-        code1 {if (oscil->Phmag[n]==64) o->selection_color(0);}
         class PSlider
       }
       Fl_Slider phase {
@@ -357,15 +367,9 @@ class Oscilharmonic {: {public Fl_Group}
         else
             x = 127 - (int)o->value();
 
-        if (x == 64)
-            o->selection_color(0);
-        else
-            o->selection_color(222);
-
         send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicPhaseBandwidth, n, x, TOPLEVEL::type::Integer);}
-        xywh {0 140 15 82} type {Vert Knob} box FLAT_BOX selection_color 222 maximum 127 step 1 value 64
+        xywh {0 140 15 82} type {Vert Knob} box FLAT_BOX maximum 127 step 1 value 64
         code0 {o->value(127 - oscil->Phphase[n]);}
-        code1 {if (oscil->Phphase[n]==64) o->selection_color(0);}
         class PSlider
       }
       Fl_Box {} {
@@ -413,16 +417,7 @@ class Oscilharmonic {: {public Fl_Group}
     code {//
     mag->value(127-oscil->Phmag[n]);
     phase->value(127-oscil->Phphase[n]);
-
-    if (oscil->Phmag[n]==64)
-        mag->selection_color(0);
-    else
-        mag->selection_color(222);
-
-    if (oscil->Phphase[n]==64)
-        phase->selection_color(0);
-    else
-        phase->selection_color(222);} {}
+    } {}
   }
   Function {~Oscilharmonic()} {} {
     code {//
@@ -1127,19 +1122,11 @@ class OscilEditor {: {public PresetsUI_}
     if (insert == TOPLEVEL::insert::harmonicAmplitude)
     {
         h[control]->mag->value(127 - value);
-        if (value == 64)
-            h[control]->mag->selection_color(0);
-        else
-            h[control]->mag->selection_color(222);
     }
 
     else if (insert == TOPLEVEL::insert::harmonicPhaseBandwidth)
     {
         h[control]->phase->value(127 - value);
-        if (value == 64)
-            h[control]->phase->selection_color(0);
-        else
-            h[control]->phase->selection_color(222);
     }
 
     else
@@ -1229,18 +1216,6 @@ class OscilEditor {: {public PresetsUI_}
                     wshbutton->value(0);
                     fltbutton->value(0);
                     sabutton->value(0);
-                }
-                for (int i = 0; i<MAX_AD_HARMONICS; ++i)
-                {
-                    if (h[i]->mag->value() == 63)
-                        h[i]->mag->selection_color(0);
-                    else
-                        h[i]->mag->selection_color(222);
-
-                    if (h[i]->phase->value() == 63)
-                        h[i]->phase->selection_color(0);
-                    else
-                        h[i]->phase->selection_color(222);
                 }
                 baseSet = true;
                 set = false;
@@ -1347,12 +1322,9 @@ class OscilEditor {: {public PresetsUI_}
                 for (int i = 0; i < MAX_AD_HARMONICS; ++i)
                 {
                     h[i]->mag->value(63);
-                    h[i]->mag->selection_color(0);
                     h[i]->phase->value(63);
-                    h[i]->phase->selection_color(0);
                 }
                 h[0]->mag->value(0);
-                h[0]->mag->selection_color(222);
                 break;
 
             case OSCILLATOR::control::convertToSine:

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -357,6 +357,7 @@ class Oscilharmonic {: {public Fl_Group}
         send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicAmplitude, n, x, TOPLEVEL::type::Integer);}
         xywh {0 1 15 122} type {Vert Knob} box FLAT_BOX minimum -63 maximum 64 step 1 value 0
         code0 {o->value(64 - oscil->Phmag[n]);}
+        code1 {o->setValueType(VC_WaveHarmonicMagnitude); o->useCustomTip(true);}
         class PSlider
       }
       Fl_Slider phase {

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -186,7 +186,7 @@ class PSlider {: {public mwheel_slider}
   Function {update_selection_color(int new_value)} {return_type void
   } {
     code {
-    const int default_val = 63; // Turn into member variable if needed
+    const int default_val = 0; // Turn into member variable if needed
     selection_color(new_value == default_val ? 0 : 222);
   } {private}
   }
@@ -344,32 +344,33 @@ class Oscilharmonic {: {public Fl_Group}
     } {
       Fl_Slider mag {
         callback {//
-        int x=64;
+        int x = 64;
         if (Fl::event_button3())
         {
             if (n == 0)
                 x = 127;
-            o->value(127 - x);
+            o->value(64 - x);
         }
         else
-            x = 127 - (int)o->value();
+            x = 64 - (int)o->value();
 
         send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicAmplitude, n, x, TOPLEVEL::type::Integer);}
-        xywh {0 1 15 122} type {Vert Knob} box FLAT_BOX maximum 127 step 1 value 64
-        code0 {o->value(127-oscil->Phmag[n]);}
+        xywh {0 1 15 122} type {Vert Knob} box FLAT_BOX minimum -63 maximum 64 step 1 value 0
+        code0 {o->value(64 - oscil->Phmag[n]);}
         class PSlider
       }
       Fl_Slider phase {
         callback {//
         int x = 64;
         if (Fl::event_button3())
-            o->value(127 - x);
+            o->value(0);
         else
-            x = 127 - (int)o->value();
+            x = 64 - (int)o->value();
 
         send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicPhaseBandwidth, n, x, TOPLEVEL::type::Integer);}
-        xywh {0 140 15 82} type {Vert Knob} box FLAT_BOX maximum 127 step 1 value 64
-        code0 {o->value(127 - oscil->Phphase[n]);}
+        xywh {0 140 15 82} type {Vert Knob} box FLAT_BOX minimum 64 maximum -63 step 1 value 0
+        code0 {o->value(64 - oscil->Phphase[n]);}
+        code1 {o->setValueType(VC_PhaseOffset); o->useCustomTip(true);}
         class PSlider
       }
       Fl_Box {} {
@@ -415,8 +416,8 @@ class Oscilharmonic {: {public Fl_Group}
   }
   Function {refresh()} {} {
     code {//
-    mag->value(127-oscil->Phmag[n]);
-    phase->value(127-oscil->Phphase[n]);
+    mag->value(64 - oscil->Phmag[n]);
+    phase->value(64 - oscil->Phphase[n]);
     } {}
   }
   Function {~Oscilharmonic()} {} {
@@ -1121,12 +1122,12 @@ class OscilEditor {: {public PresetsUI_}
     bool baseSet = false;
     if (insert == TOPLEVEL::insert::harmonicAmplitude)
     {
-        h[control]->mag->value(127 - value);
+        h[control]->mag->value(64 - value);
     }
 
     else if (insert == TOPLEVEL::insert::harmonicPhaseBandwidth)
     {
-        h[control]->phase->value(127 - value);
+        h[control]->phase->value(64 - value);
     }
 
     else
@@ -1208,8 +1209,8 @@ class OscilEditor {: {public PresetsUI_}
                 {
                     for (int i = 0; i<MAX_AD_HARMONICS; ++i)
                     {
-                        h[i]->mag->value(63);;
-                        h[i]->phase->value(63);
+                        h[i]->mag->value(0);;
+                        h[i]->phase->value(0);
                     }
                     harmonicshiftcounter->value(0);
                     h[0]->mag->value(0);
@@ -1321,8 +1322,8 @@ class OscilEditor {: {public PresetsUI_}
             case OSCILLATOR::control::clearHarmonics:
                 for (int i = 0; i < MAX_AD_HARMONICS; ++i)
                 {
-                    h[i]->mag->value(63);
-                    h[i]->phase->value(63);
+                    h[i]->mag->value(0);
+                    h[i]->phase->value(0);
                 }
                 h[0]->mag->value(0);
                 break;

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -353,18 +353,18 @@ class Oscilharmonic {: {public Fl_Group}
         callback {//
         int x = 64;
         if (Fl::event_button3())
-            o->value(x);
+            o->value(127 - x);
         else
-            x = (int)o->value();
+            x = 127 - (int)o->value();
 
         if (x == 64)
             o->selection_color(0);
         else
             o->selection_color(222);
 
-        send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicPhaseBandwidth, n, 127 - x, TOPLEVEL::type::Integer);}
+        send_data(TOPLEVEL::action::forceUpdate, TOPLEVEL::insert::harmonicPhaseBandwidth, n, x, TOPLEVEL::type::Integer);}
         xywh {0 140 15 82} type {Vert Knob} box FLAT_BOX selection_color 222 maximum 127 step 1 value 64
-        code0 {o->value(oscil->Phphase[n]);}
+        code0 {o->value(127 - oscil->Phphase[n]);}
         code1 {if (oscil->Phphase[n]==64) o->selection_color(0);}
         class PSlider
       }
@@ -412,7 +412,7 @@ class Oscilharmonic {: {public Fl_Group}
   Function {refresh()} {} {
     code {//
     mag->value(127-oscil->Phmag[n]);
-    phase->value(oscil->Phphase[n]);
+    phase->value(127-oscil->Phphase[n]);
 
     if (oscil->Phmag[n]==64)
         mag->selection_color(0);
@@ -1221,10 +1221,9 @@ class OscilEditor {: {public PresetsUI_}
                 {
                     for (int i = 0; i<MAX_AD_HARMONICS; ++i)
                     {
-                        h[i]->mag->value(64);;
-                        h[i]->phase->value(64);
+                        h[i]->mag->value(63);;
+                        h[i]->phase->value(63);
                     }
-                    h[0]->mag->value(127);
                     harmonicshiftcounter->value(0);
                     h[0]->mag->value(0);
                     wshbutton->value(0);
@@ -1233,12 +1232,12 @@ class OscilEditor {: {public PresetsUI_}
                 }
                 for (int i = 0; i<MAX_AD_HARMONICS; ++i)
                 {
-                    if (h[i]->mag->value() == 64)
+                    if (h[i]->mag->value() == 63)
                         h[i]->mag->selection_color(0);
                     else
                         h[i]->mag->selection_color(222);
 
-                    if (h[i]->phase->value() == 64)
+                    if (h[i]->phase->value() == 63)
                         h[i]->phase->selection_color(0);
                     else
                         h[i]->phase->selection_color(222);
@@ -1347,9 +1346,9 @@ class OscilEditor {: {public PresetsUI_}
             case OSCILLATOR::control::clearHarmonics:
                 for (int i = 0; i < MAX_AD_HARMONICS; ++i)
                 {
-                    h[i]->mag->value(64);
+                    h[i]->mag->value(63);
                     h[i]->mag->selection_color(0);
-                    h[i]->phase->value(64);
+                    h[i]->phase->value(63);
                     h[i]->phase->selection_color(0);
                 }
                 h[0]->mag->value(0);

--- a/src/UI/SUBnoteUI.fl
+++ b/src/UI/SUBnoteUI.fl
@@ -50,6 +50,9 @@ decl {\#include "FilterUI.h"} {public local
 decl {\#include "PresetsUI.h"} {public local
 }
 
+decl {\#include "OscilGenUI.h"} {public local
+}
+
 decl {\#include "Params/SUBnoteParameters.h"} {public local
 }
 
@@ -75,45 +78,36 @@ class SUBnoteharmonic {: {public Fl_Group}
         callback {//
         int x = 0;
         if (Fl::event_button() != 3)
-            x = 127 - lrint(o->value());
+            x = lrint(o->value());
         else
         {
             if (n == 0)
                 x = 127;
-            o->value(127 - x);
+            o->value(x);
         }
 
         send_data(0, TOPLEVEL::insert::harmonicAmplitude, n, x, TOPLEVEL::type::Integer);
-
-        if (x == 0)
-            o->selection_color(0);
-        else
-            o->selection_color(222);}
-        tooltip {Harmonic's magnitude} xywh {0 2 15 131} type {Vert Knob} box FLAT_BOX selection_color 222 maximum 127 step 1 value 127
-        code0 {o->value(127-pars->Phmag[n]);}
-        code1 {if (pars->Phmag[n]==0) o->selection_color(0);}
-        class mwheel_slider
+	}
+        tooltip {Harmonic's magnitude} xywh {0 2 15 131} type {Vert Knob} box FLAT_BOX minimum 127 maximum 0 step 1 value 127
+        code0 {o->value(pars->Phmag[n]);}
+        class PSlider
       }
       Fl_Slider bw {
         callback {//
         int x = 64;
         if (Fl::event_button() != 3)
-            x = 127 - lrint(o->value());
+            x = 64 + lrint(o->value());
         else
-            o->value(x - 1);
+            o->value(0);
 
         send_data(0, TOPLEVEL::insert::harmonicPhaseBandwidth, n, x, TOPLEVEL::type::Integer);
 
-        if (x == 64)
-            o->selection_color(0);
-        else
-            o->selection_color(222);}
-        tooltip {Harmonic's bandwidth multiplier} xywh {0 166 15 126} type {Vert Knob} box FLAT_BOX selection_color 222 maximum 127 step 1 value 63
+	}
+        tooltip {Harmonic's bandwidth multiplier} xywh {0 166 15 126} type {Vert Knob} box FLAT_BOX minimum 63 maximum -64 step 1 value 0
         code0 {o->setValueType(VC_SubBandwidthRel);}
         code1 {o->useCustomTip(true);}
-        code2 {o->value(127-pars->Phrelbw[n]);}
-        code3 {if (pars->Phrelbw[n]==64) o->selection_color(0);}
-        class mwheel_slider
+        code2 {o->value(pars->Phrelbw[n] - 64);}
+        class PSlider
       }
       Fl_Box {} {
         xywh {15 228 5 3} box FLAT_BOX color 39
@@ -147,9 +141,9 @@ class SUBnoteharmonic {: {public Fl_Group}
   }
   Function {refresh()} {} {
     code {//
-    mag->value(127-pars->Phmag[n]);
-    if (pars->Phmag[n]==0) mag->selection_color(0);
-        bw->value(127-pars->Phrelbw[n]);} {}
+    mag->value(pars->Phmag[n]);
+    bw->value(pars->Phrelbw[n] - 64);
+    } {}
   }
   Function {~SUBnoteharmonic()} {} {
     code {//
@@ -452,16 +446,13 @@ class SUBnoteUI {: {public PresetsUI_}
         callback {//
         for (int i = 0; i < MAX_SUB_HARMONICS; i++)
         {
-            h[i]->mag->value(127);
-            h[i]->mag->selection_color(0);
+            h[i]->mag->value(0);
             pars->Phmag[i] = 0;
-            h[i]->bw->value(64);
-            h[i]->bw->selection_color(0);
+            h[i]->bw->value(0);
             pars->Phrelbw[i] = 64;
         }
 
-        h[0]->mag->selection_color(222);
-        h[0]->mag->value(0);
+        h[0]->mag->value(127);
         SUBparameters->redraw();
         send_data (0, SUBSYNTH::control::clearHarmonics, o->value(), TOPLEVEL::type::Integer);}
         tooltip {Clear the harmonics} xywh {445 446 70 20} box THIN_UP_BOX labelfont 1 labelsize 11
@@ -701,12 +692,12 @@ class SUBnoteUI {: {public PresetsUI_}
     bool val_bool = YOSH::F2B(value);
     if (insert == TOPLEVEL::insert::harmonicAmplitude)
     {
-        h[control]->mag->value(127 - (int) value);
+        h[control]->mag->value((int) value);
         return;
     }
     if (insert == TOPLEVEL::insert::harmonicPhaseBandwidth)
     {
-        h[control]->bw->value(127 - (int) value);
+        h[control]->bw->value((int)value - 64);
         return;
     }
 
@@ -840,13 +831,10 @@ class SUBnoteUI {: {public PresetsUI_}
         case SUBSYNTH::control::clearHarmonics:
             for (int i = 0; i < MAX_SUB_HARMONICS; i++)
             {
-                h[i]->mag->value(127);
-                h[i]->mag->selection_color(0);
-                h[i]->bw->value(64);
-                h[i]->bw->selection_color(0);
+                h[i]->mag->value(0);
+                h[i]->bw->value(0);
             }
-            h[0]->mag->selection_color(222);
-            h[0]->mag->value(0);
+            h[0]->mag->value(127);
             break;
 
         case SUBSYNTH::control::stereo:

--- a/src/UI/SUBnoteUI.fl
+++ b/src/UI/SUBnoteUI.fl
@@ -90,6 +90,7 @@ class SUBnoteharmonic {: {public Fl_Group}
 	}
         tooltip {Harmonic's magnitude} xywh {0 2 15 131} type {Vert Knob} box FLAT_BOX minimum 127 maximum 0 step 1 value 127
         code0 {o->value(pars->Phmag[n]);}
+        code1 {o->setValueType(VC_SubHarmonicMagnitude); o->useCustomTip(true);}
         class PSlider
       }
       Fl_Slider bw {

--- a/src/UI/WidgetMWSlider.cpp
+++ b/src/UI/WidgetMWSlider.cpp
@@ -71,11 +71,11 @@ void mwheel_val_slider::useCustomTip(bool enabled)
         tooltip(tipText.c_str());
 }
 
-void mwheel_val_slider::value(double val)
+int mwheel_val_slider::value(double val)
 {
-    Fl_Valuator::value(val);
     dyntip->setValue(val);
     dyntip->setOnlyValue(true);
+    return Fl_Valuator::value(val);
 }
 
 double mwheel_val_slider::value()

--- a/src/UI/WidgetMWSlider.h
+++ b/src/UI/WidgetMWSlider.h
@@ -43,7 +43,7 @@ class mwheel_val_slider : public Fl_Value_Slider {
   /* Overridden widget methods */
   int handle(int ev);
   void tooltip(const char* tip);
-  void value(double);
+  int value(double);
   double value();
 
  protected:


### PR DESCRIPTION
* Fixes a couple of minor glitches. 
* Refactors the slider color switching code for increased sanity. 
* Adds dynamic tooltips to 5 sliders.
* Switches subsynth harmonic sliders to have the same behavior as the waveform editor harmonic sliders.
That is: you can set/reset them by dragging horizontally while holding down Shift.

* Changes direction of per-harmonic phase slider to be consistent with other vertical sliders, namely:
 up -> increase (positive phase offset)
 down -> decrease (negative phase offset)

The last change should to my knowledge not have any impact on pre-existing midi-learned parameters, other than where the slider handles will end up.

The commit messages provide more details.