### PR TITLE
Increase LV2 compatibility by supporting "UI" base class methods.

### DIFF
--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
@@ -170,12 +170,16 @@ public:
     bool init();
     static LV2UI_Handle	instantiate(const LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature *const *features);
     static void cleanup(LV2UI_Handle ui);
+    static const void *extension_data(const char *uri);
     void run();
     void show();
     void hide();
     static void callback_Run (LV2_External_UI_Widget* ui){ self(ui).run();  }
     static void callback_Show(LV2_External_UI_Widget* ui){ self(ui).show(); }
     static void callback_Hide(LV2_External_UI_Widget* ui){ self(ui).hide(); }
+    static int callback_IdleInterface(LV2_Handle ui){ self(ui).run(); return 0; }
+    static int callback_ShowInterface(LV2_Handle ui){ self(ui).show(); return 0; }
+    static int callback_HideInterface(LV2_Handle ui){ self(ui).hide(); return 0; }
 
 private:
     SynthEngine& engine() { return corePlugin->synth; } // use friend access

--- a/src/LV2_Plugin/manifest.ttl
+++ b/src/LV2_Plugin/manifest.ttl
@@ -15,4 +15,8 @@
 <http://yoshimi.sourceforge.net/lv2_plugin#ExternalUI>
     a <http://kxstudio.sf.net/ns/lv2ext/external-ui#Widget> ;
     ui:binary <yoshimi_lv2.so> ;
+    lv2:extensionData <http://lv2plug.in/ns/extensions/ui#idleInterface> ,
+                      <http://lv2plug.in/ns/extensions/ui#showInterface> ;
+    lv2:optionalFeature <http://lv2plug.in/ns/extensions/ui#idleInterface> ;
+    lv2:optionalFeature <http://lv2plug.in/ns/extensions/ui#showInterface> ;
     lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> .


### PR DESCRIPTION
The interfaces "showInterface" and "idleInterface" are meant as fallbacks if none of the sub class methods work or are supported. This enables the jalv standalone host to launch Yoshimi, which wasn't possible before.

Note that support for the sub class extension "external-ui" is still preferred, since without it Yoshimi has no way to tell the host that the UI was closed. So we keep that as the main class with the "UI" base class as a fallback.