### PR TITLE
LFO syncing for effects

### DIFF
--- a/src/CLI/CmdInterpreter.cpp
+++ b/src/CLI/CmdInterpreter.cpp
@@ -1376,7 +1376,7 @@ int CmdInterpreter::effects(Parser& input, unsigned char controlType)
             partno = TOPLEVEL::section::insertEffects;
         else
             partno = TOPLEVEL::section::systemEffects;
-        return sendNormal(synth, 0, nFXpreset, controlType, 16, partno,  EFFECT::type::none + nFXtype, nFX);
+        return sendNormal(synth, 0, nFXpreset, controlType, EFFECT::control::preset, partno,  EFFECT::type::none + nFXtype, nFX);
     }
     return REPLY::op_msg;
 }

--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -43,11 +43,10 @@ static unsigned char presets[NUM_PRESETS][PRESET_SIZE] = {
 };
 
 Alienwah::Alienwah(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth),
     lfo(_synth),
     oldl(NULL),
-    oldr(NULL),
-    synth(_synth)
+    oldr(NULL)
 {
     setpreset(Ppreset);
     cleanup();

--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -189,6 +189,8 @@ void Alienwah::setpreset(unsigned char npreset)
             changepar(n, presets[npreset][n]);
         if (insertion)
             changepar(0, presets[npreset][0] / 2); // lower the volume if this is insertion effect
+        // All presets use no BPM syncing.
+        changepar(EFFECT::control::bpm, 0);
         Ppreset = npreset;
     }
     else
@@ -251,6 +253,12 @@ void Alienwah::changepar(int npar, unsigned char value)
         case 10:
             setphase(value);
             break;
+        case EFFECT::control::bpm:
+            lfo.Pbpm = value;
+            break;
+        case EFFECT::control::bpmStart:
+            lfo.PbpmStart = value;
+            break;
     }
     Pchanged = true;
 }
@@ -272,6 +280,8 @@ unsigned char Alienwah::getpar(int npar)
         case 8:  return Pdelay;
         case 9:  return Plrcross;
         case 10: return Pphase;
+        case EFFECT::control::bpm: return lfo.Pbpm;
+        case EFFECT::control::bpmStart: return lfo.PbpmStart;
         default: break;
     }
     return 0;
@@ -321,7 +331,13 @@ float Alienlimit::getlimits(CommandBlock *getData)
             break;
         case 10:
             break;
-        case 16:
+        case EFFECT::control::bpm:
+            max = 1;
+            canLearn = 0;
+            break;
+        case EFFECT::control::bpmStart:
+            break;
+        case EFFECT::control::preset:
             max = 3;
             canLearn = 0;
             break;

--- a/src/Effects/Alienwah.h
+++ b/src/Effects/Alienwah.h
@@ -73,8 +73,6 @@ class Alienwah : public Effect
         complex<float> oldclfol, oldclfor;
         int oldk;
 
-        SynthEngine *synth;
-
 };
 
 class Alienlimit

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -56,9 +56,9 @@ static unsigned char presets[NUM_PRESETS][PRESET_SIZE] = {
 
 
 Chorus::Chorus(bool insertion_, float *const efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth),
     lfo(_synth),
-    synth(_synth)
+    fb(0, _synth->samplerate)
 {
     dlk = drk = 0;
     maxdelay = (int)(MAX_CHORUS_DELAY / 1000.0f * synth->samplerate_f);

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -204,6 +204,8 @@ void Chorus::setpreset(unsigned char npreset)
             npreset = NUM_PRESETS - 1;
         for (int n = 0; n < PRESET_SIZE; ++n)
             changepar(n, presets[npreset][n]);
+        // All presets use no BPM syncing.
+        changepar(EFFECT::control::bpm, 0);
         Ppreset = npreset;
     }
     else
@@ -270,6 +272,12 @@ void Chorus::changepar(int npar, unsigned char value)
         case 11:
             Poutsub = (value > 1) ? 1 : value;
             break;
+        case EFFECT::control::bpm:
+            lfo.Pbpm = value;
+            break;
+        case EFFECT::control::bpmStart:
+            lfo.PbpmStart = value;
+            break;
         default:
             Pchanged = false;
     }
@@ -293,6 +301,8 @@ unsigned char Chorus::getpar(int npar)
         case 9:  return Plrcross;
         case 10: return Pflangemode;
         case 11: return Poutsub;
+        case EFFECT::control::bpm: return lfo.Pbpm;
+        case EFFECT::control::bpmStart: return lfo.PbpmStart;
         default: return 0;
     }
 }
@@ -341,7 +351,13 @@ float Choruslimit::getlimits(CommandBlock *getData)
             max = 1;
             canLearn = 0;
             break;
-        case 16:
+        case EFFECT::control::bpm:
+            max = 1;
+            canLearn = 0;
+            break;
+        case EFFECT::control::bpmStart:
+            break;
+        case EFFECT::control::preset:
             max = 9;
             canLearn = 0;
             break;

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -67,7 +67,7 @@ class Chorus : public Effect
         // Internal Values
         float depth;
         float delay;
-        InterpolatedParameter fb;
+        synth::InterpolatedValue<float> fb;
         float dl1;
         float dl2;
         float dr1;
@@ -84,8 +84,6 @@ class Chorus : public Effect
         int dlhi2;
         float dllo;
         float mdel;
-
-        SynthEngine *synth;
 };
 class Choruslimit
 {

--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -52,7 +52,7 @@ namespace { // Implementation details...
 
 
 Distorsion::Distorsion(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth),
     Pvolume(50),
     Pdrive(90),
     Plevel(64),
@@ -62,7 +62,9 @@ Distorsion::Distorsion(bool insertion_, float *efxoutl_, float *efxoutr_, SynthE
     Phpf(0),
     Pstereo(1),
     Pprefiltering(0),
-    synth(_synth)
+    level(0, synth->samplerate),
+    lpffr(0, synth->samplerate),
+    hpffr(0, synth->samplerate)
 {
     level.setTargetValue(Plevel / 127.0f);
     lpfl = new AnalogFilter(2, 22000, 1, 0, synth);

--- a/src/Effects/Distorsion.h
+++ b/src/Effects/Distorsion.h
@@ -63,17 +63,15 @@ class Distorsion : public Effect, WaveShapeSamples
         void setlpf(unsigned char Plpf_);
         void sethpf(unsigned char Phpf_);
 
-        InterpolatedParameter level;
+        synth::InterpolatedValue<float> level;
 
         // Real Parameters
         AnalogFilter *lpfl;
         AnalogFilter *lpfr;
         AnalogFilter *hpfl;
         AnalogFilter *hpfr;
-        InterpolatedParameter lpffr;
-        InterpolatedParameter hpffr;
-
-        SynthEngine *synth;
+        synth::InterpolatedValue<float> lpffr;
+        synth::InterpolatedValue<float> hpffr;
 };
 
 class Distlimit

--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -167,9 +167,7 @@ void DynamicFilter::reinitfilter(void)
 
 void DynamicFilter::setpreset(unsigned char npreset)
 {
-
-
-if (npreset < 0xf)
+    if (npreset < 0xf)
     {
         if (npreset >= NUM_PRESETS)
             npreset = NUM_PRESETS - 1;
@@ -269,6 +267,9 @@ if (npreset < 0xf)
         if (insertion == 0)
             changepar(0, presets[npreset][0] * 0.5f); // lower the volume if this is
                                                   // system effect
+        // All presets use no BPM syncing.
+        changepar(EFFECT::control::bpm, 0);
+
         Ppreset = npreset;
         reinitfilter();
     }
@@ -340,6 +341,14 @@ void DynamicFilter::changepar(int npar, unsigned char value)
             Pampsmooth = value;
             setampsns(Pampsns);
             break;
+
+        case EFFECT::control::bpm:
+            lfo.Pbpm = value;
+            break;
+
+        case EFFECT::control::bpmStart:
+            lfo.PbpmStart = value;
+            break;
     }
     Pchanged = true;
 }
@@ -360,6 +369,8 @@ unsigned char DynamicFilter::getpar(int npar)
         case 7:  return Pampsns;
         case 8:  return Pampsnsinv;
         case 9:  return Pampsmooth;
+        case EFFECT::control::bpm: return lfo.Pbpm;
+        case EFFECT::control::bpmStart: return lfo.PbpmStart;
         default: break;
     }
     return 0;
@@ -407,7 +418,13 @@ float Dynamlimit::getlimits(CommandBlock *getData)
             break;
         case 9:
             break;
-        case 16:
+        case EFFECT::control::bpm:
+            max = 1;
+            canLearn = 0;
+            break;
+        case EFFECT::control::bpmStart:
+            break;
+        case EFFECT::control::preset:
             max = 4;
             canLearn = 0;
             break;

--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -43,15 +43,14 @@ static const char presets[NUM_PRESETS][PRESET_SIZE] = {
 };
 
 DynamicFilter::DynamicFilter(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64, 0, _synth), 0),
