### PR TITLE
Fix old LV2 state data not being saved correctly after loading.

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1492,8 +1492,8 @@ void Part::getfromXMLinstrument(XMLwrapper *xml)
             Poriginal = UNTITLED;
         if (Pname.empty()) // it's an older state file
         {
-            if (Poriginal.empty() || Poriginal == UNTITLED)
-                Pname = DEFAULT_NAME;
+            if (Poriginal.empty())
+                Pname = UNTITLED;
             else
                 Pname = Poriginal;
         }


### PR DESCRIPTION
The problem is that the Pname is set to DEFAULT_NAME, which then prevents saving later, even though the sound is correct at the time of the load. Most likely we should never set it to DEFAULT_NAME as long as it isn't explicitly set to that in the XML.

This is a very destructive bug as it is not apparent that it has happened until the next time you load.