### PR TITLE
Make Reverb computations reproducible

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,11 @@
 yoshimi 2.1.2 M
 
+2022-2-11 Hermann
+* Changes to make Reverb computations completely reproducible
+* Ensure InterpolatedValue stops when passing beyond interpolation-length
+* Allow to forcibly push InterpolatedValue to the next target; used for Effect::cleanup()
+* Fix spurious AnalogFilter recalculations due to float comparison glitches
+
 2022-2-5 Will
 * Added copy of MPE spec to dev_notes.
 * Corrected spelling mistakes here!

--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -340,6 +340,11 @@ void AnalogFilter::computefiltercoefs(void)
 }
 
 
+float AnalogFilter::getFreq()
+{
+    return this->freq;
+}
+
 void AnalogFilter::setfreq(float frequency)
 {
     if (frequency < 0.1f)

--- a/src/DSP/AnalogFilter.h
+++ b/src/DSP/AnalogFilter.h
@@ -40,6 +40,7 @@ class AnalogFilter : public Filter_
         Filter_* clone() { return new AnalogFilter(*this); };
         void filterout(float *smp);
         void setfreq(float frequency);
+        float getFreq();
         void setfreq_and_q(float frequency, float q_);
         void setq(float q_);
 

--- a/src/DSP/Unison.h
+++ b/src/DSP/Unison.h
@@ -28,6 +28,8 @@
 
 #include "Misc/SynthEngine.h"
 
+#include <memory>
+
 #define UNISON_FREQ_SPAN 2.0f // how much the unison frequencies varies (always >= 1.0)
 
 class SynthEngine;
@@ -36,7 +38,7 @@ class Unison
 {
     public:
         Unison(int update_period_samples_, float max_delay_sec_, SynthEngine *_synth);
-        ~Unison();
+       ~Unison() = default;
 
         void setSize(int new_size);
         void setBaseFrequency(float freq);
@@ -48,32 +50,34 @@ class Unison
         void updateParameters(void);
         void updateUnisonData(void);
 
-        int   unison_size;
-        float base_freq;
         struct UnisonVoice {
             float step;     // base LFO
             float position;
             float realpos1; // the position regarding samples
             float realpos2;
             float relative_amplitude;
-            float lin_fpos;
-            float lin_ffreq;
-            UnisonVoice() {
-                realpos1 = 0.0f;
-                realpos2 = 0.0f;
-                step     = 0.0f;
-                relative_amplitude = 1.0f;
-            }
+            UnisonVoice()
+                : step{0.0f}
+                , position{}
+                , realpos1{}
+                , realpos2{}
+                , relative_amplitude{1.0f}
+            { }
+
             void setPosition(float newPos) {
                 position = newPos;
             }
-        } *uv;
+        };
+        int   unison_size;
+        float base_freq;
+        int   max_delay, delay_k;
+        bool  first_time;
+
+        std::unique_ptr<UnisonVoice[]> voice;
+        std::unique_ptr<float[]> delay_buffer;
 
         int           update_period_samples;
         int           update_period_sample_k;
-        int           max_delay, delay_k;
-        bool          first_time;
-        float        *delay_buffer;
         float         unison_amplitude_samples;
         float         unison_bandwidth_cents;
 

--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -121,6 +121,7 @@ void Alienwah::out(float *smpsl, float *smpsr)
 // Cleanup the effect
 void Alienwah::cleanup(void)
 {
+    Effect::cleanup();
     for (int i = 0; i < Pdelay; ++i)
     {
         oldl[i] = complex<float>(0.0f, 0.0f);

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -167,6 +167,8 @@ void Chorus::out(float *smpsl, float *smpsr)
 // Cleanup the effect
 void Chorus::cleanup(void)
 {
+    Effect::cleanup();
+    fb.pushToTarget();
     for (int i = 0; i < maxdelay; ++i)
         delayl[i] = delayr[i] = 0.0f;
     lfo.resetState();

--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -93,6 +93,10 @@ Distorsion::~Distorsion()
 // Cleanup the effect
 void Distorsion::cleanup(void)
 {
+    Effect::cleanup();
+    level.pushToTarget();
+    lpffr.pushToTarget();
+    hpffr.pushToTarget();
     lpfl->cleanup();
     hpfl->cleanup();
     lpfr->cleanup();

--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -121,6 +121,7 @@ void DynamicFilter::out(float *smpsl, float *smpsr)
 // Cleanup the effect
 void DynamicFilter::cleanup(void)
 {
+    Effect::cleanup();
     reinitfilter();
     ms1 = ms2 = ms3 = ms4 = 0.0f;
     lfo.resetState();

--- a/src/Effects/EQ.cpp
+++ b/src/Effects/EQ.cpp
@@ -33,27 +33,16 @@ using func::powFrac;
 using func::asDecibel;
 
 
-EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
-    Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth)
+EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth)
+    : Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, _synth)
+    , Pchanged{false}
+    , Pvolume{}
+    , Pband{0}
+    , filter{*synth,*synth,*synth,*synth,*synth,*synth,*synth,*synth} // MAX_EQ_BANDS
 {
-    for (int i = 0; i < MAX_EQ_BANDS; ++i)
-    {
-        filter[i].Ptype = 0;
-        filter[i].Pfreq = 64;
-        filter[i].Pgain = 64;
-        filter[i].Pq = 64;
-        filter[i].Pstages = 0;
-        filter[i].l = new AnalogFilter(6, 1000.0, 1.0, 0, synth);
-        filter[i].r = new AnalogFilter(6, 1000.0, 1.0, 0, synth);
-        filter[i].freq.setSampleRate(synth->samplerate);
-        filter[i].gain.setSampleRate(synth->samplerate);
-        filter[i].q.setSampleRate(synth->samplerate);
-    }
     // default values
     setvolume(50);
-    Pband = 0;
     setpreset(Ppreset);
-    Pchanged = false;
     cleanup();
 }
 
@@ -61,6 +50,7 @@ EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth) :
 // Cleanup the effect
 void EQ::cleanup(void)
 {
+    Effect::cleanup();
     for (int i = 0; i < MAX_EQ_BANDS; ++i)
     {
         filter[i].l->cleanup();

--- a/src/Effects/EQ.h
+++ b/src/Effects/EQ.h
@@ -28,10 +28,12 @@
 #ifndef EQ_H
 #define EQ_H
 
+#include "Misc/SynthEngine.h"
 #include "DSP/AnalogFilter.h"
 #include "Effects/Effect.h"
 
-class SynthEngine;
+#include <memory>
+
 
 class EQ : public Effect
 {
@@ -46,16 +48,35 @@ class EQ : public Effect
         float getfreqresponse(float freq);
 
     private:
+        void setvolume(unsigned char Pvolume_);
+
         // Parameters
         bool Pchanged;
         unsigned char Pvolume;
         unsigned char Pband;
-        void setvolume(unsigned char Pvolume_);
-        struct {
+
+        struct FilterParam
+        {
             unsigned char Ptype, Pfreq, Pgain, Pq, Pstages; // parameters
-            synth::InterpolatedValueDfl<float> freq, gain, q;
-            AnalogFilter *l, *r; // internal values
-        } filter[MAX_EQ_BANDS];
+            synth::InterpolatedValue<float> freq, gain, q;
+            std::unique_ptr<AnalogFilter> l; // internal values
+            std::unique_ptr<AnalogFilter> r; // internal values
+
+            FilterParam(SynthEngine& synth)
+                :Ptype{0}
+                ,Pfreq{64}
+                ,Pgain{64}
+                ,Pq{64}
+                ,Pstages{0}
+                ,freq{0, synth.samplerate}
+                ,gain{0, synth.samplerate}
+                ,q   {0, synth.samplerate}
+                ,l{new AnalogFilter(6, 1000.0, 1.0, 0, &synth)}
+                ,r{new AnalogFilter(6, 1000.0, 1.0, 0, &synth)}
+            { }
+        };
+
+        FilterParam filter[MAX_EQ_BANDS];
 };
 
 class EQlimit

--- a/src/Effects/Echo.h
+++ b/src/Effects/Echo.h
@@ -65,11 +65,11 @@ class Echo : public Effect
         void setvolume(unsigned char Pvolume_);
         void setdelay(unsigned char Pdelay_);
         void setlrdelay(unsigned char Plrdelay_);
-        void setfb(unsigned char Pfb_);
+        void setfeedback(unsigned char Pfb_);
         void sethidamp(unsigned char Phidamp_);
 
         // Real Parameters
-        synth::InterpolatedValue<float> fb, hidamp;
+        synth::InterpolatedValue<float> feedback, hidamp;
         int dl, dr, delay, lrdelay;
 
         void initdelays(void);

--- a/src/Effects/Effect.cpp
+++ b/src/Effects/Effect.cpp
@@ -29,6 +29,10 @@
 
 using func::setAllPan;
 
+namespace {
+    const float PAN_NORMAL_CENTRE = cosf(0.5f * HALFPI);
+}
+
 Effect::Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
                FilterParams *filterpars_, unsigned char Ppreset_,
                SynthEngine *synth_) :
@@ -39,13 +43,25 @@ Effect::Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
     volume(0.5f, synth_->samplerate),
     filterpars(filterpars_),
     insertion(insertion_),
-    pangainL(0.5f, synth_->samplerate),
-    pangainR(0.5f, synth_->samplerate),
-    lrcross(0.5f, synth_->samplerate),
+    pangainL(PAN_NORMAL_CENTRE, synth_->samplerate),
+    pangainR(PAN_NORMAL_CENTRE, synth_->samplerate),
+    lrcross(40.0f/127, synth_->samplerate),
     synth(synth_)
 {
     setpanning(64);
     setlrcross(40);
+}
+
+
+// base implementation: force to clean reproducible state.
+// Note: be sure to invoke that from overridden implementations.
+void Effect::cleanup()
+{
+    outvolume.pushToTarget();
+    volume   .pushToTarget();
+    pangainL.pushToTarget();
+    pangainR.pushToTarget();
+    lrcross.pushToTarget();
 }
 
 

--- a/src/Effects/Effect.h
+++ b/src/Effects/Effect.h
@@ -42,7 +42,7 @@ class Effect
         virtual void changepar(int npar, unsigned char value) = 0;
         virtual unsigned char getpar(int npar) = 0;
         virtual void out(float *smpsl, float *smpsr) = 0;
-        virtual void cleanup() { };
+        virtual void cleanup();
         virtual float getfreqresponse(float /* freq */) { return (0); };
 
         unsigned char Ppreset; // Currentl preset

--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -70,8 +70,6 @@ void EffectMgr::changeeffect(int _nefx)
     if (nefx == _nefx)
         return;
     nefx = _nefx;
-    memset(efxoutl, 0, synth->bufferbytes);
-    memset(efxoutr, 0, synth->bufferbytes);
     if (efx)
         delete efx;
     switch (nefx)
@@ -128,6 +126,8 @@ int EffectMgr::geteffect(void)
 // Cleanup the current effect
 void EffectMgr::cleanup(void)
 {
+    memset(efxoutl, 0, synth->bufferbytes);
+    memset(efxoutr, 0, synth->bufferbytes);
     if (efx)
         efx->cleanup();
 }

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -305,6 +305,7 @@ void Phaser::NormalPhase(float *smpsl, float *smpsr)
 // Cleanup the effect
 void Phaser::cleanup(void)
 {
+    Effect::cleanup();
     fbl = fbr = oldlgain = oldrgain = 0.0f;
     memset(oldl, 0, sizeof(float)*Pstages * 2);
     memset(oldr, 0, sizeof(float)*Pstages * 2);

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -270,8 +270,8 @@ void Reverb::out(float *smps_l, float *smps_r)
          hpf->filterout(inputbuf);
     }
 
-    processmono(0, efxoutl); // left
-    processmono(1, efxoutr); // right
+    processmono(0, efxoutl); // reverb processing inputbuf -> left
+    processmono(1, efxoutr); // reverb processing inputbuf -> right
 
     float lvol = rs / REV_COMBS * pangainL.getAndAdvanceValue();
     float rvol = rs / REV_COMBS * pangainR.getAndAdvanceValue();

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -209,6 +209,17 @@ void Reverb::processmono(int ch, float *output)
 }
 
 
+namespace { //Helper: detect change above rounding errors for frequency interpolation
+
+    const float FREQUENCY_EPSILON = 1e-3;
+
+    bool significantChange(float newVal, float oldVal)
+    {
+        return std::fabs(newVal - oldVal) > FREQUENCY_EPSILON;
+    }
+}
+
+
 // Effect output
 void Reverb::out(float *smps_l, float *smps_r)
 {
@@ -238,9 +249,9 @@ void Reverb::out(float *smps_l, float *smps_r)
 
     if (lpf)
     {
-        float fr = lpffr.getValue();
+        float currFreq = lpf->getFreq();
         lpffr.advanceValue(synth->sent_buffersize);
-        if (fr != lpffr.getValue())
+        if (significantChange(currFreq, lpffr.getValue()))
         {
             lpf->interpolatenextbuffer();
             lpf->setfreq(lpffr.getValue());
@@ -249,9 +260,9 @@ void Reverb::out(float *smps_l, float *smps_r)
     }
      if (hpf)
     {
-        float fr = hpffr.getValue();
+        float currFreq = hpf->getFreq();
         hpffr.advanceValue(synth->sent_buffersize);
-        if (fr != hpffr.getValue())
+        if (significantChange(currFreq, hpffr.getValue()))
         {
             hpf->interpolatenextbuffer();
             hpf->setfreq(hpffr.getValue());

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -293,6 +293,9 @@ void Reverb::out(float *rawL, float *rawR)
 // Reset the effect to pristine state
 void Reverb::cleanup()
 {
+    Effect::cleanup();
+    lpffr.pushToTarget();
+    hpffr.pushToTarget();
     setupPipelines();
     settime(Ptime);
     clearBuffers();
@@ -418,7 +421,7 @@ void Reverb::settype(unsigned char Ptype_)
     if (Ptype >= NUM_TYPES)
         Ptype = NUM_TYPES - 1;
 
-    cleanup();
+    cleanup(); // invokes setupPipelines()
 }
 
 
@@ -429,14 +432,13 @@ void Reverb::setupPipelines()
 
         // Freeverb by Jezar at Dreampoint
         { 1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617 },
-        // duplicate of Freeverb by Jezar at Dreampoint
         { 1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617 }
     };
 
     int aptunings[NUM_TYPES][REV_APS] = {
         { 0, 0, 0, 0 },         // this is unused (for random)
         { 225, 341, 441, 556 }, // Freeverb by Jezar at Dreampoint
-        { 225, 341, 441, 556 }  // duplicate of Freeverb by Jezar at Dreampoint
+        { 225, 341, 441, 556 }
     };
 
     float samplerate_adjust = synth->samplerate_f / 44100.0f;

--- a/src/Effects/Reverb.h
+++ b/src/Effects/Reverb.h
@@ -91,20 +91,20 @@ class Reverb : public Effect
         float idelayfb;
         float roomsize;
         float rs; // rs is used to "normalise" the volume according to the roomsize
-        int comblen[REV_COMBS * 2];
-        int aplen[REV_APS * 2];
+        int comblen[REV_COMBS * 2];   // length for each CombFilter feedback line (random)
+        int aplen[REV_APS * 2];       // length for each AllPass feedback line (random)
         Unison *bandwidth;
 
         // Internal Variables
-        float *comb[REV_COMBS * 2];
-        int combk[REV_COMBS * 2];
-        float combfb[REV_COMBS * 2];// <feedback-ul fiecarui filtru "comb"
-        float lpcomb[REV_COMBS * 2];  // <pentru Filtrul LowPass
-        float *ap[REV_APS * 2];
-        int apk[REV_APS * 2];
-        float *idelay;
-        AnalogFilter *lpf;  // filters
-        AnalogFilter *hpf;
+        float *comb[REV_COMBS * 2];   // N CombFilter pipelines for each channel
+        int combk[REV_COMBS * 2];     // current offset of the comb insertion point (cycling)
+        float combfb[REV_COMBS * 2];  // feedback coefficient of each Comb-filter
+        float lpcomb[REV_COMBS * 2];  // LowPass filtered output feedback from Comb
+        float *ap[REV_APS * 2];       // AllPass-filter
+        int apk[REV_APS * 2];         // current offset of the AllPass insertion point (cycling)
+        float *idelay;                // Input delay line
+        AnalogFilter *lpf;            // LowPass-filter on the input
+        AnalogFilter *hpf;            // HighPass-filter on the input
         synth::InterpolatedValue<float> lpffr;
         synth::InterpolatedValue<float> hpffr;
         float *inputbuf;

--- a/src/Effects/Reverb.h
+++ b/src/Effects/Reverb.h
@@ -33,6 +33,7 @@
 #define REV_COMBS 8
 #define REV_APS 4
 
+
 class Unison;
 class AnalogFilter;
 
@@ -43,7 +44,7 @@ class Reverb : public Effect
     public:
         Reverb(bool insertion_, float *efxoutl_, float *efxoutr_, SynthEngine *_synth);
         ~Reverb();
-        void out(float *smps_l, float *smps_r);
+        void out(float *rawL, float *rawR);
         void cleanup(void);
 
         void setpreset(unsigned char npreset);
@@ -52,6 +53,8 @@ class Reverb : public Effect
 
 
     private:
+        static constexpr size_t NUM_TYPES = 3;
+
         // Parametrii
         bool Pchanged;
         unsigned char Pvolume;
@@ -78,7 +81,6 @@ class Reverb : public Effect
         void settype(unsigned char Ptype_);
         void setroomsize(unsigned char Proomsize_);
         void setbandwidth(unsigned char Pbandwidth_);
-        void processmono(int ch, float *output);
 
 //        float erbalance;    // **** RHL ****
 
@@ -91,23 +93,28 @@ class Reverb : public Effect
         float idelayfb;
         float roomsize;
         float rs; // rs is used to "normalise" the volume according to the roomsize
-        int comblen[REV_COMBS * 2];   // length for each CombFilter feedback line (random)
-        int aplen[REV_APS * 2];       // length for each AllPass feedback line (random)
+        size_t comblen[REV_COMBS * 2];   // length for each CombFilter feedback line (random)
+        size_t aplen[REV_APS * 2];       // length for each AllPass feedback line (random)
         Unison *bandwidth;
 
         // Internal Variables
         float *comb[REV_COMBS * 2];   // N CombFilter pipelines for each channel
-        int combk[REV_COMBS * 2];     // current offset of the comb insertion point (cycling)
+        size_t combk[REV_COMBS * 2];  // current offset of the comb insertion point (cycling)
         float combfb[REV_COMBS * 2];  // feedback coefficient of each Comb-filter
         float lpcomb[REV_COMBS * 2];  // LowPass filtered output feedback from Comb
         float *ap[REV_APS * 2];       // AllPass-filter
-        int apk[REV_APS * 2];         // current offset of the AllPass insertion point (cycling)
+        size_t apk[REV_APS * 2];      // current offset of the AllPass insertion point (cycling)
         float *idelay;                // Input delay line
         AnalogFilter *lpf;            // LowPass-filter on the input
         AnalogFilter *hpf;            // HighPass-filter on the input
         synth::InterpolatedValue<float> lpffr;
         synth::InterpolatedValue<float> hpffr;
-        float *inputbuf;
+        float* inputbuf;
+
+        void preprocessInput(float *rawL, float *rawR, float* inputFeed);
+        void calculateReverb(size_t ch, float* inputFeed, float *output);
+        void setupPipelines();
+        void clearBuffers();
 };
 
 class Revlimit

--- a/src/Misc/ConfBuild.h
+++ b/src/Misc/ConfBuild.h
@@ -2,4 +2,4 @@
     ConfBuild.h
 */
 
-#define BUILD_NUMBER 2082
+#define BUILD_NUMBER 2084

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -533,6 +533,7 @@ void SynthEngine::setAllPartMaps(void)
  * also resets long lived procedural state and rebuilds PAD wavetables */
 void SynthEngine::setReproducibleState(int seed)
 {
+    ShutUp();
     LFOtime = 0;
     monotonicBeat = songBeat = 0.0f;
     prng.init(seed);

--- a/src/Misc/TestInvoker.h
+++ b/src/Misc/TestInvoker.h
@@ -378,8 +378,6 @@ class TestInvoker
             size_t holdCnt = ceilf(holdfraction*duration * synth.samplerate / chunksize);
             holdCnt = std::min(holdCnt,turnCnt);
 
-            synth.ShutUp(); // TODO Ichthyo 6/21: why do we need to invoke that twice to clear state on chained reverb effects?
-
             // calculate sound data
             for (int tone=0; tone<repetitions; ++tone)
             {


### PR DESCRIPTION
This is a spin off from the "padthread" effort;
After fixing the "1st note problem", the Testsuite still showed a smallish but random discrepancy around -50dB, which emenates from the Reverb Effect. This was caused by a combination of various _inconsistencies_ -- none of this is critical and seemingly the differences are not audible.

- spurious recomputation of AnalogFilter coefficients due to comparing floats directly (fix: compare with ε )
- moreover, InterpolatedValue did not stop interpolation when surpassing the interpolationLength
- several further problems related to a incomplete `Effect::cleanup()`
  * outputBuffer of Reverb not cleared on `cleanup()`
  * read positions in the comb and allpass pipelines not reset on `cleanup()`
  * InterpolatedValue should be set to a reproducible state; now it is pushed forwards to the current _target_ value on `cleanup()`

Moreover, there was a memory leak in the EQ effect (the two AnalogFilters in each Band were leaked). Fixed that by managing with a std::unique_ptr.

During the investigation of Reverb I had to understand it's workings. I tried to improve the code by making some variable names more clear and explicit, by decomposing into several functions, and by passing all input / output buffers as function arguments, instead of working by side effect.