### PR TITLE
Make sure only the required symbols are exported.

### DIFF
--- a/src/LV2_Plugin/CMakeLists.txt
+++ b/src/LV2_Plugin/CMakeLists.txt
@@ -108,6 +108,7 @@ set (FltkUI_sources
 )
 
 add_definitions (-DYOSHIMI_LV2_PLUGIN=1)
+add_definitions (-fvisibility=hidden)
 
 add_library (yoshimi_lv2 MODULE
             ${yoshimi_lv2_plugin_files}


### PR DESCRIPTION
The LV2 descriptor functions are already marked as exported by the LV2
headers, no need to mark them explicitly. The rest should be hidden.

Signed-off-by: Kristian Amlie <kristian@amlie.name>