### PR TITLE
Fix detune accumulation bug in SUB synth when altering live voice.

### DIFF
--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -44,7 +44,7 @@ class SUBnote
         SUBnote(const SUBnote &rhs);
         ~SUBnote();
 
-        void legatoFadeIn(float freq_, float velocity_, int portamento_, int midinote_);
+        void legatoFadeIn(float basefreq_, float velocity_, int portamento_, int midinote_);
         void legatoFadeOut(const SUBnote &syncwith);
 
         int noteout(float *outl,float *outr); // note output, return 0 if the
@@ -74,7 +74,7 @@ class SUBnote
         int numharmonics; // number of harmonics (after the too higher hamonics are removed)
         int start; // how the harmonics start
         float basefreq;
-        float initialfreq;
+        float notefreq;
         float velocity;
         int portamento;
         int midinote;
@@ -128,7 +128,7 @@ class SUBnote
         void computeallfiltercoefs();
         void computefiltercoefs(bpfilter &filter, float freq, float bw, float gain);
         void computeNoteParameters();
-        void setBaseFreq(float basefreq_);
+        void computeNoteFreq();
         void filter(bpfilter &filter, float *smps);
         void filterVarRun(bpfilter &filter, float *smps);
         float getHgain(int harmonic);


### PR DESCRIPTION
Switch the name `initialfreq` to `basefreq`. This has no functional
impact, but is merely to match the naming in ADsynth; less surprises
for the reader. And then introduce `notefreq` to mean the frequency
which with all detuning applied. ADsynth has no equivalent of
notefreq, it is updated on every cycle. Also rename `setBaseFreq` to
`computeNoteFreq` and remove the argument, to make it more clear that
this function just updates the internal state.

After the renaming, make sure that notefreq is used in all places
where we need the detuned note frequency, and basefreq in all places
where we need the original, unaltered frequency.

Signed-off-by: Kristian Amlie <kristian@amlie.name>