+    Effect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64, 0, _synth), 0, _synth),
     lfo(_synth),
     Pdepth(0),
     Pampsns(90),
     Pampsnsinv(0),
     Pampsmooth(60),
     filterl(NULL),
-    filterr(NULL),
-    synth(_synth)
+    filterr(NULL)
 {
     setvolume(110);
     setpreset(Ppreset);

--- a/src/Effects/DynamicFilter.h
+++ b/src/Effects/DynamicFilter.h
@@ -67,8 +67,6 @@ class DynamicFilter : public Effect
 
         Filter *filterl, *filterr;
         float ms1, ms2, ms3, ms4; // mean squares
-
-        SynthEngine *synth;
 };
 
 class Dynamlimit

--- a/src/Effects/EQ.cpp
+++ b/src/Effects/EQ.cpp
@@ -32,8 +32,7 @@ using func::rap2dB;
 
 
 EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
-    synth(_synth)
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth)
 {
     for (int i = 0; i < MAX_EQ_BANDS; ++i)
     {
@@ -44,6 +43,9 @@ EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
         filter[i].Pstages = 0;
         filter[i].l = new AnalogFilter(6, 1000.0, 1.0, 0, synth);
         filter[i].r = new AnalogFilter(6, 1000.0, 1.0, 0, synth);
+        filter[i].freq.setSampleRate(synth->samplerate);
+        filter[i].gain.setSampleRate(synth->samplerate);
+        filter[i].q.setSampleRate(synth->samplerate);
     }
     // default values
     setvolume(50);

--- a/src/Effects/EQ.h
+++ b/src/Effects/EQ.h
@@ -53,11 +53,9 @@ class EQ : public Effect
         void setvolume(unsigned char Pvolume_);
         struct {
             unsigned char Ptype, Pfreq, Pgain, Pq, Pstages; // parameters
-            InterpolatedParameter freq, gain, q;
+            synth::InterpolatedValueDfl<float> freq, gain, q;
             AnalogFilter *l, *r; // internal values
         } filter[MAX_EQ_BANDS];
-
-        SynthEngine *synth;
 };
 
 class EQlimit

--- a/src/Effects/Echo.cpp
+++ b/src/Effects/Echo.cpp
@@ -66,6 +66,7 @@ Echo::Echo(bool insertion_, float* efxoutl_, float* efxoutr_, SynthEngine *_synt
     rdelay = new float[maxdelay];
     realposl = realposr = 1;
     cleanup();
+    initdelays();
 }
 
 
@@ -79,8 +80,8 @@ Echo::~Echo()
 // Cleanup the effect
 void Echo::cleanup(void)
 {
-    memset(ldelay, 0, dl * sizeof(float));
-    memset(rdelay, 0, dr * sizeof(float));
+    memset(ldelay, 0, maxdelay * sizeof(float));
+    memset(rdelay, 0, maxdelay * sizeof(float));
     oldl = oldr = 0.0f;
 }
 

--- a/src/Effects/Echo.h
+++ b/src/Effects/Echo.h
@@ -30,6 +30,12 @@
 
 #include "Effects/Effect.h"
 
+// The ratio which, when exceeded, causes the echo effect to update its internal
+// delay. If not exceeded, the delay remains constant even if the BPM
+// changes. This is to combat fluctuations in inaccurate BPM sources, such as
+// ALSA. Must be a number above 1.0f.
+#define ECHO_INACCURATE_BPM_THRESHOLD 1.02f
+
 class SynthEngine;
 
 class Echo : public Effect
@@ -54,6 +60,7 @@ class Echo : public Effect
         unsigned char Plrdelay; // 4 L/R delay difference
         unsigned char Pfb;      // 6 Feedback
         unsigned char Phidamp;  // 7 Dampening of the Echo
+        bool Pbpm;
 
         void setvolume(unsigned char Pvolume_);
         void setdelay(unsigned char Pdelay_);
@@ -70,6 +77,8 @@ class Echo : public Effect
         float *rdelay;
         int maxdelay;
         float  oldl, oldr; // pt. lpf
+
+        float prevBeat; // Used to calculate BPM.
 
         int realposl, realposr;
         synth::InterpolatedValue<int> lxfade, rxfade;

--- a/src/Effects/Echo.h
+++ b/src/Effects/Echo.h
@@ -62,17 +62,17 @@ class Echo : public Effect
         void sethidamp(unsigned char Phidamp_);
 
         // Real Parameters
-        InterpolatedParameter fb, hidamp;
+        synth::InterpolatedValue<float> fb, hidamp;
         int dl, dr, delay, lrdelay;
 
         void initdelays(void);
         float *ldelay;
         float *rdelay;
+        int maxdelay;
         float  oldl, oldr; // pt. lpf
 
-        int kl, kr;
-
-        SynthEngine *synth;
+        int realposl, realposr;
+        synth::InterpolatedValue<int> lxfade, rxfade;
 };
 
 class Echolimit

--- a/src/Effects/Effect.cpp
+++ b/src/Effects/Effect.cpp
@@ -23,77 +23,26 @@
     This file is derivative of ZynAddSubFX original code, modified April 2011
 */
 
+#include "Misc/SynthEngine.h"
 #include "Effects/Effect.h"
 #include "Misc/NumericFuncs.h"
 
-#define DEFAULT_PARAM_INTERPOLATION_LENGTH_MSECS 10.0f
-
 using func::setAllPan;
 
-float InterpolatedParameter::sampleRate = 0;
-
-InterpolatedParameter::InterpolatedParameter() :
-    targetValue(0.5f),
-    currentValue(0.5f),
-    samplesLeft(0)
-{
-    setInterpolationLength(DEFAULT_PARAM_INTERPOLATION_LENGTH_MSECS);
-}
-
-void InterpolatedParameter::setSampleRate(float sampleRate)
-{
-    InterpolatedParameter::sampleRate = sampleRate;
-}
-
-void InterpolatedParameter::setInterpolationLength(float msecs)
-{
-    float samples = msecs / 1000.0f * sampleRate;
-    // Round up so we are as smooth as possible.
-    samplesToInterpolate = ceilf(samples);
-}
-
-void InterpolatedParameter::setTargetValue(float value)
-{
-    targetValue = value;
-    samplesLeft = samplesToInterpolate;
-}
-
-float InterpolatedParameter::getAndAdvanceValue()
-{
-    float ret = currentValue;
-    advanceValue();
-    return ret;
-}
-
-void InterpolatedParameter::advanceValue()
-{
-    if (samplesLeft > 1) {
-        currentValue = currentValue + (targetValue - currentValue) / samplesLeft;
-        samplesLeft--;
-    } else {
-        currentValue = targetValue;
-        samplesLeft = 0;
-    }
-}
-
-void InterpolatedParameter::advanceValue(int samples)
-{
-    if (samplesLeft > 1 && samples < samplesLeft) {
-        currentValue = currentValue + (targetValue - currentValue) / samplesLeft * (float)samples;
-        samplesLeft -= samples;
-    } else {
-        currentValue = targetValue;
-        samplesLeft = 0;
-    }
-}
-
 Effect::Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
