### PR TITLE
No libjack for LV2 plugin (#107)

### DIFF
--- a/src/LV2_Plugin/CMakeLists.txt
+++ b/src/LV2_Plugin/CMakeLists.txt
@@ -141,7 +141,6 @@ target_link_libraries(yoshimi_lv2
                       ${LIBSNDFILE_LIBRARIES}
                       ${FFTW3F_LIBRARIES}
                       ${LIBCAIRO_LIBRARIES}
-                      ${JACK_LIBRARIES}
                       z
                       ${LIBDL_LINUX_LIBS}
 )


### PR DESCRIPTION
This should fix the problem fro #107. I tested it.