### PR TITLE
Simplify UI bootstrap

### DIFF
--- a/src/Interface/GuiDataExchange.cpp
+++ b/src/Interface/GuiDataExchange.cpp
@@ -217,15 +217,6 @@ RoutingTag GuiDataExchange::fetchTag(size_t idx)
 }
 
 
-bool GuiDataExchange::isValidPushMsg(CommandBlock const& notification)
-{
-    size_t slotIDX = notification.data.offset;
-    return notification.data.control == TOPLEVEL::control::dataExchange
-       and notification.data.part    == TOPLEVEL::section::message
-       and isTimely(manager->storage.entryAge(slotIDX));
-}
-
-
 void GuiDataExchange::dispatchUpdates(CommandBlock const& notification)
 {
     if (notification.data.control != TOPLEVEL::control::dataExchange)

--- a/src/Interface/GuiDataExchange.h
+++ b/src/Interface/GuiDataExchange.h
@@ -192,9 +192,6 @@ public:
     };
 
 
-    /** message describes a push update, corresponding to GuiDataExchange data? */
-    bool isValidPushMsg(CommandBlock const&);
-
     /**
      * Dispatch a notification regarding data updates -> GUI.
      * The given CommandBlock contains a data handle(index); routing info an
@@ -289,7 +286,4 @@ inline bool GuiDataExchange::RoutingTag::operator!=(RoutingTag const& otag)  con
 }
 
 
-/////////////////////////////////////////////////////////////////////////////////////////////////WIP Prototype 1/24 - throw away when done!!!!!
-void run_GuiDataExchangeTest();
-/////////////////////////////////////////////////////////////////////////////////////////////////WIP Prototype 1/24 - throw away when done!!!!!
 #endif /*GUI_DATA_EXCHANGE_H*/

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -159,10 +159,8 @@ bool InterChange::Init()
 #ifdef GUI_FLTK
 void InterChange::createGuiMaster()
 {
-    // allocate a data Slot in GuiDataExchange and emplace
-    // an InterfaceAnchor record with all connection IDs
-    size_t slotIDX = synth.publishGuiAnchor();
-    guiMaster.reset(new MasterUI(*this, slotIDX));
+    // provide InterfaceAnchor record with all connection IDs
+    guiMaster.reset(new MasterUI(*this, synth.buildGuiAnchor()));
     guiMaster->Init();
 }
 

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -157,24 +157,13 @@ bool InterChange::Init()
 }
 
 #ifdef GUI_FLTK
-MasterUI& InterChange::createGuiMaster()
+void InterChange::createGuiMaster()
 {
-    CommandBlock bootstrapMsg;
-    while (toGUI.read(bootstrapMsg.bytes))
-        if (guiDataExchange.isValidPushMsg(bootstrapMsg))
-        {
-            size_t slotIDX = bootstrapMsg.data.offset;
-            guiMaster.reset(new MasterUI(*this, slotIDX));
-            assert(guiMaster);
-            return *guiMaster;
-        }
-    throw std::logic_error("Instance Lifecycle broken: expect bootstrap message.");
-    // Explanation: after a suitable MusicIO backend has been established, the SynthEngine::Init()
-    //              will initialise the InterChange for this Synth and then prime the toGUI ringbuffer
-    //              with a key for the GuiDataExchange to pass an InterfaceAnchor record up into the GUI.
-    //              See SynthEngine::publishGuiAnchor() and InstanceManager::SynthGroom::dutyCycle();
-    //              this bootstrap record provides connection IDs used by various UI components to
-    //              receive push-updates from the Core and is thus embedded directly into MasterUI.
+    // allocate a data Slot in GuiDataExchange and emplace
+    // an InterfaceAnchor record with all connection IDs
+    size_t slotIDX = synth.publishGuiAnchor();
+    guiMaster.reset(new MasterUI(*this, slotIDX));
+    guiMaster->Init();
 }
 
 void InterChange::shutdownGui()

--- a/src/Interface/InterChange.h
+++ b/src/Interface/InterChange.h
@@ -85,7 +85,7 @@ class InterChange : private DataText
         bool Init();
 
 #ifdef GUI_FLTK
-        MasterUI& createGuiMaster();
+        void createGuiMaster();
         void shutdownGui();
 #endif
 

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -109,7 +109,6 @@ SynthEngine::SynthEngine(uint instanceID)
     , midilearn{*this}
     , mididecode{this}
     , vectorcontrol{this}
-    , rootCon{interchange.guiDataExchange.createConnection<InterfaceAnchor>()}
     , audioOut{}
     , partlock{}
     , legatoPart{0}