-               FilterParams *filterpars_, unsigned char Ppreset_) :
+               FilterParams *filterpars_, unsigned char Ppreset_,
+               SynthEngine *synth_) :
     Ppreset(Ppreset_),
     efxoutl(efxoutl_),
     efxoutr(efxoutr_),
+    outvolume(0.5f, synth_->samplerate),
+    volume(0.5f, synth_->samplerate),
     filterpars(filterpars_),
-    insertion(insertion_)
+    insertion(insertion_),
+    pangainL(0.5f, synth_->samplerate),
+    pangainR(0.5f, synth_->samplerate),
+    lrcross(0.5f, synth_->samplerate),
+    synth(synth_)
 {
     setpanning(64);
     setlrcross(40);

--- a/src/Effects/Effect.h
+++ b/src/Effects/Effect.h
@@ -28,42 +28,14 @@
 #define EFFECT_H
 
 #include "Params/FilterParams.h"
-
-class InterpolatedParameter
-{
-    public:
-        InterpolatedParameter();
-        static void setSampleRate(float sampleRate);
-        void setInterpolationLength(float msecs);
-        void setTargetValue(float value);
-        float getValue() const
-        {
-            return currentValue;
-        }
-        float getTargetValue() const
-        {
-            return targetValue;
-        }
-        // Get value and advance to the next sample.
-        float getAndAdvanceValue();
-        // Advance to next sample(s) without getting value.
-        void advanceValue();
-        void advanceValue(int samples);
-
-    private:
-        static float sampleRate;
-
-        float targetValue;
-        float currentValue;
-        float samplesLeft;
-        float samplesToInterpolate;
-};
+#include "Misc/SynthHelper.h"
 
 class Effect
 {
     public:
         Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
-               FilterParams *filterpars_, unsigned char Ppreset_);
+               FilterParams *filterpars_, unsigned char Ppreset_,
+               SynthEngine *synth_);
         virtual ~Effect() { };
 
         virtual void setpreset(unsigned char npreset) = 0;
@@ -76,8 +48,8 @@ class Effect
         unsigned char Ppreset; // Currentl preset
         float *const efxoutl;
         float *const efxoutr;
-        InterpolatedParameter outvolume;
-        InterpolatedParameter volume;
+        synth::InterpolatedValue<float> outvolume;
+        synth::InterpolatedValue<float> volume;
         FilterParams *filterpars;
 
     protected:
@@ -86,10 +58,12 @@ class Effect
 
         bool  insertion;
         char  Ppanning;
-        InterpolatedParameter pangainL;
-        InterpolatedParameter pangainR;
+        synth::InterpolatedValue<float> pangainL;
+        synth::InterpolatedValue<float> pangainR;
         char  Plrcross; // L/R mix
-        InterpolatedParameter lrcross;
+        synth::InterpolatedValue<float> lrcross;
+
+        SynthEngine *synth;
 };
 
 #endif

--- a/src/Effects/EffectLFO.h
+++ b/src/Effects/EffectLFO.h
@@ -38,10 +38,13 @@ class EffectLFO
         unsigned char Prandomness;
         unsigned char PLFOtype;
         unsigned char Pstereo; // 64 = center
+        unsigned char Pbpm;
+        unsigned char PbpmStart;
     private:
         float getlfoshape(float x);
 
-        float xl,xr;
+        float xl, xr;
+        float xdelta; // position delta to x when using stereo separation.
         float incx;
         float ampl1, ampl2, ampr1, ampr2; // necessary for "randomness"
         float lfornd;

--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -43,7 +43,6 @@ EffectMgr::EffectMgr(const bool insertion_, SynthEngine *_synth) :
     efxoutr = (float*)fftwf_malloc(synth->bufferbytes);
     memset(efxoutl, 0, synth->bufferbytes);
     memset(efxoutr, 0, synth->bufferbytes);
-    InterpolatedParameter::setSampleRate(synth->samplerate_f);
     defaults();
 }
 
@@ -248,8 +247,7 @@ void EffectMgr::out(float *smpsl, float *smpsr)
 // Get the effect volume for the system effect
 float EffectMgr::sysefxgetvolume(void)
 {
-    // No interpolation for system effect currently (direct target value).
-    return (!efx) ? 1.0f : efx->outvolume.getTargetValue();
+    return (!efx) ? 1.0f : efx->outvolume.getValue();
 }
 
 

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -399,6 +399,8 @@ void Phaser::setpreset(unsigned char npreset)
             npreset = NUM_PRESETS - 1;
         for (int n = 0; n < PRESET_SIZE; ++n)
             changepar(n, presets[npreset][n]);
+        // All presets use no BPM syncing.
+        changepar(EFFECT::control::bpm, 0);
         Ppreset = npreset;
     }
     else
@@ -488,6 +490,14 @@ void Phaser::changepar(int npar, unsigned char value)
         case 14:
             Panalog = value;
             break;
+
+        case EFFECT::control::bpm:
+            lfo.Pbpm = value;
+            break;
+
+        case EFFECT::control::bpmStart:
+            lfo.PbpmStart = value;
+            break;
     }
     Pchanged = true;
 }
@@ -515,6 +525,8 @@ unsigned char Phaser::getpar(int npar)
         case 12: return Phyper;
         case 13: return Pdistortion;
         case 14: return Panalog;
+        case EFFECT::control::bpm: return lfo.Pbpm;
+        case EFFECT::control::bpmStart: return lfo.PbpmStart;
         default: break;
     }
     return 0;
@@ -576,7 +588,13 @@ float Phaserlimit::getlimits(CommandBlock *getData)
             max = 1;
             canLearn = 0;
             break;
