### PR TITLE
Fix missing phase randomness when importing sub voices.

### DIFF
--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -166,6 +166,8 @@ class ADnote
         void computeUnisonFreqRap(int nvoice);
         void computeNoteParameters(void);
         void computeWorkingParameters(void);
+        void computePhaseOffsets(int nvoice);
+        void computeFMPhaseOffsets(int nvoice);
         void initParameters(void);
         void initSubVoices(void);
         void killVoice(int nvoice);


### PR DESCRIPTION
This was working for normal oscillators at one point, but was broken
when the live editing was introduced. For modulators I believe it has
never worked. Depending on how the sound is set up, the effect can be
very subtle, so it took me a long time to discover it.

However, there is one scenario where it is very audible. Set the
second voice to import from the first voice (doesn't matter which
waveform), and set unison of the second voice to 50. Make sure phase
randomness is at 100%. This produces a loud volume spike at the
beginning of the sound because all the waveforms' phases line up
exactly, before they start drifting apart. This should not happen when
randomness is on.

This required several fixes. First and foremost, we were not even
storing the phase offset for modulators, so introduce that in the
constructor.

Second, a problem is that the assignment of phases in the parent voice
was happening too late; the sub voice was created, and its phase
assigned, before the parent voice had calculated any phase. Because of
live editing, most of the phase calculations now happens in
computeNoteParameters(), which executes on every cycle. However, it
would be unreasonably expensive to call this early, because we still
have to call it again as part of the normal cycle. Then we would have
to call it twice for every note, and it's not a cheap function.

So instead, split out the part that deals with the phases into
separate functions, and call them when we need them instead. This is
still two calls, but much cheaper than computeNoteParameters().

And finally, the code was restructured slightly to be make sure we
call synth->numRandom() only once, while the rest of the calculation
we can call as many times as we want. Otherwise every cycle would have
a new random phase, which is just noise.

Signed-off-by: Kristian Amlie <kristian@amlie.name>