### PR TITLE
some further code clean-up for JackEngine

### DIFF
--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <string>
 #include <vector>
-#include <semaphore.h>
 
 #include "Misc/SynthEngine.h"
 #include "Interface/InterChange.h"
@@ -72,7 +71,6 @@ private:
    LV2_URID _atom_bpm;
    uint32_t _bufferPos;
    uint32_t _offsetPos;
-   sem_t _midiSem;
 
    struct midi_event {
        uint32_t time;

--- a/src/MusicIO/JackEngine.h
+++ b/src/MusicIO/JackEngine.h
@@ -24,10 +24,7 @@
 #define JACK_ENGINE_H
 
 #include <string>
-#include <pthread.h>
-#include <semaphore.h>
 #include <jack/jack.h>
-//#include <jack/ringbuffer.h>
 
 #if defined(JACK_SESSION)
     #include <jack/session.h>
@@ -74,7 +71,6 @@ class JackEngine : public MusicIO
 #if defined(JACK_SESSION)
             static void _jsessionCallback(jack_session_event_t *event, void *arg);
             void jsessionCallback(jack_session_event_t *event);
-            jack_session_event_t *lastevent;
 #endif
 
 #if defined(JACK_LATENCY)
@@ -82,24 +78,20 @@ class JackEngine : public MusicIO
             void latencyCallback(jack_latency_callback_mode_t mode);
 #endif
 
-        jack_client_t      *jackClient;
-        struct {
+        struct JackAudio
+        {
             unsigned int  jackSamplerate;
             unsigned int  jackNframes;
             jack_port_t  *ports[2*NUM_MIDI_PARTS+2];
             float        *portBuffs[2*NUM_MIDI_PARTS+2];
-        } audio;
+        };
 
-        struct {
-            jack_port_t*       port;
-            //jack_ringbuffer_t *ringBuf;
-            size_t             *ringBuf;
-            pthread_t          pThread;
-        } midi;
-
-        float bpm;
+        jack_client_t *jackClient;
+        JackAudio      audio;
+        jack_port_t   *midiPort;
 
         unsigned int internalbuff;
-};
 
-#endif
+        float bpm;
+};
+#endif /*JACK_ENGINE_H*/


### PR DESCRIPTION
Am 25.06.21 um 21:07 schrieb Will Godfrey:
> In some headers we were still including jack/ringbuffer but this was
> only referenced in the midi struct in jackEngine.h and that struct only
> called for in jackEngine.cpp


Hi Will,

just cross-checked that also with the "references" feature of my IDE.

Not only the `ringBuf` field is unused, also the `pThread` field in the same structure. Thus, the only field in this `midi` strucutre, that is actively initialised and accessed from other code is the `port` field. Moreover, this structure is private in `class JackEngine` and it is never exposed or passed to any other function as such.

Thus we can do a more radical clean-up here: we can remove that structure altogether and just use a plain field of `type jack_port_t`

This has the nice side effect that we can also drop the `#include <pthread.h>`

----

Expanding a little on that, also the field `jack_session_event_t *lastevent`
in the Jack-Session support is unused. And in a similar vein, also the
header `<semaphore.h>` in JackEngine.h and YoshimiLV2Plugin.h is unnecessary.
JackClient doesn't use any semaphores any more, and also YoshimiLV2Plugin
has a private field `_midiSem`, which is no longer referenced any more.

-- Hermann