-        case 16:
+        case EFFECT::control::bpm:
+            max = 1;
+            canLearn = 0;
+            break;
+        case EFFECT::control::bpmStart:
+            break;
+        case EFFECT::control::preset:
             max = 11;
             canLearn = 0;
             break;

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -64,15 +64,14 @@ namespace {
 
 
 Phaser::Phaser(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth),
     lfo(_synth),
     oldl(NULL),
     oldr(NULL),
     xn1l(NULL),
     xn1r(NULL),
     yn1l(NULL),
-    yn1r(NULL),
-    synth(_synth)
+    yn1r(NULL)
 {
     analog_setup();
     setpreset(Ppreset);

--- a/src/Effects/Phaser.h
+++ b/src/Effects/Phaser.h
@@ -114,8 +114,6 @@ class Phaser : public Effect
 
         void NormalPhase(float *smpsl, float *smpsr);
         float applyPhase(float x, float g, float *old);
-
-        SynthEngine *synth;
 };
 
 class Phaserlimit

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -68,7 +68,7 @@ static unsigned char presets[NUM_PRESETS][PRESET_SIZE] = {
 // todo: EarlyReflections, Prdelay, Perbalance
 
 Reverb::Reverb(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0),
+    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth),
     // defaults
 //    Pvolume(48),
     Ptime(64),
@@ -88,7 +88,8 @@ Reverb::Reverb(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_
     idelay(NULL),
     lpf(NULL),
     hpf(NULL), // no filter
-    synth(_synth)
+    lpffr(0, synth->samplerate),
+    hpffr(0, synth->samplerate)
 {
     setvolume(48);
     inputbuf = (float*)fftwf_malloc(synth->bufferbytes);

--- a/src/Effects/Reverb.h
+++ b/src/Effects/Reverb.h
@@ -105,11 +105,9 @@ class Reverb : public Effect
         float *idelay;
         AnalogFilter *lpf;  // filters
         AnalogFilter *hpf;
-        InterpolatedParameter lpffr;
-        InterpolatedParameter hpffr;
+        synth::InterpolatedValue<float> lpffr;
+        synth::InterpolatedValue<float> hpffr;
         float *inputbuf;
-
-        SynthEngine *synth;
 };
 
 class Revlimit

--- a/src/Interface/Data2Text.cpp
+++ b/src/Interface/Data2Text.cpp
@@ -3303,12 +3303,16 @@ string DataText::resolveEffects(CommandBlock *getData, bool addValue)
         }
         case EFFECT::type::echo:
             effname = " Echo ";
-            controlType = echolist[control * 2];
+            if (ref > 6) // there is no 7-16 in the list names
+                ref -= 10;
+            controlType = echolist[ref * 2];
             break;
         case EFFECT::type::chorus:
         {
             effname = " Chorus ";
-            if (ref > 9) // there is no 10 in the list names
+            if (ref > 10) // there is no 11-16 in the list names
+                ref -= 6;
+            else if (ref > 9) // there is no 10 in the list names
                 ref --;
             controlType = choruslist[ref * 2];
             if (addValue == true && offset > 0)
@@ -3334,7 +3338,9 @@ string DataText::resolveEffects(CommandBlock *getData, bool addValue)
         }
         case EFFECT::type::phaser:
             effname = " Phaser ";
-            controlType = phaserlist[control * 2];
+            if (ref > 14) // there is no 15-16 in the list names
+                ref -= 2;
+            controlType = phaserlist[ref * 2];
             if (addValue == true && offset > 0)
             {
                 switch (control)
@@ -3360,7 +3366,9 @@ string DataText::resolveEffects(CommandBlock *getData, bool addValue)
             break;
         case EFFECT::type::alienWah:
             effname = " AlienWah ";
-            controlType = alienwahlist[control * 2];
+            if (ref > 10) // there is no 11-16 in the list names
+                ref -= 6;
+            controlType = alienwahlist[ref * 2];
             if (control == 4 && addValue == true  && offset > 0)
             {
                 showValue = false;
@@ -3432,7 +3440,9 @@ string DataText::resolveEffects(CommandBlock *getData, bool addValue)
         }
         case EFFECT::type::dynFilter:
             effname = " DynFilter ";
-            controlType = dynfilterlist[control * 2];
+            if (ref > 10) // there is no 11-16 in the list names
+                ref -= 6;
+            controlType = dynfilterlist[ref * 2];
             if (addValue == true && offset > 0)
             {
                 if (control == 4)
@@ -3459,7 +3469,7 @@ string DataText::resolveEffects(CommandBlock *getData, bool addValue)
             contstr = " Unrecognised";
     }
     //std::cout << "control " << int(control) << std::endl;
-    if (control == 16 && kititem != EFFECT::type::eq)
+    if (control == EFFECT::control::preset && kititem != EFFECT::type::eq)
     {
         contstr = " Preset " + to_string (value + 1);
         showValue = false;

--- a/src/Interface/TextLists.h
+++ b/src/Interface/TextLists.h
@@ -766,6 +766,7 @@ static std::string echolist [] = {
     "CROssover <n>",    "left-right crossover",
     "FEEdback <n>",     "echo feedback",
     "DAMp <n>",         "feedback damping",
+    "BPM <s>",          "delay BPM sync (ON {other})",
     "@end"
 };
 
@@ -781,6 +782,8 @@ static std::string choruslist [] = {
     "FEEdback <n>",     "chorus feedback",
     "CROssover <n>",    "L/R routing",
     "SUBtract <s>",     "invert output (ON {other})",
+    "BPM <s>",          "LFO BPM sync (ON {other})",
+    "STArt <n>",        "LFO BPM phase start",
     "@end"
 };
 
@@ -800,6 +803,8 @@ static std::string phaserlist [] = {
     "HYPer <s>",        "hyper ?  (ON {other})",
     "OVErdrive <n>",    "distortion",
     "ANAlog <s>",       "analog emulation (ON {other})",
+    "BPM <s>",          "LFO BPM sync (ON {other})",
+    "STArt <n>",        "LFO BPM phase start",
     "@end"
 };
 
@@ -815,6 +820,8 @@ static std::string alienwahlist [] = {
     "DELay <n>",        "LFO delay",
     "CROssover <n>",    "L/R routing",
     "RELative <n>",     "relative phase",
+    "BPM <s>",          "LFO BPM sync (ON {other})",
+    "STArt <n>",        "LFO BPM phase start",
     "@end"
 };
 
@@ -858,6 +865,8 @@ static std::string dynfilterlist [] = {
     "INVert <s>",       "reverse effect of sensitivity (ON {other})",
     "RATe <n>",         "speed of filter change with amplitude",
     "FILter ...",       "enter dynamic filter context",
+    "BPM <s>",          "LFO BPM sync (ON {other})",
+    "STArt <n>",        "LFO BPM phase start",
     "@end"
 };
 

--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -77,8 +77,6 @@ private:
        char data[4]; // all events of interest are <= 4bytes
    };
 
-   float _bpm;
-
    float *_bFreeWheel;
 
    pthread_t _pIdleThread;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -258,9 +258,13 @@ class SynthEngine
         int64_t getLFOtime() {return LFOtime;}
         float getSongBeat() {return songBeat;}
         float getMonotonicBeat() {return monotonicBeat;}
-        void setBeatValues(float song, float monotonic) {
-            songBeat = song;
-            monotonicBeat = monotonic;
+        float getBPM() { return bpm; }
+        bool isBPMAccurate() { return bpmAccurate; }
+        void setBPMAccurate(bool value) { bpmAccurate = value; }
+        void setBeatValues(float songBeat, float monotonicBeat, float bpm) {
+            this->songBeat = songBeat;
+            this->monotonicBeat = monotonicBeat;
+            this->bpm = bpm;
         }
         string makeUniqueName(const string& name);
 
@@ -292,6 +296,9 @@ class SynthEngine
         int64_t LFOtime; // used by Pcontinous without Pbpm
         float songBeat; // used by Pbpm without Pcontinous
         float monotonicBeat; // used by Pbpm
+        float bpm; // used by Echo Effect
+        bool bpmAccurate; // Set to false by engines that can't provide an
+                          // accurate BPM value.
 
         string windowTitle;
         //MusicClient *musicClient;

--- a/src/MusicIO/AlsaEngine.h
+++ b/src/MusicIO/AlsaEngine.h
@@ -36,6 +36,9 @@
 
 #define MIDI_SONGPOS_BEAT_DIVISION 4
 
+#define ALSA_MIDI_BPM_MEDIAN_WINDOW 48
+#define ALSA_MIDI_BPM_MEDIAN_AVERAGE_WINDOW 20
+
 class SynthEngine;
 
 class AlsaEngine : public MusicIO
@@ -119,6 +122,10 @@ class AlsaEngine : public MusicIO
             // Reset to zero every MIDI_CLOCK_DIVISION. This is actually an
             // integer, but stored as float for calculation purposes.
             float             clockCount;
+
+            float             prevBpms[ALSA_MIDI_BPM_MEDIAN_WINDOW];
+            int               prevBpmsPos;
+            int64_t           prevClockUs;
         } midi;
 };
 

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -91,7 +91,5 @@ class JackEngine : public MusicIO
         jack_port_t   *midiPort;
 
         unsigned int internalbuff;
-
-        float bpm;
 };
 #endif /*JACK_ENGINE_H*/

