### PR TITLE
Fix inconsistent envelope timing under LV2.

### DIFF
--- a/src/Synth/Envelope.h
+++ b/src/Synth/Envelope.h
@@ -48,7 +48,6 @@ class Envelope
         Presets::PresetsUpdate envUpdate;
         int envpoints;
         int envsustain;   // "-1" means disabled
-        float envdt[MAX_ENVELOPE_POINTS];  // milliseconds
         float envval[MAX_ENVELOPE_POINTS]; // [0.0 .. 1.0]
         float envstretch;
         int linearenvelope;


### PR DESCRIPTION
The timing values were previously calculated only once, based on the
static block size. Instead, calculate them on every cycle, based on
the block size for that cycle.

Signed-off-by: Kristian Amlie <kristian@amlie.name>