### PR TITLE
Remove unneeded idle thread from LV2 plugin.

### DIFF
--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -79,14 +79,11 @@ private:
 
    float *_bFreeWheel;
 
-   pthread_t _pIdleThread;
-
    float *lv2Left [NUM_MIDI_PARTS + 1];
    float *lv2Right [NUM_MIDI_PARTS + 1];
 
    void process(uint32_t sample_count);
    void processMidiMessage(const uint8_t *msg);
-   void *idleThread(void);
    std::vector <LV2_Program_Descriptor> flatbankprgs;
    const LV2_Descriptor *_lv2_desc;
 public:
@@ -124,8 +121,6 @@ public:
 
    const LV2_Program_Descriptor * getProgram(uint32_t index);
    void selectProgramNew(unsigned char channel, uint32_t bank, uint32_t program);
-
-   static void *static_idleThread(void *arg);
 
    static LV2_State_Status static_StateSave(LV2_Handle instance, LV2_State_Store_Function store, LV2_State_Handle handle, uint32_t flags, const LV2_Feature *const * features);
    static LV2_State_Status static_StateRestore(LV2_Handle instance, LV2_State_Retrieve_Function retrieve, LV2_State_Handle handle, uint32_t flags, const LV2_Feature *const * features);


### PR DESCRIPTION
The thread does nothing but spin and use CPU time. This makes an
enormous difference on big projects where you have many Yoshimi
instances.

Signed-off-by: Kristian Amlie <kristian@amlie.name>