### PR TITLE
Fix compile with Clang: initialise static var out-of-class

### DIFF
--- a/src/Misc/NumericFuncs.h
+++ b/src/Misc/NumericFuncs.h
@@ -93,13 +93,17 @@ namespace {
     template<unsigned int base, bool fraction=false>
     struct PowerFunction
     {
-        static constexpr float LN_BASE = log(fraction? 1.0/base : double(base));
+        static_assert(base > 0, "0^x is always zero");
 
         static float invoke(float exponent)
         {
             return expf(LN_BASE * exponent);
         }
+        static const float LN_BASE;
     };
+
+    template<unsigned int base, bool fraction>
+    const float PowerFunction<base,fraction>::LN_BASE = log(fraction? 1.0/base : double(base));
 }
 
 /* compute base^exponent for a fixed integral base */


### PR DESCRIPTION
The "constexpr" was used here solely to allow in-class initialisation,
while in fact we do not need a compiletime expression, since we are
initialising a static variable at program start anyway.

Clang complains that the initialiser can not be constexpr.
GCC is more tolerant here (which is a non-standard extension)

log, exp, and similar math functions can not be constexpr,
at least when taking the standard literally.