@@ -419,7 +418,7 @@ bail_out:
  * where it typically is the very first message, since this function is
  * invoked from SynthEngine::Init().
  */
-size_t SynthEngine::publishGuiAnchor()
+InterfaceAnchor SynthEngine::buildGuiAnchor()
 {
     InterfaceAnchor anchorRecord;
     anchorRecord.synth = this;
@@ -433,8 +432,7 @@ size_t SynthEngine::publishGuiAnchor()
     anchorRecord.partEffectParam = partEffectUiCon;
     anchorRecord.partEffectEQ    = partEqGraphUiCon;
 
-    // bootstrap message picked up when event-thread creates MasterUI
-    return rootCon.emplace(anchorRecord);
+    return anchorRecord;
 }
 
 

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -379,13 +379,6 @@ bool SynthEngine::Init(uint audiosrate, int audiobufsize)
         goto bail_out;
     }
 
-#ifdef GUI_FLTK
-    // Init the Gui-Data-Exchange
-    if (Runtime.showGui)
-        publishGuiAnchor();
-#endif
-
-
     // we seem to need this here only for first time startup :(
     bank.setCurrentBankID(Runtime.tempBank, false);
     return true;
@@ -426,7 +419,7 @@ bail_out:
  * where it typically is the very first message, since this function is
  * invoked from SynthEngine::Init().
  */
-void SynthEngine::publishGuiAnchor()
+size_t SynthEngine::publishGuiAnchor()
 {
     InterfaceAnchor anchorRecord;
     anchorRecord.synth = this;
@@ -441,7 +434,7 @@ void SynthEngine::publishGuiAnchor()
     anchorRecord.partEffectEQ    = partEqGraphUiCon;
 
     // bootstrap message picked up when event-thread creates MasterUI
-    rootCon.publish(anchorRecord);
+    return rootCon.emplace(anchorRecord);
 }
 
 

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -79,9 +79,6 @@ class SynthEngine
         MidiDecode mididecode;
         Vectors vectorcontrol;
 
-    private:
-        GuiDataExchange::Connection<InterfaceAnchor> rootCon;
-
     public:
         Config& getRuntime()     {return Runtime;}
         uint getUniqueId() const {return uniqueId;}
@@ -95,7 +92,7 @@ class SynthEngine
         SynthEngine& operator=(SynthEngine const&) = delete;
 
         bool Init(uint audiosrate, int audiobufsize);
-        size_t publishGuiAnchor();
+        InterfaceAnchor buildGuiAnchor();
         void postBootHook(bool);
 
         bool savePatchesXML(string filename);

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -95,7 +95,7 @@ class SynthEngine
         SynthEngine& operator=(SynthEngine const&) = delete;
 
         bool Init(uint audiosrate, int audiobufsize);
