### PR TITLE
Fixes for two problems discovered in v2.3.4

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -1422,10 +1422,7 @@ int InterChange::indirectConfig(CommandBlock& cmd, uchar& newMsg, bool& guiTo, s
             {
                 text = synth.getRuntime().configFile;
                 if (synth.getRuntime().saveInstanceConfig())
-                {
-                    partsChanged = 0;
                     text = "d " + text;
-                }
                 else
                     text = " FAILED " + text;
             }
@@ -3159,7 +3156,6 @@ void InterChange::commandConfig(CommandBlock& cmd)
         case CONFIG::control::saveAllXMLdata:
             if (write)
             {
-                partsChanged = 0;
                 synth.getRuntime().xmlmax = value_bool;
                 synth.getRuntime().updateConfig(control, value_int);
             }

--- a/src/Interface/MidiLearn.cpp
+++ b/src/Interface/MidiLearn.cpp
@@ -966,7 +966,9 @@ bool MidiLearn::extractMidiListData(XMLStore& xml)
         {
             uint ident{0};
             uint status{0};
-            LearnBlock entry;
+            midi_list.emplace_back();
+            LearnBlock& entry = midi_list.back();
+
             if (xmlLine.getPar_bool("Mute", 0))
                 status |= 4;
             if (xmlLine.getPar_bool("NRPN", 0))
@@ -1006,10 +1008,9 @@ bool MidiLearn::extractMidiListData(XMLStore& xml)
 
             // completed processing <LINE> element
             entry.status = status;
-            midi_list.push_back(entry);
             ++ ID;
 
-            /* --------------------- Diagnostics --------------------- */
+            /* -------------- decode and re-code command ------------- */
             CommandBlock cmd;
 if (DECODE_MODE)
 {


### PR DESCRIPTION
Both problems are rather arcane and were overlooked in the tests before release.

- the porting of old command-data in MIDI-Learn files was bypassed
- in two cases the new »part dirty« flag was cleared while it shouldn't
