### PR TITLE
Prevent unlimited unison count on layered sub voices.

### DIFF
--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -129,11 +129,12 @@ public:
 class ADnote
 {
         ADnote(ADnoteParameters& adpars_, Controller& ctl_, Note note_, bool portamento_
-              ,ADnote *topVoice_, int subVoiceNr, int phaseOffset, float *parentFMmod_, bool forFM_);
+              ,ADnote *topVoice_, int subVoiceNr, int phaseOffset, float *parentFMmod_
+              ,bool forFM_, size_t unison_total_size);
+        ADnote(ADnote *topVoice_, float freq_, int phase_offset_, int subVoiceNumber_,
+               float *parentFMmod_, bool forFM_, size_t unison_total_size);
     public:
         ADnote(ADnoteParameters& adpars_, Controller& ctl_, Note, bool portamento_);
-        ADnote(ADnote *topVoice_, float freq_, int phase_offset_, int subVoiceNumber_,
-               float *parentFMmod_, bool forFM_);
         ADnote(const ADnote &orig, ADnote *topVoice_ = NULL, float *parentFMmod_ = NULL);
        ~ADnote();
 
@@ -150,7 +151,7 @@ class ADnote
         void legatoFadeOut();
 
     private:
-        void construct();
+        void construct(size_t unison_total_size);
         void allocateUnison(size_t unisonCnt, size_t buffSize);
 
         void setfreq(int nvoice, float in_freq, float pitchdetune);
@@ -169,7 +170,7 @@ class ADnote
         void computePhaseOffsets(int nvoice);
         void computeFMPhaseOffsets(int nvoice);
         void initParameters();
-        void initSubVoices();
+        void initSubVoices(size_t unison_total_size);
         void killVoice(int nvoice);
         void killNote();
         float getVoiceBaseFreq(int nvoice);

--- a/src/globals.h
+++ b/src/globals.h
@@ -103,6 +103,9 @@ using ushort = unsigned short;
 
 // these were previously (pointlessly) user configurable
 #define NUM_VOICES 8
+// Maximum in the UI is 50, but 64 unison size can happen for PWM
+// modulation. See ADnote.cpp for details.
+#define MAX_UNISON 64
 #define POLYPHONY 60 // per part!
 #define PART_DEFAULT_LIMIT 20
 #define NUM_SYS_EFX 4


### PR DESCRIPTION
This should have been there since the introduction of sub voices, I just forgot to add a ceiling check back then.

Fun fact: Before this fix, if you try to set all 8 voices to have 50 unison count, and stack them as sub voices on top of each other, it tries to allocate nearly forty trillion unison buffers, and several hundred billion voices. It might be tough to run that realtime!