### PR TITLE
Fix Equal Temperament variation when voice is being imported.

### DIFF
--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1590,13 +1590,17 @@ float ADnote::getVoiceBaseFreq(int nvoice)
     if (subVoiceNumber == -1)
         detune += NoteGlobalPar.Detune / 100.0f;
 
-    // Fixed frequency is disabled for sub voices. We get the basefreq from the
-    // parent.
-    if (!NoteVoicePar[nvoice].fixedfreq || subVoiceNumber != -1)
+    if (!NoteVoicePar[nvoice].fixedfreq)
         return basefreq * powf(2.0f, detune / 12.0f);
     else // fixed freq is enabled
     {
-        float fixedfreq = 440.0f;
+        float fixedfreq;
+        if (subVoiceNumber != -1)
+            // Fixed frequency is not used in sub voices. We get the basefreq
+            // from the parent.
+            fixedfreq = basefreq;
+        else
+            fixedfreq = 440.0f;
         int fixedfreqET = NoteVoicePar[nvoice].fixedfreqET;
         if (fixedfreqET)
         {   // if the frequency varies according the keyboard note


### PR DESCRIPTION
When the voice is imported, the 440Hz is not used, the frequency is
taken from the importing voice. However, it should still be possible
to use the Eq.T. wheel if 440Hz is enabled in both voices.

With this fix it is even possible to use Eq.T. without 440Hz enabled,
if the importing voice has it disabled. The effect is then added to
the existing 1x equal temperament from the importing voice.

Signed-off-by: Kristian Amlie <kristian@amlie.name>