### PR TITLE
fix crash when duplicating tracks

### DIFF
--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -389,17 +389,19 @@ LV2_Handle	YoshimiLV2Plugin::instantiate (const LV2_Descriptor *desc, double sam
         return NULL;
     }
     Fl::lock();
-    /*
-     * Perform further global initialisation.
-     * For stand-alone the equivalent init happens in main(),
-     * after mainCreateNewInstance() returned successfully.
-     */
-    synth->installBanks();
-    synth->loadHistory();
 
     YoshimiLV2Plugin *inst = new YoshimiLV2Plugin(synth, sample_rate, bundle_path, features, desc);
     if (inst->init())
+    {
+        /*
+        * Perform further global initialisation.
+        * For stand-alone the equivalent init happens in main(),
+        * after mainCreateNewInstance() returned successfully.
+        */
+        synth->installBanks();
+        synth->loadHistory();
         return static_cast<LV2_Handle>(inst);
+    }
     else
     {
         synth->getRuntime().LogError("Failed to create Yoshimi LV2 plugin");


### PR DESCRIPTION
I am not sure that this is the correct fix but after this fix it will not crash anymore when the track is duplicated.

Here /home/iurie/projects/yoshimi-1.7.3/src/Interface/InterChange.cpp:1603

At line 1603 there is a try to access a null pointer synth->part[npart]->Pname = name;
i.e. synth->part[npart] is NULL (I have debugged this). This means that the plugin SynthEngine::Init() where the parts are created is called later than the init of banks.

#0 0x00007f8253107d35 in std::__cxx11::basic_string<char, std::char_traits, std::allocator >::_M_assign(std::__cxx11::basic_string<char, std::char_traits, std::allocator > const&) ()
at /lib/x86_64-linux-gnu/libstdc++.so.6
#1 0x00007f825310812e in std::__cxx11::basic_string<char, std::char_traits, std::allocator >::operator=(std::__cxx11::basic_string<char, std::char_traits, std::allocator > const&) ()
at /lib/x86_64-linux-gnu/libstdc++.so.6
#2 0x00007f820a4668e1 in InterChange::generateSpecialInstrument(int, std::__cxx11::basic_string<char, std::char_traits, std::allocator >) (this=0x55d682405a60, npart=0, name="First Instrument")
at /home/iurie/projects/yoshimi-1.7.3/src/Interface/InterChange.cpp:1603
#3 0x00007f820a3d4d3a in Bank::generateSingleRoot(std::__cxx11::basic_string<char, std::char_traits, std::allocator > const&, bool) (this=0x55d6824059f8, newRoot="yoshimi/banks", clear=true)
at /home/iurie/projects/yoshimi-1.7.3/src/Misc/Bank.cpp:1209
#4 0x00007f820a3d6865 in Bank::parseBanksFile(XMLwrapper*) (this=0x55d6824059f8, xml=0x0) at /home/iurie/projects/yoshimi-1.7.3/src/Misc/Bank.cpp:1507
#5 0x00007f820a414e1c in SynthEngine::installBanks() (this=0x55d6824059f0) at /home/iurie/projects/yoshimi-1.7.3/src/Misc/SynthEngine.cpp:2425
#6 0x00007f820a3ae863 in YoshimiLV2Plugin::instantiate(_LV2_Descriptor const*, double, char const*, _LV2_Feature const* const*)
(desc=0x7f820a613960 <yoshimi_lv2_desc>, sample_rate=44100, bundle_path=0x55d6823f0b40 "/usr/local/lib/lv2/yoshimi.lv2/", features=0x55d6823b08c0)
at /home/iurie/projects/yoshimi-1.7.3/src/LV2_Plugin/YoshimiLV2Plugin.cpp:397
#7 0x00007f82532f1623 in lilv_plugin_instantiate () at /lib/x86_64-linux-gnu/liblilv-0.so.0
#8 0x00007f82568594dc in ARDOUR::LV2Plugin::init(void const*, long) (this=0x55d6823823e0, c_plugin=0x55d66b2c8780, rate=44100) at ../libs/ardour/lv2_plugin.cc:631
#9 0x00007f8256857d19 in ARDOUR::LV2Plugin::LV2Plugin(ARDOUR::AudioEngine&, ARDOUR::Session&, void const*, long) (this=0x55d6823823e0, engine=..., session=..., c_plugin=0x55d66b2c8780, rate=44100)