### PR TITLE
Require and link against threads library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ endif ()
 
 find_package (PkgConfig REQUIRED)
 
+find_package(Threads REQUIRED)
 
 check_c_source_compiles (
     "#include <argp.h>
@@ -435,6 +436,7 @@ set(ExternLibraries
     ${Readline_LIBRARY}
     ${ZLIB_LIBRARIES}
     ${LIBDL_LINUX}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")


### PR DESCRIPTION
src/CMakeLists.txt
Use FindThreads
(https://cmake.org/cmake/help/latest/module/FindThreads.html) to
explicitly find and link against a threads library.

Fixes #154