### PR TITLE
Find manual: don't descend into any network mounts

### DIFF
--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -1573,13 +1573,13 @@ std::string Config::findHtmlManual(void)
 {
     string namelist = "";
     string tempnames = "";
-    if(file::cmd2string("find /usr/share/ -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
+    if(file::cmd2string("find /usr/share/ -xdev -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
         namelist = tempnames;
 
-    if(file::cmd2string("find /usr/local/share/ -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
+    if(file::cmd2string("find /usr/local/share/ -xdev -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
         namelist += tempnames;
 
-    if(file::cmd2string("find /home/ -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
+    if(file::cmd2string("find /home/ -type f -xdev -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
         namelist += tempnames;
 
     //cout << "man list" << namelist << endl;

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -1579,7 +1579,7 @@ std::string Config::findHtmlManual(void)
     if(file::cmd2string("find /usr/local/share/ -xdev -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
         namelist += tempnames;
 
-    if(file::cmd2string("find /home/ -type f -xdev -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
+    if(file::cmd2string("find /home/ -xdev -type f -name 'yoshimi_user_guide_version' 2>/dev/null", tempnames))
         namelist += tempnames;
 
     //cout << "man list" << namelist << endl;


### PR DESCRIPTION
In case there is a network filesystem mounted somewhere under /home/, don't descend into this when finding the manual.

On my computer it starts searching an SMB mount containing many gigabytes of files just to find the manual.

From 'man find':
-xdev Don't descend directories on other filesystems.
