### PR TITLE
Some small fixes.

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -5887,6 +5887,7 @@ void InterChange::envelopeReadWrite(CommandBlock *getData, EnvelopeParams *pars)
                 pars->Penvval[point] = val;
                 getData->data.value = val;
                 getData->data.offset = Xincrement;
+                pars->presetsUpdated();
             }
             else
                 getData->data.value = UNUSED;
@@ -5910,6 +5911,7 @@ void InterChange::envelopeReadWrite(CommandBlock *getData, EnvelopeParams *pars)
                 -- pars->Penvsustain;
             pars->Penvpoints = envpoints;
             getData->data.value = envpoints;
+            pars->presetsUpdated();
         }
         return;
     }
@@ -5929,6 +5931,7 @@ void InterChange::envelopeReadWrite(CommandBlock *getData, EnvelopeParams *pars)
                 Xincrement = 0;
             else
                 pars->Penvdt[point] = Xincrement;
+            pars->presetsUpdated();
         }
         else
         {

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -741,7 +741,7 @@ void ADnote::legatoFadeIn(float freq_, float velocity_, int portamento_, int mid
         if (subVoice[i] != NULL)
             for (int k = 0; k < unison_size[i]; ++k)
                 subVoice[i][k]->legatoFadeIn(getVoiceBaseFreq(i), velocity_, portamento_, midinote_);
-        else if (subFMVoice[i] != NULL)
+        if (subFMVoice[i] != NULL)
             for (int k = 0; k < unison_size[i]; ++k)
                 subFMVoice[i][k]->legatoFadeIn(getFMVoiceBaseFreq(i), velocity_, portamento_, midinote_);
     }
@@ -853,7 +853,7 @@ void ADnote::legatoFadeOut(const ADnote &orig)
         if (subVoice[i] != NULL)
             for (int k = 0; k < unison_size[i]; ++k)
                 subVoice[i][k]->legatoFadeOut(*orig.subVoice[i][k]);
-        else if (subFMVoice[i] != NULL)
+        if (subFMVoice[i] != NULL)
             for (int k = 0; k < unison_size[i]; ++k)
                 subFMVoice[i][k]->legatoFadeOut(*orig.subFMVoice[i][k]);
     }


### PR DESCRIPTION
```
commit 07cbde08582b07341421cbca1002d2b9b537130d
Author: Kristian Amlie <kristian@amlie.name>
Date:   Sun Sep 13 19:45:24 2020 +0200

    Fix several legato issues when both Osc and Mod use sub voice.
    
    Innocent looking mistake, we need to handle sub voices for both
    components, not just one of them.
    
    The symptoms were incorrect frequency in the legatoFadeIn case, and
    abrupt phase change in the legatoFadeOut case.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>

commit 9f026f1afc0cec354b4b89ed1fca434671a86a14
Author: Kristian Amlie <kristian@amlie.name>
Date:   Sun Sep 13 19:42:12 2020 +0200

    Fix live feedback inside Envelope Free Mode.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>
```