### PR TITLE
Performance improvements in sortResultsThread.

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -117,6 +117,8 @@ InterChange::InterChange(SynthEngine *_synth) :
     undoStart = false;
     cameFrom = envControl::input;
     undoMarker.data.part = TOPLEVEL::section::undoMark;
+
+    sem_init(&sortResultsThreadSemaphore, 0, 0);
 }
 
 
@@ -145,6 +147,10 @@ bool InterChange::Init()
     }
 }
 
+void InterChange::spinSortResultsThread()
+{
+    sem_post(&sortResultsThreadSemaphore);
+}
 
 void *InterChange::_sortResultsThread(void *arg)
 {
@@ -180,8 +186,8 @@ void *InterChange::sortResultsThread(void)
             else
                 resolveReplies(&getData);
         }
-            usleep(80); // actually gives around 120 uS
 
+        sem_wait(&sortResultsThreadSemaphore);
     }
     return NULL;
 }
@@ -189,9 +195,14 @@ void *InterChange::sortResultsThread(void)
 
 InterChange::~InterChange()
 {
-    if (sortResultsThreadHandle)
+    if (sortResultsThreadHandle) {
+        // Get it to quit.
+        spinSortResultsThread();
         pthread_join(sortResultsThreadHandle, 0);
+    }
     undoRedoClear();
+
+    sem_destroy(&sortResultsThreadSemaphore);
 }
 
 
@@ -211,7 +222,7 @@ void InterChange::muteQueueWrite(CommandBlock *getData)
     }
     if (synth->audioOut.load() == _SYS_::mute::Idle)
     {
-        synth->audioOut.store(_SYS_::mute::Pending);
+        synth->audioOutStore(_SYS_::mute::Pending);
     }
 }
 
@@ -1979,6 +1990,7 @@ void InterChange::returns(CommandBlock *getData)
     }
     if (!decodeLoopback.write(getData->bytes))
         synth->getRuntime().Log("Unable to write to decodeLoopback buffer");
+    spinSortResultsThread();
 }
 
 

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -102,7 +102,6 @@ InterChange::InterChange(SynthEngine *_synth) :
     returnsBuffer(),
     syncWrite(false),
     lowPrioWrite(false),
-    tick(0),
     sortResultsThreadHandle(0),
     swapRoot1(UNUSED),
     swapBank1(UNUSED),
