### PR TITLE
Fix incorrect header in state data when saving with LV2.

### DIFF
--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -3184,6 +3184,7 @@ int SynthEngine::getalldata(char **data)
 {
     bool oldFormat = usingYoshiType;
     usingYoshiType = true; // make sure everything is saved
+    getRuntime().xmlType = TOPLEVEL::XML::State;
     XMLwrapper *xml = new XMLwrapper(this, true);
     add2XML(xml);
     midilearn.insertMidiListData(xml);


### PR DESCRIPTION
I don't think it has any effect currently, but doesn't hurt to do it right.