### PR TITLE
LV2 fix: Mixer Audio Send dropdown disabled when it shouldn't be.

### DIFF
--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -447,7 +447,12 @@ bool YoshimiLV2Plugin::init()
 LV2_Handle	YoshimiLV2Plugin::instantiate (const LV2_Descriptor *desc, double sample_rate, const char *bundle_path, const LV2_Feature *const *features)
 {
     std::list<string> dummy;
-    SynthEngine *synth = new SynthEngine(dummy, true);
+    LV2PluginType lv2Type;
+    if (std::string(desc->URI) == std::string(yoshimi_lv2_multi_desc.URI))
+        lv2Type = LV2PluginTypeMulti;
+    else
+        lv2Type = LV2PluginTypeSingle;
+    SynthEngine *synth = new SynthEngine(dummy, lv2Type);
     if (!synth->getRuntime().isRuntimeSetupCompleted())
     {
         delete synth;

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -116,16 +116,16 @@ static unsigned int getRemoveSynthId(bool remove = false, unsigned int idx = 0)
 }
 
 
-SynthEngine::SynthEngine(std::list<string>& allArgs, bool _isLV2Plugin, unsigned int forceId) :
+SynthEngine::SynthEngine(std::list<string>& allArgs, LV2PluginType _lv2PluginType, unsigned int forceId) :
     uniqueId(getRemoveSynthId(false, forceId)),
-    isLV2Plugin(_isLV2Plugin),
+    lv2PluginType(_lv2PluginType),
     needsSaving(false),
     bank(this),
     interchange(this),
     midilearn(this),
     mididecode(this),
     //unifiedpresets(this),
-    Runtime(this, allArgs, isLV2Plugin),
+    Runtime(this, allArgs, getIsLV2Plugin()),
     presetsstore(this),
     textMsgBuffer(TextMsgBuffer::instance()),
     fadeAll(0),
@@ -3357,7 +3357,7 @@ MasterUI *SynthEngine::getGuiMaster(bool createGui)
 
 void SynthEngine::guiClosed(bool stopSynth)
 {
-    if (stopSynth && !isLV2Plugin)
+    if (stopSynth && !getIsLV2Plugin())
         Runtime.runSynth = false;
 #ifdef GUI_FLTK
     if (guiClosedCallback != NULL)

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -59,12 +59,18 @@ class MasterUI;
 
 using std::string;
 
+enum LV2PluginType
+{
+    LV2PluginTypeNone,
+    LV2PluginTypeSingle,
+    LV2PluginTypeMulti
+};
 
 class SynthEngine
 {
     private:
         unsigned int uniqueId;
-        bool isLV2Plugin;
+        LV2PluginType lv2PluginType;
         bool needsSaving;
     public:
         std::atomic <uint8_t> audioOut;
@@ -78,7 +84,7 @@ class SynthEngine
         PresetsStore presetsstore;
     public:
         TextMsgBuffer& textMsgBuffer;
-        SynthEngine(std::list<string>& allArgs, bool _isLV2Plugin = false, unsigned int forceId = 0);
+        SynthEngine(std::list<string>& allArgs, LV2PluginType _lv2PluginType = LV2PluginTypeNone, unsigned int forceId = 0);
         ~SynthEngine();
         bool Init(unsigned int audiosrate, int audiobufsize);
 
@@ -242,7 +248,8 @@ class SynthEngine
         int meterDelay;
         void fetchMeterData(void);
 
-        inline bool getIsLV2Plugin() {return isLV2Plugin; }
+        inline LV2PluginType getLV2PluginType() {return lv2PluginType;}
+        inline bool getIsLV2Plugin() {return lv2PluginType != LV2PluginTypeNone; }
         inline Config &getRuntime() {return Runtime;}
         inline PresetsStore &getPresetsStore() {return presetsstore;}
         unsigned int getUniqueId() {return uniqueId;}

--- a/src/UI/MasterMiscUI.fl
+++ b/src/UI/MasterMiscUI.fl
@@ -433,7 +433,7 @@ class Panellistitem {: {public Fl_Group}
       Fl_Group panellistitemgroup {
         xywh {0 -5 65 279} box PLASTIC_THIN_UP_BOX
         code0 {if (!synth->partonoffRead(npart + *plgroup)) o->deactivate();}
-        code1 {if (synth->getRuntime().audioEngine != jack_audio) audiosend->deactivate();}
+        code1 {if (synth->getRuntime().audioEngine != jack_audio && synth->getLV2PluginType() != LV2PluginTypeMulti) audiosend->deactivate();}
       } {
         Fl_Group {} {
           xywh {30 64 26 112} box ENGRAVED_FRAME

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,7 +303,7 @@ int mainCreateNewInstance(unsigned int forceId)
 {
     MusicClient *musicClient = NULL;
     unsigned int instanceID;
-    SynthEngine *synth = new SynthEngine(globalAllArgs, false, forceId);
+    SynthEngine *synth = new SynthEngine(globalAllArgs, LV2PluginTypeNone, forceId);
     if (!synth->getRuntime().isRuntimeSetupCompleted())
         goto bail_out;
     instanceID = synth->getUniqueId();


### PR DESCRIPTION
It depends on the value of the preferred audio driver, but this is
irrelevant when running with LV2. Instead we need to check for whether
the LV2 instance is Multi or Single.

Signed-off-by: Kristian Amlie <kristian@amlie.name>