-        void publishGuiAnchor();
+        size_t publishGuiAnchor();
         void postBootHook(bool);
 
         bool savePatchesXML(string filename);

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -308,8 +308,8 @@ class KeyHandle {: {public Fl_Box}
 
 class MasterUI {: {public GuiUpdates}
 } {
-  Function {MasterUI(InterChange& _interChange, size_t slotIDX)
-	 : GuiUpdates{_interChange, slotIDX}} {} {
+  Function {MasterUI(InterChange& _interChange, InterfaceAnchor connectionData)
+	 : GuiUpdates{_interChange, std::move(connectionData)}} {} {
     code {//
       synth = nullptr;
       presetsui = nullptr;
@@ -407,8 +407,8 @@ class MasterUI {: {public GuiUpdates}
   }
   Function {Init()} {} {
     code {//
-      current_ID = anchor.get().synthID;
-      synth = anchor.get().synth;
+      current_ID = anchor.synthID;
+      synth = anchor.synth;
       assert(synth);
       file::createDir(file::configDir() + "/windows");
       panelType = 5;
@@ -1027,7 +1027,7 @@ class MasterUI {: {public GuiUpdates}
       } {
         Fl_Group syseffectui {
           xywh {3 188 379 95} labeltype NO_LABEL labelcolor 64
-          code0 {o->init(synth, anchor.get().sysEffectParam, anchor.get().sysEffectEQ, TOPLEVEL::section::systemEffects);
+          code0 {o->init(synth, anchor.sysEffectParam, anchor.sysEffectEQ, TOPLEVEL::section::systemEffects);
                  o->activate();
                  o->show();}
           class EffUI
@@ -1039,7 +1039,7 @@ class MasterUI {: {public GuiUpdates}
       } {
         Fl_Group inseffectui {
           xywh {3 188 379 95} color 52 labelcolor 64
-          code0 {o->init(synth, anchor.get().insEffectParam, anchor.get().insEffectEQ, TOPLEVEL::section::insertEffects);
+          code0 {o->init(synth, anchor.insEffectParam, anchor.insEffectEQ, TOPLEVEL::section::insertEffects);
                  o->hide();}
           code1 {o->deactivate(); // initially deactivated}
           class EffUI

--- a/src/UI/MiscGui.cpp
+++ b/src/UI/MiscGui.cpp
@@ -165,13 +165,10 @@ string input_text(SynthEngine *synth, string label, string text)
 }
 
 
-GuiUpdates::GuiUpdates(InterChange& _interChange, size_t slotIDX)
+GuiUpdates::GuiUpdates(InterChange& _interChange, InterfaceAnchor&& connectionData)
     : interChange{_interChange}
-    , anchor{interChange.guiDataExchange.bootstrapConnection<InterfaceAnchor>(slotIDX)}
-{
-    // cause update to be pushed into MirrorData buffer
-    interChange.guiDataExchange.pushUpdates(slotIDX);
-}
+    , anchor{std::move(connectionData)}
+{ }
 
 
 void GuiUpdates::read_updates(SynthEngine *synth)

--- a/src/UI/MiscGui.h
+++ b/src/UI/MiscGui.h
@@ -163,7 +163,7 @@ unsigned int logDial2millisec(int);
 class GuiUpdates
 {
 protected:
-    GuiUpdates(InterChange&, size_t);
+    GuiUpdates(InterChange&, InterfaceAnchor&&);
 
     // must not be copied nor moved
     GuiUpdates(GuiUpdates &&)                =delete;
@@ -175,18 +175,11 @@ protected:
 
 public:
     InterChange& interChange;
-    MirrorData<InterfaceAnchor> anchor;
+    InterfaceAnchor anchor;
 
-    auto connectSysEffect() { return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.get().sysEffectParam); }
-    auto connectInsEffect() { return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.get().insEffectParam); }
-    auto connectPartEffect(){ return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.get().partEffectParam);}
-
-    template<class DAT>
-    GuiDataExchange::Connection<DAT> connectCore(GuiDataExchange::RoutingTag InterfaceAnchor::*tag)
-    {
-        (anchor.get().*tag).verifyType<DAT>();
-        return GuiDataExchange::Connection<DAT>(interChange.guiDataExchange, anchor.get().*tag);
-    }
+    auto connectSysEffect() { return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.sysEffectParam); }
+    auto connectInsEffect() { return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.insEffectParam); }
+    auto connectPartEffect(){ return GuiDataExchange::Connection<EffectDTO>(interChange.guiDataExchange, anchor.partEffectParam);}
 
 private:
     void decode_envelope(SynthEngine *synth, CommandBlock *getData);

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -718,7 +718,7 @@ class PartUI {: {public Fl_Group, PartUI_}
       } {
         Fl_Group inseffectui {
           xywh {5 38 379 95}
-          code0 {InterfaceAnchor& anchor = synth->getGuiMaster()->anchor.get();
+          code0 {InterfaceAnchor& anchor = synth->getGuiMaster()->anchor;
                  o->init(synth, anchor.partEffectParam, anchor.partEffectEQ, npart);}
           class EffUI
         } {}


### PR DESCRIPTION
With #200 and #207 several deep changes were made related to the connection between SynthEngine core and GUI. The overall goal is to reduce direct access from the GUI into core data.

With Release v2.3.3. this changed connection scheme is in widespread use now.
Unfortunately, the start-up fails under some circumstances with a timeout error.

Those problems are related to the initial »bootstrap« of the connection when the GUI is launched. The GUI now needs a set of _connection IDs_ to allow for direct push-updates into some components. A data record with these IDs was sent as an initial push-update over the new connection mechanism; but the GUI could be delayed by other start-up activity, causing the timeout and consequently a failure to get the GUI connection established.

After reconsidering the whole topic, in hindsight it seems that it was a bad idea to attempt to use a bootstrap message, instead of making this initialisation a direct part of the GUI startup. Generally speaking, the situation at start-up is complicated by the possibility to launch several instances; moreover, a variant of the Yoshimi code is packaged as **LV2** plugin -- and in this case not much can be assumed regarding the threads and the order in which the start-up is performed. We must be prepared that the core is initialised in another thread than the GUI and that both threads are already running. Using the communication via ringbuffer would obviously circumvent those synchronisation issues -- but the same effect can be achieved by relying on explicit locking, which is done anyway for parts of the Instance creation.

So with these changes, the launch of the UI is now always from a call protected by a Mutex in the `InstanceManager` and thus the communication-IDs can be read directly from the SynthEngine and passed to the newly created MasterUI object.
