### PR TITLE
Fix channel aftertouch using the wrong parameter as basis.

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -299,7 +299,7 @@ void Part::setChannelAT(int type, int value)
         if (value > 0)
         {
             if (oldFilterQstate == -1)
-                oldFilterQstate = ctl->filtercutoff.data;
+                oldFilterQstate = ctl->filterq.data;
             float adjust = oldFilterQstate / 127.0f;
             if (type & PART::aftertouchType::filterQdown)
                 ctl->setfilterq(oldFilterQstate - (value * adjust));


### PR DESCRIPTION
This results in several bugs, both setting the wrong parameter during the aftertouch, and restoring it to the wrong value afterwards.