--- a/src/MusicIO/MusicIO.h
+++ b/src/MusicIO/MusicIO.h
@@ -67,6 +67,13 @@ class MusicIO
 class BeatTracker
 {
     public:
+        struct BeatValues {
+            float songBeat;
+            float monotonicBeat;
+            float bpm;
+        };
+
+    public:
         BeatTracker();
         virtual ~BeatTracker();
 
@@ -79,11 +86,11 @@ class BeatTracker
         // storing the wrapped value in order to preserve precision when the
         // beat count gets high. The wrapped around value is guaranteed to
         // divide all possible LFO fractions.
-        virtual std::pair<float, float> setBeatValues(std::pair<float, float> beats) = 0;
-        virtual std::pair<float, float> getBeatValues() = 0;
+        virtual BeatValues setBeatValues(BeatValues beats) = 0;
+        virtual BeatValues getBeatValues() = 0;
 
     protected:
-        void adjustMonotonicRounding(std::pair<float, float> *beats);
+        void adjustMonotonicRounding(BeatValues *beats);
 
     private:
         float songVsMonotonicBeatDiff;
@@ -98,8 +105,8 @@ class MultithreadedBeatTracker : public BeatTracker
         // These two functions are mutually thread safe, even though they
         // operate on the same data. The first is usually called from the MIDI
         // thread, the second from the audio thread.
-        std::pair<float, float> setBeatValues(std::pair<float, float> beats);
-        std::pair<float, float> getBeatValues();
+        BeatValues setBeatValues(BeatValues beats);
+        BeatValues getBeatValues();
 
     private:
         // Current and last time and beats of the MIDI clock.
@@ -109,6 +116,7 @@ class MultithreadedBeatTracker : public BeatTracker
         volatile uint64_t timeUs;
         volatile float    songBeat;
         volatile float    monotonicBeat;
+        volatile float    bpm;
         pthread_mutex_t   mutex;
 };
 
@@ -117,12 +125,11 @@ class SinglethreadedBeatTracker : public BeatTracker
     public:
         SinglethreadedBeatTracker();
 
-        std::pair<float, float> setBeatValues(std::pair<float, float> beats);
-        std::pair<float, float> getBeatValues();
+        BeatValues setBeatValues(BeatValues beats);
+        BeatValues getBeatValues();
 
     private:
-        float songBeat;
-        float monotonicBeat;
+        BeatValues beats;
 };
 
 #endif

--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -55,8 +55,10 @@ LFO::LFO(LFOParams *_lfopars, float _basefreq, SynthEngine *_synth):
         {
             prevMonotonicBeat = synth->getMonotonicBeat();
             prevBpmFrac = getBpmFrac();
-            startPhase = remainderf(startPhase - prevMonotonicBeat
-                                    * prevBpmFrac.first / prevBpmFrac.second, 1.0f);
+            startPhase = fmodf(startPhase - prevMonotonicBeat
+                               * prevBpmFrac.first / prevBpmFrac.second, 1.0f);
+            if (startPhase < 0)
+                startPhase += 1.0f;
         }
     }
     else if (lfopars->Pbpm == 0)
@@ -270,7 +272,9 @@ float LFO::lfoout()
                     // Since we reset the phase on every cycle, if the BPM
                     // fraction changes we need to adapt startPhase or we will
                     // get an abrupt phase change.
-                    startPhase = remainderf(x - prevMonotonicBeat * frac.first / frac.second, 1.0f);
+                    startPhase = fmodf(x - prevMonotonicBeat * frac.first / frac.second, 1.0f);
+                    if (startPhase < 0)
+                        startPhase += 1.0f;
                     prevBpmFrac = frac;
                 }
                 newBeat = synth->getMonotonicBeat();