@@ -157,22 +156,6 @@ void *InterChange::sortResultsThread(void)
 {
     while (synth->getRuntime().runSynth)
     {
-        /*
-         * To maintain portability we synthesise a very simple low accuracy
-         * timer based on the loop time of this function. As it makes no system
-         * calls apart from usleep() it is lightweight and should have no thread
-         * safety issues. It is used mostly for low priority timeouts.
-         */
-        ++ tick;
-
-        /*if (!(tick & 8191))
-        {
-            if (tick & 16383)
-                std::cout << "Tick" << std::endl;
-            else
-                std::cout << "Tock" << std::endl;
-        }*/
-
         CommandBlock getData;
 
         /* It is possible that several operations initiated from

--- a/src/Interface/InterChange.h
+++ b/src/Interface/InterChange.h
@@ -33,6 +33,8 @@
 #include "Params/OscilParameters.h"
 #include "Synth/Resonance.h"
 
+#include <semaphore.h>
+
 #include <list>
 
 class DataText;
@@ -77,6 +79,9 @@ class InterChange : private DataText
         RingBuffer <10, log2 (commandBlockSize)> fromMIDI;
         RingBuffer <10, log2 (commandBlockSize)> returnsBuffer;
         RingBuffer <4, log2 (commandBlockSize)> muteQueue;
+
+        sem_t sortResultsThreadSemaphore;
+        void spinSortResultsThread();
 
         void generateSpecialInstrument(int npart, std::string name);
         void mediate(void);

--- a/src/Interface/InterChange.h
+++ b/src/Interface/InterChange.h
@@ -94,8 +94,6 @@ class InterChange : private DataText
         std::atomic<bool> syncWrite;
         std::atomic<bool> lowPrioWrite;
 
-        unsigned int tick; // needs to be read by synth
-
     private:
         void *sortResultsThread(void);
         static void *_sortResultsThread(void *arg);

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -656,8 +656,11 @@ int SynthEngine::RunChannelSwitch(unsigned char chan, int value)
      * loop and twoway are increment counters
      * we assume nobody can repeat a switch press within 60mS!
      */
-            if ((interchange.tick - CHtimer) > 511) // approx 60mS
-                CHtimer = interchange.tick;
+            timespec now_struct;
+            clock_gettime(CLOCK_MONOTONIC, &now_struct);
+            int64_t now_ms = int64_t(now_struct.tv_sec) * 1000 + int64_t(now_struct.tv_nsec) / 1000000;
+            if ((now_ms - CHtimer) > 60)
+                CHtimer = now_ms;
             else
                 return 0; // de-bounced
         }

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -215,7 +215,7 @@ SynthEngine::~SynthEngine()
 
 bool SynthEngine::Init(unsigned int audiosrate, int audiobufsize)
 {
-    audioOut.store(_SYS_::mute::Active);
+    audioOutStore(_SYS_::mute::Active);
     samplerate_f = samplerate = audiosrate;
     halfsamplerate_f = samplerate_f / 2;
 
@@ -506,6 +506,12 @@ void SynthEngine::setAllPartMaps(void)
     // we swap all maps together after they've been changed
     for (int npart = 0; npart < NUM_MIDI_PARTS; ++ npart)
         part[npart]->PmapOffset = 128 - part[npart]->PmapOffset;
+}
+
+void SynthEngine::audioOutStore(uint8_t num)
+{
+    audioOut.store(num);
+    interchange.spinSortResultsThread();
 }
 
 
@@ -2057,14 +2063,14 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
         case _SYS_::mute::Pending:
             // set by resolver
             fadeLevel = 1.0f;
-            audioOut.store(_SYS_::mute::Fading);
+            audioOutStore(_SYS_::mute::Fading);
             sound = _SYS_::mute::Fading;
             //std::cout << "here fading" << std:: endl;
             break;
         case _SYS_::mute::Fading:
             if (fadeLevel < 0.001f)
             {
-                audioOut.store(_SYS_::mute::Active);
+                audioOutStore(_SYS_::mute::Active);
                 sound = _SYS_::mute::Active;
                 fadeLevel = 0;
             }
@@ -2074,12 +2080,12 @@ int SynthEngine::MasterAudio(float *outl [NUM_MIDI_PARTS + 1], float *outr [NUM_
             break;
         case _SYS_::mute::Complete:
             // set by resolver and paste
-            audioOut.store(_SYS_::mute::Idle);
+            audioOutStore(_SYS_::mute::Idle);
             //std::cout << "here complete" << std:: endl;
             break;
         case _SYS_::mute::Request:
             // set by paste routine
-            audioOut.store(_SYS_::mute::Immediate);
+            audioOutStore(_SYS_::mute::Immediate);
             sound = _SYS_::mute::Active;
             //std::cout << "here requesting" << std:: endl;
             break;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -168,6 +168,7 @@ class SynthEngine
         unsigned char legatoPart;
         void setPartMap(int npart);
         void setAllPartMaps(void);
+        void audioOutStore(uint8_t num);
 
         bool masterMono;
         bool fileCompatible;

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -309,7 +309,7 @@ class SynthEngine
         void( *guiClosedCallback)(void*);
         void *guiCallbackArg;
 
-        int CHtimer;
+        int64_t CHtimer;
 
         int64_t LFOtime; // used by Pcontinous without Pbpm
         float songBeat; // used by Pbpm without Pcontinous

--- a/src/UI/PresetsUI.fl
+++ b/src/UI/PresetsUI.fl
@@ -181,7 +181,7 @@ o->hide();}
             pastewin->hide();
             return;
         }
-        synth->audioOut.store(_SYS_::mute::Request);
+        synth->audioOutStore(_SYS_::mute::Request);
         while (synth->audioOut.load() == _SYS_::mute::Request)
             usleep (1000); // wait for full mute
         p->paste(n);
@@ -195,20 +195,20 @@ o->hide();}
             // be done directly - trying to get rid of these!
         }
         if (synth->audioOut.load() == _SYS_::mute::Immediate)
-            synth->audioOut.store(_SYS_::mute::Complete);}
+            synth->audioOutStore(_SYS_::mute::Complete);}
         xywh {10 355 160 20} box THIN_UP_BOX labelcolor 64
       }
       Fl_Button pastebutton {
         label {Paste from Clipboard}
         callback {//
-        synth->audioOut.store(_SYS_::mute::Request);
+        synth->audioOutStore(_SYS_::mute::Request);
         while (synth->audioOut.load() == _SYS_::mute::Request)
             usleep (1000); // wait for full mute
         p->paste(0);
         pastewin->hide();
         pui->refresh();
         if (synth->audioOut.load() == _SYS_::mute::Immediate)
-            synth->audioOut.store(_SYS_::mute::Complete);}
+            synth->audioOutStore(_SYS_::mute::Complete);}
         xywh {25 385 90 35} box THIN_UP_BOX labelcolor 64 align 192
       }
       Fl_Button pastecancel {


### PR DESCRIPTION
```
commit bd64fca3c46c8e17c238ca6da0de075dc3af5a06
Author: Kristian Amlie <kristian@amlie.name>
Date:   Thu Apr 6 14:09:13 2023 +0200

    solo: Replace custom timekeeping with `clock_gettime`.
    
    This should improve both performance and accuracy since the kernel is
    in charge of the ticks.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>

commit 958f5237234d98f82d63a40da74247c276e2d353 (mine/sortResultsThread)
Author: Kristian Amlie <kristian@amlie.name>
Date:   Thu Apr 6 14:10:58 2023 +0200

    Spin sortResultsThread only when we need to, instead of all the time.
    
    This improves performance significantly, especially when using
    multiple instances where most are idle.
    
    Signed-off-by: Kristian Amlie <kristian@amlie.name>
```