### PR TITLE
legato: Fix incorrect allocation size in cloneArray, leading to crash.

### DIFF
--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -202,7 +202,7 @@ namespace{ // Array-cloning helper
         Arr const& oldArray = oldData.*arrMember;
         Arr&       newArray = newData.*arrMember;
 
-        newArray[voice].reset(new VAL[NUM_VOICES]);
+        newArray[voice].reset(new VAL[unisonSiz]);
         memcpy(newArray[voice].get(), oldArray[voice].get(), unisonSiz * sizeof(VAL));
     }
 }


### PR DESCRIPTION
It worked fine as long as the unison size was eight or less, since that's the number of voices, but not for 9 and above.