--- a/src/UI/EffUI.fl
+++ b/src/UI/EffUI.fl
@@ -751,6 +751,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
         tooltip {LFO Randomness} xywh {120 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
       Fl_Dial awp5 {
@@ -1033,6 +1034,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
         tooltip {LFO Randomness} xywh {118 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
       Fl_Dial dfp5 {

--- a/src/UI/EffUI.fl
+++ b/src/UI/EffUI.fl
@@ -360,7 +360,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
   }
   Function {make_echo_window()} {} {
     Fl_Window effechowindow {
-      xywh {1006 149 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1 labelsize 12 hide
+      xywh {979 149 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1 labelsize 12 hide
       class Fl_Group
     } {
       Fl_Text_Display echoname {
@@ -397,7 +397,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         int butt = 2;
         send_data(0, butt, o->value(), EFFECT::type::echo, TOPLEVEL::type::Integer);}
         xywh {111 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
-        code0 {o->setValueType(VC_FXEchoDelay);}
+        code0 {o->setValueType(eff->geteffectpar(EFFECT::control::bpm) ? VC_FXlfofreqBPM : VC_FXEchoDelay);}
         class WidgetPDial
       }
       Fl_Dial echop3 {
@@ -436,6 +436,12 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
+      Fl_Check_Button echop17 {
+        label BPM
+        callback {//
+        send_data(0, EFFECT::control::bpm, o->value(), EFFECT::type::echo, TOPLEVEL::type::Integer);}
+        tooltip {Synchronize the frequency to a multiple of the BPM. Note that the delay is capped at 5 seconds, even if the tempo is slower than this.} xywh {325 10 45 15} down_box DOWN_BOX labelsize 11
+      }
     }
   }
   Function {make_chorus_window()} {} {
@@ -458,14 +464,14 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         label {LFO type}
         callback {//
         send_data(0, 4, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {LFO function} xywh {154 56 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
+        tooltip {LFO function} xywh {189 65 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
         code0 {o->add("Sine");o->add("Tri");}
       } {}
       Fl_Dial chorusp0 {
         label Vol
         callback {//
         send_data(0, 0, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        xywh {10 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {10 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXdefaultVol);}
         class WidgetPDial
       }
@@ -474,7 +480,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 1;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        xywh {45 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {45 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_PanningStd);}
         class WidgetPDial
       }
@@ -483,8 +489,17 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 2;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {LFO Frequency} xywh {85 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
-        code0 {o->setValueType(VC_FXlfofreq);}
+        tooltip {LFO Frequency} xywh {85 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        code0 {o->setValueType(eff->geteffectpar(EFFECT::control::bpm) ? VC_FXlfofreqBPM : VC_FXlfofreq);}
+        class WidgetPDial
+      }
+      Fl_Dial chorusp18 {
+        label Start
+        callback {//
+        send_data(0, EFFECT::control::bpmStart, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
+        tooltip {Start of LFO phase relative to start of beat. This has no effect unless you are syncing to a song position, using MIDI or a plugin host.} xywh {120 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_PhaseOffset);}
+        code1 {if (eff->geteffectpar(EFFECT::control::bpm)) o->activate(); else o->deactivate();}
         class WidgetPDial
       }
       Fl_Dial chorusp3 {
@@ -492,7 +507,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {LFO Randomness} xywh {120 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        tooltip {LFO Randomness} xywh {155 49 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
         code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
@@ -501,7 +516,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 5;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {L/R Phase Shift} xywh {200 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {L/R Phase Shift} xywh {235 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXlfoStereo);}
         class WidgetPDial
       }
@@ -510,7 +525,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 6;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {LFO Depth} xywh {235 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {LFO Depth} xywh {270 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXChorusDepth);}
         class WidgetPDial
       }
@@ -519,7 +534,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 7;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        xywh {270 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {305 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXChorusDelay);}
         class WidgetPDial
       }
@@ -528,7 +543,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt =8;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip Feedback xywh {305 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip Feedback xywh {340 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXdefaultFb);}
         class WidgetPDial
       }
@@ -537,7 +552,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 9;
         send_data(0, butt, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {Channel Routing} xywh {340 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Channel Routing} xywh {252 15 30 30} box ROUND_UP_BOX labelsize 11 align 1 maximum 127
         code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
@@ -553,14 +568,20 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         label Subtract
         callback {//
         send_data(0, 11, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
-        tooltip {inverts the output} xywh {232 13 83 16} box THIN_UP_BOX down_box DOWN_BOX color 230 labelsize 11
+        tooltip {inverts the output} xywh {295 19 70 16} down_box DOWN_BOX color 230 labelsize 11
         class Fl_Check_Button2
+      }
+      Fl_Check_Button chorusp17 {
+        label BPM
+        callback {//
+        send_data(0, EFFECT::control::bpm, o->value(), EFFECT::type::chorus, TOPLEVEL::type::Integer);}
+        tooltip {Synchronize the frequency to a multiple of the BPM.} xywh {190 45 50 15} down_box DOWN_BOX labelsize 11
       }
     }
   }
   Function {make_phaser_window()} {} {
     Fl_Window effphaserwindow {
-      xywh {461 237 375 95} type Double box PLASTIC_UP_BOX color 221 labelsize 11 hide
+      xywh {849 326 375 95} type Double box PLASTIC_UP_BOX color 221 labelsize 11 hide
       class Fl_Group
     } {
       Fl_Text_Display phasername {
@@ -571,14 +592,14 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         label Preset
         callback {//
         send_data(TOPLEVEL::action::forceUpdate, 16, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        xywh {80 21 82 15} box UP_BOX down_box BORDER_BOX color 14 selection_color 0 labelsize 11 align 1 textfont 1 textsize 10 textcolor 7
+        xywh {65 21 82 15} box UP_BOX down_box BORDER_BOX color 14 selection_color 0 labelsize 11 align 1 textfont 1 textsize 10 textcolor 7
         code0 {o->add("Phaser 1");o->add("Phaser 2");o->add("Phaser 3");o->add("Phaser 4");o->add("Phaser 5");o->add("Phaser 6");o->add("APhaser 1");o->add("APhaser 2");o->add("APhaser 3");o->add("APhaser 4");o->add("APhaser 5");o->add("APhaser 6");}
       } {}
       Fl_Choice phaserp4 {
         label {LFO Type}
         callback {//
         send_data(0, 4, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        tooltip {LFO function} xywh {161 65 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
+        tooltip {LFO function} xywh {199 65 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
         code0 {o->add("Sine");o->add("Tri");}
       } {}
       Fl_Dial phaserp0 {
@@ -604,7 +625,16 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         int butt = 2;
         send_data(0, butt, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
         tooltip {LFO frequency} xywh {84 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
-        code0 {o->setValueType(VC_FXlfofreq);}
+        code0 {o->setValueType(eff->geteffectpar(EFFECT::control::bpm) ? VC_FXlfofreqBPM : VC_FXlfofreq);}
+        class WidgetPDial
+      }
+      Fl_Dial phaserp18 {
+        label Start
+        callback {//
+        send_data(0, EFFECT::control::bpmStart, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
+        tooltip {Start of LFO phase relative to start of beat. This has no effect unless you are syncing to a song position, using MIDI or a plugin host.} xywh {125 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_PhaseOffset);}
+        code1 {if (eff->geteffectpar(EFFECT::control::bpm)) o->activate(); else o->deactivate();}
         class WidgetPDial
       }
       Fl_Dial phaserp3 {
@@ -612,16 +642,24 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        tooltip {LFO randomness} xywh {122 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        tooltip {LFO randomness} xywh {165 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
         code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
+      }
+      Fl_Check_Button phaserp17 {
+        label BPM
+        callback {//
+        send_data(0, EFFECT::control::bpm, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
+        tooltip {Synchronize the frequency to a multiple of the BPM.} xywh {200 47 17 15} down_box DOWN_BOX labelsize 11 align 8
+        code0 {o->value(eff->geteffectpar(EFFECT::control::bpm));}
+        class Fl_Check_Button2
       }
       Fl_Dial phaserp5 {
         label {St.df}
         callback {//
         int butt = 5;
         send_data(0, butt, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        tooltip {Left/Right Channel Phase Shift} xywh {210 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Left/Right Channel Phase Shift} xywh {248 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXlfoStereo);}
         class WidgetPDial
       }
@@ -639,7 +677,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 7;
         send_data(0, butt, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        tooltip Feedback xywh {248 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip Feedback xywh {286 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         code0 {o->setValueType(VC_FXdefaultFb);}
         class WidgetPDial
       }
@@ -670,7 +708,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 11;
         send_data(0, butt, o->value(), EFFECT::type::phaser, TOPLEVEL::type::Integer);}
-        xywh {286 50 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {150 15 30 30} box ROUND_UP_BOX labelsize 11 align 1 maximum 127
         code0 {o->setValueType(VC_percent127);}
         class WidgetPDial
       }
@@ -699,9 +737,10 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
       }
     }
   }
-  Function {make_alienwah_window()} {} {
+  Function {make_alienwah_window()} {
+  } {
     Fl_Window effalienwahwindow {
-      xywh {883 397 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1 hide
+      xywh {845 398 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1 hide
       class Fl_Group
     } {
       Fl_Text_Display alienname {
@@ -719,14 +758,14 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         label {LFO type}
         callback {//
         send_data(0, 4, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip {LFO function} xywh {154 56 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
+        tooltip {LFO function} xywh {185 65 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
         code0 {o->add("Sine");o->add("Tri");}
       } {}
       Fl_Dial awp0 {
         label Vol
         callback {//
         send_data(0, 0, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip {Effect Volume} xywh {10 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Effect Volume} xywh {5 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp1 {
@@ -734,7 +773,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 1;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        xywh {45 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {40 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp2 {
@@ -742,7 +781,8 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 2;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip {LFO Frequency} xywh {85 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {LFO Frequency} xywh {80 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        code0 {o->setValueType(eff->geteffectpar(EFFECT::control::bpm) ? VC_FXlfofreqBPM : VC_FXlfofreq);}
         class WidgetPDial
       }
       Fl_Dial awp3 {
@@ -750,8 +790,17 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip {LFO Randomness} xywh {120 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        tooltip {LFO Randomness} xywh {150 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
         code0 {o->setValueType(VC_percent127);}
+        class WidgetPDial
+      }
+      Fl_Dial awp18 {
+        label Start
+        callback {//
+        send_data(0, EFFECT::control::bpmStart, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
+        tooltip {Start of LFO phase relative to start of beat. This has no effect unless you are syncing to a song position, using MIDI or a plugin host.} xywh {115 50 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_PhaseOffset);}
+        code1 {if (eff->geteffectpar(EFFECT::control::bpm)) o->activate(); else o->deactivate();}
         class WidgetPDial
       }
       Fl_Dial awp5 {
@@ -759,7 +808,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 5;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip {Left/Right Channel Phase Shift} xywh {200 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Left/Right Channel Phase Shift} xywh {231 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp6 {
@@ -767,7 +816,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 6;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip Depth xywh {235 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip Depth xywh {266 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp7 {
@@ -775,7 +824,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 7;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        tooltip Feedback xywh {270 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip Feedback xywh {301 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp9 {
@@ -783,7 +832,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 9;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        xywh {345 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {285 15 30 30} box ROUND_UP_BOX labelsize 11 align 1 maximum 127
         class WidgetPDial
       }
       Fl_Dial awp10 {
@@ -791,14 +840,21 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 10;
         send_data(0, butt, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        xywh {309 8 26 26} box ROUND_UP_BOX labelsize 11 align 4 maximum 127
+        xywh {245 15 30 30} box ROUND_UP_BOX labelsize 11 align 1 maximum 127
         class WidgetPDial
       }
       Fl_Counter awp8 {
         label Delay
         callback {//
         send_data(0, 8, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
-        xywh {305 55 35 15} type Simple labelsize 11 minimum 0 maximum 100 step 1 textsize 11
+        xywh {336 64 35 15} type Simple labelsize 11 minimum 0 maximum 100 step 1 textsize 11
+      }
+      Fl_Check_Button awp17 {
+        label BPM
+        callback {//
+        send_data(0, EFFECT::control::bpm, o->value(), EFFECT::type::alienWah, TOPLEVEL::type::Integer);}
+        tooltip {Synchronize the frequency to a multiple of the BPM.} xywh {185 45 45 15} down_box DOWN_BOX labelsize 11
+        code0 {o->value(eff->geteffectpar(EFFECT::control::bpm));}
       }
     }
   }
@@ -982,9 +1038,10 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
       }
     }
   }
-  Function {make_dynamicfilter_window()} {} {
+  Function {make_dynamicfilter_window()} {
+  } {
     Fl_Window effdynamicfilterwindow {
-      xywh {1009 883 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1 hide
+      xywh {859 349 375 95} type Double box PLASTIC_UP_BOX color 221 labelfont 1
       class Fl_Group
     } {
       Fl_Text_Display dfname {
@@ -1002,14 +1059,14 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         label {LFO type}
         callback {//
         send_data(0, 4, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {LFO function} xywh {154 55 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
+        tooltip {LFO function} xywh {190 64 43 15} down_box BORDER_BOX labelsize 10 align 2 textfont 1 textsize 9
         code0 {o->add("Sine");o->add("Tri");}
       } {}
       Fl_Dial dfp0 {
         label Vol
         callback {//
         send_data(0, 0, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {Effect Volume} xywh {6 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Effect Volume} xywh {6 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial dfp1 {
@@ -1017,7 +1074,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 1;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        xywh {42 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        xywh {42 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial dfp2 {
@@ -1025,7 +1082,8 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 2;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {LFO Frequency} xywh {80 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {LFO Frequency} xywh {80 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        code0 {o->setValueType(eff->geteffectpar(EFFECT::control::bpm) ? VC_FXlfofreqBPM : VC_FXlfofreq);}
         class WidgetPDial
       }
       Fl_Dial dfp3 {
@@ -1033,53 +1091,69 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
         callback {//
         int butt = 3;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {LFO Randomness} xywh {118 40 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        tooltip {LFO Randomness} xywh {155 49 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
         code0 {o->setValueType(VC_percent127);}
+        class WidgetPDial
+      }
+      Fl_Dial dfp18 {
+        label Start
+        callback {//
+        send_data(0, EFFECT::control::bpmStart, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
+        tooltip {Start of LFO phase relative to start of beat. This has no effect unless you are syncing to a song position, using MIDI or a plugin host.} xywh {118 49 30 30} box ROUND_UP_BOX labelsize 11 when 4 maximum 127
+        code0 {o->setValueType(VC_PhaseOffset);}
+        code1 {if (eff->geteffectpar(EFFECT::control::bpm)) o->activate(); else o->deactivate();}
         class WidgetPDial
       }
       Fl_Dial dfp5 {
         label {St.df}
         callback {int butt = 5;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {Left/Right Channel Phase Shift} xywh {205 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {Left/Right Channel Phase Shift} xywh {240 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
         class WidgetPDial
       }
       Fl_Dial dfp6 {
         label LfoD
         callback {int butt = 6;
         send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-        tooltip {LFO Depth} xywh {240 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+        tooltip {LFO Depth} xywh {240 10 30 30} box ROUND_UP_BOX labelsize 11 align 8 maximum 127
         class WidgetPDial
       }
       Fl_Button filter {
         label Filter
         callback {Showfilt();}
-        xywh {235 13 37 16} box PLASTIC_THIN_UP_BOX labelsize 11
+        xywh {325 14 37 16} box PLASTIC_THIN_UP_BOX labelsize 11
       }
       Fl_Group {} {
-        xywh {275 33 100 53} box EMBOSSED_BOX color 181
+        xywh {275 42 100 53} box EMBOSSED_BOX color 181
       } {
         Fl_Dial dfp7 {
           label {A.S.}
           callback {int butt = 7;
           send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-          tooltip {Filter vs Amplitude} xywh {280 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+          tooltip {Filter vs Amplitude} xywh {280 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
           class WidgetPDial
         }
         Fl_Dial dfp9 {
           label {A.M}
           callback {int butt = 9;
           send_data(0, butt, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-          tooltip {rate that  amplitude changes the filter} xywh {316 40 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
+          tooltip {rate that  amplitude changes the filter} xywh {316 49 30 30} box ROUND_UP_BOX labelsize 11 maximum 127
           class WidgetPDial
         }
         Fl_Check_Button dfp8 {
           label {Inv.}
           callback {//
           send_data(0, 8, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
-          tooltip {enable for filter frequency to lower with higher input amplitude} xywh {352 55 15 15} down_box DOWN_BOX labelsize 11 align 2
+          tooltip {enable for filter frequency to lower with higher input amplitude} xywh {352 64 15 15} down_box DOWN_BOX labelsize 11 align 2
           class Fl_Check_Button2
         }
+      }
+      Fl_Check_Button dfp17 {
+        label BPM
+        callback {//
+        send_data(0, EFFECT::control::bpm, o->value(), EFFECT::type::dynFilter, TOPLEVEL::type::Integer);}
+        tooltip {Synchronize the frequency to a multiple of the BPM.} xywh {191 45 45 15} down_box DOWN_BOX labelsize 11
+        code0 {o->value(eff->geteffectpar(EFFECT::control::bpm));}
       }
     }
   }
@@ -1214,6 +1288,13 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 case 6:
                     echop6->value(value);
                     break;
+                case EFFECT::control::bpm:
+                    echop17->value(value);
+                    if (value)
+                        echop2->setValueType(VC_FXlfofreqBPM);
+                    else
+                        echop2->setValueType(VC_FXEchoDelay);
+                    break;
                 case EFFECT::control::preset:
                     refresh();
                     break;
@@ -1254,6 +1335,22 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                     break;
                 case 11:
                     chorusp11->value(value_int);
+                    break;
+                case EFFECT::control::bpm:
+                    chorusp17->value(value);
+                    if (value)
+                    {
+                        chorusp2->setValueType(VC_FXlfofreqBPM);
+                        chorusp18->activate();
+                    }
+                    else
+                    {
+                        chorusp2->setValueType(VC_FXlfofreq);
+                        chorusp18->deactivate();
+                    }
+                    break;
+                case EFFECT::control::bpmStart:
+                    chorusp18->value(value);
                     break;
                 case EFFECT::control::preset:
                     refresh();
@@ -1325,6 +1422,22 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                         phaserp13->deactivate();
                     }
                     break;
+                case EFFECT::control::bpm:
+                    phaserp17->value(value);
+                    if (value)
+                    {
+                        phaserp2->setValueType(VC_FXlfofreqBPM);
+                        phaserp18->activate();
+                    }
+                    else
+                    {
+                        phaserp2->setValueType(VC_FXlfofreq);
+                        phaserp18->deactivate();
+                    }
+                    break;
+                case EFFECT::control::bpmStart:
+                    phaserp18->value(value);
+                    break;
                 case EFFECT::control::preset:
                     refresh();
                     break;
@@ -1368,6 +1481,22 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                     break;
                 case 10:
                     awp10->value(value);
+                    break;
+                case EFFECT::control::bpm:
+                    awp17->value(value);
+                    if (value)
+                    {
+                        awp2->setValueType(VC_FXlfofreqBPM);
+                        awp18->activate();
+                    }
+                    else
+                    {
+                        awp2->setValueType(VC_FXlfofreq);
+                        awp18->deactivate();
+                    }
+                    break;
+                case EFFECT::control::bpmStart:
+                    awp18->value(value);
                     break;
                 case EFFECT::control::preset:
                     refresh();
@@ -1505,6 +1634,22 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 case 9:
                     dfp9->value(value);
                     break;
+                case EFFECT::control::bpm:
+                    dfp17->value(value);
+                    if (value)
+                    {
+                        dfp2->setValueType(VC_FXlfofreqBPM);
+                        dfp18->activate();
+                    }
+                    else
+                    {
+                        dfp2->setValueType(VC_FXlfofreq);
+                        dfp18->deactivate();
+                    }
+                    break;
+                case EFFECT::control::bpmStart:
+                    dfp18->value(value);
+                    break;
                 case EFFECT::control::preset:
                     refresh();
                     break;
@@ -1604,6 +1749,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
             echop4->value(eff->geteffectpar(4));
             echop5->value(eff->geteffectpar(5));
             echop6->value(eff->geteffectpar(6));
+            echop17->value(eff->geteffectpar(17));
             effechowindow->show();
             break;
         case 3:
@@ -1624,6 +1770,18 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
             chorusp8->value(eff->geteffectpar(8));
             chorusp9->value(eff->geteffectpar(9));
             chorusp11->value(eff->geteffectpar(11));
+            chorusp17->value(eff->geteffectpar(17));
+            if (chorusp17->value())
+            {
+                chorusp2->setValueType(VC_FXlfofreqBPM);
+                chorusp18->activate();
+            }
+            else
+            {
+                chorusp2->setValueType(VC_FXlfofreq);
+                chorusp18->deactivate();
+            }
+            chorusp18->value(eff->geteffectpar(18));
             effchoruswindow->show();
             break;
         case 4:
@@ -1662,6 +1820,18 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 phaserp12->deactivate();
                 phaserp13->deactivate();
             }
+            phaserp17->value(eff->geteffectpar(17));
+            if (phaserp17->value())
+            {
+                phaserp2->setValueType(VC_FXlfofreqBPM);
+                phaserp18->activate();
+            }
+            else
+            {
+                phaserp2->setValueType(VC_FXlfofreq);
+                phaserp18->deactivate();
+            }
+            phaserp18->value(eff->geteffectpar(18));
 
             effphaserwindow->show();
             break;
@@ -1680,6 +1850,18 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
             awp8->value(eff->geteffectpar(8));
             awp9->value(eff->geteffectpar(9));
             awp10->value(eff->geteffectpar(10));
+            awp17->value(eff->geteffectpar(17));
+            if (awp17->value())
+            {
+                awp2->setValueType(VC_FXlfofreqBPM);
+                awp18->activate();
+            }
+            else
+            {
+                awp2->setValueType(VC_FXlfofreq);
+                awp18->deactivate();
+            }
+            awp18->value(eff->geteffectpar(18));
             effalienwahwindow->show();
             break;
         case 6:
@@ -1737,6 +1919,18 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
             dfp7->value(eff->geteffectpar(7));
             dfp8->value(eff->geteffectpar(8));
             dfp9->value(eff->geteffectpar(9));
+            dfp17->value(eff->geteffectpar(17));
+            if (dfp17->value())
+            {
+                dfp2->setValueType(VC_FXlfofreqBPM);
+                dfp18->activate();
+            }
+            else
+            {
+                dfp2->setValueType(VC_FXlfofreq);
+                dfp18->deactivate();
+            }
+            dfp18->value(eff->geteffectpar(18));
             effdynamicfilterwindow->show();
             break;
         default:
@@ -1833,6 +2027,7 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 echop4->labelsize(size11);
                 echop5->labelsize(size11);
                 echop6->labelsize(size11);
+                echop17->labelsize(size11);
             	break;
             case 3: // chorus
                 chorusname->labelsize(size12);
@@ -1852,6 +2047,8 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 chorusp9->labelsize(size11);
                 chorusflange->labelsize(size);
                 chorusp11->labelsize(size11);
+                chorusp17->labelsize(size11);
+                chorusp18->labelsize(size11);
                 break;
             case 4: // phaser
                 phasername->labelsize(size12);
@@ -1875,6 +2072,8 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 phaserp12->labelsize(size11);
                 phaserp13->labelsize(size11);
                 phaserp14->labelsize(size11);
+                phaserp17->labelsize(size11);
+                phaserp18->labelsize(size11);
                 break;
             case 5: // alienwah
                 alienname->labelsize(size12);
@@ -1895,6 +2094,8 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
                 awp10->labelsize(size11);
                 awp8->labelsize(size11);
                     awp8->textsize(size11);
+                awp17->labelsize(size11);
+                awp18->labelsize(size11);
                 break;
             case 6: // distortion
                 distname->labelsize(size12);
@@ -1946,8 +2147,10 @@ class EffUI {: {public Fl_Group,public PresetsUI_}
 
                 filter->labelsize(size11);
                 dfp7->labelsize(size11);
-                dfp9->labelsize(size11);
                 dfp8->labelsize(size11);
+                dfp9->labelsize(size11);
+                dfp17->labelsize(size11);
+                dfp18->labelsize(size11);
 
                 filterclose->labelsize(size12);
                 break;

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -1133,6 +1133,9 @@ string convert_value(ValueType type, float val)
             f = (powf(2.0f, (int)val / 127.0f * 10.0f) - 1.0f) * 0.03f;
             return variable_prec_units(f, "Hz", 3);
 
+        case VC_FXlfofreqBPM:
+            return freqBPMStr(val / 127.0f);
+
         case VC_FXChorusDepth:
             f = powf(8.0f, ((int)val / 127.0f) * 2.0f) -1.0f; //ms
             return variable_prec_units(f, "ms", 2, true);

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -105,6 +105,7 @@ enum ValueType {
     VC_FXChorusDelay,
     VC_FXlfoStereo,
     VC_FXlfofreq,
+    VC_FXlfofreqBPM,
     VC_FXdefaultDW,
     VC_FXEQfreq,
     VC_FXEQq,

--- a/src/globals.h
+++ b/src/globals.h
@@ -1063,6 +1063,8 @@ namespace EFFECT // usage EFFECT::type::none
         panning, // band for EQ
         frequency, // time reverb, delay echo, L/R-mix dist, Not EQ
         preset = 16, // not EQ
+        bpm,
+        bpmStart,
         changed = 129 // not EQ
     };
 


### PR DESCRIPTION
The last commit is the main one, with some additional fixes/support commits before that, including a rewrite of the InterpolatedParameter class to support array indexes.

@abrolag: I have not added support for the CLI in this implementation. I can of course do this, but I don't know it so well, and I thought maybe this is a pretty quick thing for you to add? It should be pretty straightforward, just a BPM boolean setting to the effects AlienWah, Chorus, DynamicFilter, Echo and Phaser, as well as a Start setting to all the same effects, except for Echo.

Other than that, I have tested all combinations of Alsa, LV2 and Jack as well as I can, and it seems to be pretty stable for me now.