### PR TITLE
Make LFO processing work with variable size block buffers (LV2).

### DIFF
--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -276,7 +276,7 @@ float LFO::lfoout()
             x = fmodf(newBeat * frac.first / frac.second + startPhase, 1.0f);
         }
     } else
-        lfoelapsed += synth->fixed_sample_step_f;
+        lfoelapsed += synth->sent_buffersize_f / synth->samplerate_f;
 
     return out;
 }


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian@amlie.name>