### PR TITLE
LV2 instance config and patch-state handling

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -861,10 +861,8 @@ int InterChange::indirectMain(CommandBlock& cmd, uchar &newMsg, bool &guiTo, str
             if (synth.loadStateAndUpdate(text))
             {
                 text = setExtension(text, EXTEN::state);
-                string name = file::configDir() + string(YOSHIMI);
-                name += ("-" + to_string(synth.getUniqueId()));
-                name += ".state";
-                if ((text != name)) // never include default state
+                string defaultName = synth.getRuntime().defaultSession;
+                if ((text != defaultName)) // never include default state
                     synth.addHistory(text, TOPLEVEL::XML::State);
                 text = "ed " + text;
             }
@@ -878,10 +876,8 @@ int InterChange::indirectMain(CommandBlock& cmd, uchar &newMsg, bool &guiTo, str
             string filename = setExtension(text, EXTEN::state);
             if (synth.saveState(filename))
             {
-                string name = file::configDir() + string(YOSHIMI);
-                name += ("-" + to_string(synth.getUniqueId()));
-                name += ".state";
-                if ((text != name)) // never include default state
+                string defaultName = synth.getRuntime().defaultSession;
+                if ((text != defaultName)) // never include default state
                     synth.addHistory(filename, TOPLEVEL::XML::State);
                 text = "d " + text;
             }

--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
@@ -542,7 +542,7 @@ LV2_State_Status YoshimiLV2Plugin::stateSave(LV2_State_Store_Function store, LV2
     // suppress warnings - may use later
 
     char *data = NULL;
-    int sz = synth.getalldata(&data);
+    int sz = runtime().saveSessionData(&data);
 
     store(handle, _yoshimi_state_id, data, sz, _atom_string_id, LV2_STATE_IS_POD | LV2_STATE_IS_PORTABLE);
     free(data);
@@ -564,7 +564,7 @@ LV2_State_Status YoshimiLV2Plugin::stateRestore(LV2_State_Retrieve_Function retr
     const char *data = (const char *)retrieve(handle, _yoshimi_state_id, &sz, &type, &new_flags);
 
     if (sz > 0)
-        synth.putalldata(data, sz);
+        runtime().restoreSessionData(data, sz);
     return LV2_STATE_SUCCESS;
 }
 

--- a/src/Misc/CmdOptions.cpp
+++ b/src/Misc/CmdOptions.cpp
@@ -43,7 +43,7 @@ namespace { // constants used in the implementation
         "Copyright 2012-2013 Jeremy Jongepier and others,\n"
         "Copyright 2014-2025 Will Godfrey and others";
 
-    string stateText = "load saved state, defaults to '$HOME/" + EXTEN::config + "/yoshimi/yoshimi-0.state'";
+    string stateText = "load saved state, defaults to '$HOME/" + EXTEN::config + "/yoshimi/yoshimi-0"+EXTEN::state+"'";
 
     const argp_option OPTION_SPEC[] = {
         {"alsa-audio",        'A',  "<device>", OPTION_ARG_OPTIONAL, "use alsa audio output", 0},

--- a/src/Misc/Config.h
+++ b/src/Misc/Config.h
@@ -82,8 +82,10 @@ class Config
         bool saveInstanceConfig();
         void loadConfig();
         bool updateConfig(int control, int value);
-        bool saveSessionData(string savefile);
+        bool saveSessionData(string sessionfile);
+        int  saveSessionData(char** dataBuffer);
         bool restoreSessionData(string sessionfile);
+        bool restoreSessionData(const char* dataBuffer, int size);
         bool restoreJsession();
         void setJackSessionSave(int event_type, string const& session_file);
         float getConfigLimits(CommandBlock*);
@@ -106,7 +108,6 @@ class Config
         uint    build_ID;
         int     lastXMLmajor;
         int     lastXMLminor;
-        bool    stateChanged;
         bool    oldConfig;
 
         static bool        showSplash;
@@ -272,6 +273,8 @@ class Config
         bool initFromPersistentConfig();
         bool extractBaseParameters(XMLwrapper& xml);
         bool extractConfigData(XMLwrapper& xml);
+        void capturePatchState(XMLwrapper& xml);
+        bool restorePatchState(XMLwrapper& xml);
         void addConfigXML(XMLwrapper& xml);
         void saveJackSession();
 

--- a/src/Misc/Config.h
+++ b/src/Misc/Config.h
@@ -268,6 +268,7 @@ class Config
         pthread_t  findManual_Thread;
 
         void defaultPresets();
+        void buildConfigLocation();
         bool initFromPersistentConfig();
         bool extractBaseParameters(XMLwrapper& xml);
         bool extractConfigData(XMLwrapper& xml);

--- a/src/Misc/FileMgrFuncs.h
+++ b/src/Misc/FileMgrFuncs.h
@@ -85,6 +85,9 @@ namespace file {
 using std::string;
 using std::stringstream;
 
+// Marker used for instance config when started as LV2 plugin
+const string LV2_INSTANCE = "LV2";
+
 // make a filename legal
 inline void make_legit_filename(string& fname)
 {

--- a/src/Misc/InstanceManager.cpp
+++ b/src/Misc/InstanceManager.cpp
@@ -300,8 +300,9 @@ bool InstanceManager::Instance::startUp(PluginCreator pluginCreator)
 {
     cout << "\nStart-up Synth-Instance("<< getID() << ")..."<< endl;
     state = BOOTING;
-    runtime().loadConfig();
     bool isLV2 = bool(pluginCreator);
+    runtime().isLV2 = isLV2;
+    runtime().loadConfig();
     assert (not runtime().runSynth);
     if (isLV2)
     {

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1372,7 +1372,6 @@ void Part::add2XML(XMLwrapper& xml, bool subset)
 
 bool Part::saveXML(string filename, bool yoshiFormat)
 {
-    synth->usingYoshiType = yoshiFormat;
     synth->getRuntime().xmlType = TOPLEVEL::XML::Instrument;
     auto xml{std::make_unique<XMLwrapper>(*synth, yoshiFormat)};
 

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -1992,8 +1992,8 @@ void SynthEngine::resetAll(bool andML)
     ClearNRPNs();
     if (Runtime.loadDefaultState)
     {
-        string filename = Runtime.defaultStateName + ("-" + to_string(this->getUniqueId()));
-        if (isRegularFile(filename + ".state"))
+        string filename = Runtime.defaultSession;
+        if (isRegularFile(filename))
         {
             Runtime.stateFile = filename;
             Runtime.restoreSessionData(Runtime.stateFile);
@@ -2773,7 +2773,7 @@ bool SynthEngine::loadHistory()
     string historyname = file::localDir()  + "/recent";
     if (!isRegularFile(historyname))
     {   // recover old version
-        historyname = file::configDir() + '/' + string(YOSHIMI) + ".history";
+        historyname = file::configDir() + '/' + YOSHIMI + ".history";
         if (!isRegularFile(historyname))
         {
             Runtime.Log("Missing recent history file");

--- a/src/Misc/SynthEngine.h
+++ b/src/Misc/SynthEngine.h
@@ -117,9 +117,6 @@ class SynthEngine
 
         bool getfromXML(XMLwrapper& xml);
 
-        int getalldata(char **data);
-        void putalldata(const char *data, int size);
-
         void NoteOn(uchar chan, uchar note, uchar velocity);
         void NoteOff(uchar chan, uchar note);
         int RunChannelSwitch(uchar chan, int value);
@@ -164,7 +161,6 @@ class SynthEngine
 
         bool masterMono;
         bool fileCompatible;
-        bool usingYoshiType;
 
         float getLimits(CommandBlock *getData);
         float getVectorLimits(CommandBlock *getData);

--- a/src/Misc/XMLwrapper.cpp
+++ b/src/Misc/XMLwrapper.cpp
@@ -579,7 +579,7 @@ bool XMLwrapper::loadXMLfile(string const& filename)
     else
         synth.getRuntime().lastXMLminor = 0;
     string exten = findExtension(filename);
-    if (exten.length() != 4 && exten != ".state")
+    if (exten.length() != 4 && exten != EXTEN::state)
         return true; // we don't want config stuff
 
     if (synth.getRuntime().logXMLheaders)

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -719,10 +719,8 @@ class MasterUI {: {public GuiUpdates}
             break;
         case 29: // default
             {
-            string name = synth->getRuntime().defaultStateName;
-            name += ("-" + to_string(current_ID));
-            send_data(TOPLEVEL::action::lowPrio | TOPLEVEL::action::forceUpdate, MAIN::control::saveNamedState, 0, TOPLEVEL::type::Integer, TOPLEVEL::section::main, UNUSED, UNUSED, UNUSED, textMsgBuffer.push(name + ".state"));
-
+                string name = synth->getRuntime().defaultSession;
+                send_data(TOPLEVEL::action::lowPrio | TOPLEVEL::action::forceUpdate, MAIN::control::saveNamedState, 0, TOPLEVEL::type::Integer, TOPLEVEL::section::main, UNUSED, UNUSED, UNUSED, textMsgBuffer.push(name));
             }
             break;
         case 30: // recent


### PR DESCRIPTION
Together with #216 , this is the result from an extended [discussion of config handling](https://sourceforge.net/p/yoshimi/mailman/yoshimi-devel/thread/588de901-d31d-4767-8813-1aa656f68fa2%40ichthyostega.de/) on the developers-list. To summarise...

### Issues

- LV2 happened to use the instance configuration mechanism primarily intended for running several `SynthEngine` instances in a single process of Yoshimi (stand-alone); a LV2 host may instantiate several LV2 plug-in instances in the same process, thereby implicitly creating several instances of the `SynthEngine`.
- however, the instance-ID is assigned in a _first come, first serve_ way, and so there is no way for the user to control the identities of those instances. A LV2 plug-in instance thus picks up an persistent instance config, which just accidentally happens to be marked with a specific instance-ID.
- typically, the effects of this random aliasing of instance configs is covered up by the fact that most LV2 hosts maintain a patch-state per plug-in instance.

### Conclusions

- the general structure of the config (with the three layers base-config, instance-config and patch-state) was discussed and considered adequate and a good compromise
- it is valid and desirable that a patch-state also contains some config settings, which may impact the generated sound or behaviour
- however, we consider it undesirable to alias between config intended for stand-alone instances and LV2. Thus, with this change, a distinct instance-config labelled as `LV2` is introduced. It will be populated by defaults and handled like any other instance-config.
- moreover, the state-saving for stand-alone (state-files, session manager) and LV2 is harmonised and now uses a common implementation, so that both the instance-config and the details of the patch-state are included.