### PR TITLE
improve metainfo

### DIFF
--- a/desktop/metainfo/yoshimi.metainfo.xml
+++ b/desktop/metainfo/yoshimi.metainfo.xml
@@ -88,6 +88,6 @@
     <keyword>Synthesizer</keyword>
     <keyword>Softsynth</keyword>
   </keywords>
-  <url type="homepage">https://sourceforge.net/projects/yoshimi/</url>
+  <url type="homepage">https://yoshimi.sourceforge.io/</url>
   <url type="help">http://yoshimi.github.io/docs/user-guide/</url>
 </component>

--- a/desktop/metainfo/yoshimi.metainfo.xml
+++ b/desktop/metainfo/yoshimi.metainfo.xml
@@ -40,8 +40,8 @@
     <p>
     Version 2.3.3 has improved memory management, extension to keyboard shortcuts, better configuration control, and expands theme colour control, and adds realtime theme editing.
     </p>
-    Version 2.3.3 A new 'Omni' made has been added. Warnings provided when overwriting edited  instruments. Revision of XML files for cross-compatibility with MXML versions.
     <p>
+    Version 2.3.3 A new 'Omni' made has been added. Warnings provided when overwriting edited  instruments. Revision of XML files for cross-compatibility with MXML versions.
     </p>
   </description>
    <launchable type="desktop-id">yoshimi.desktop</launchable>

--- a/desktop/metainfo/yoshimi.metainfo.xml
+++ b/desktop/metainfo/yoshimi.metainfo.xml
@@ -89,5 +89,5 @@
     <keyword>Softsynth</keyword>
   </keywords>
   <url type="homepage">https://yoshimi.sourceforge.io/</url>
-  <url type="help">http://yoshimi.github.io/docs/user-guide/</url>
+  <url type="help">https://yoshimi.sourceforge.io/docs/user-guide/</url>
 </component>

--- a/desktop/metainfo/yoshimi.metainfo.xml
+++ b/desktop/metainfo/yoshimi.metainfo.xml
@@ -55,7 +55,7 @@
 
   <screenshots>
     <screenshot type="default">
-       <image>https://yoshimi.sourceforge.io/docs/user-guide/images/Main.png</image>
+       <image>https://yoshimi.sourceforge.io/docs/user-guide/images/main.png</image>
        <caption>Yoshimi's main window</caption>
     </screenshot>
     <screenshot>


### PR DESCRIPTION
`appstreamcli validate desktop/metainfo/yoshimi.metainfo.xml` showed a couple of problems, which I am fixing with this PR:
- use https://yoshimi.sourceforge.io as the base-URL for all documentation/homepage (rather than a mixture of sourceforge.io, sourceforge.net and github.io; also use https:// throughout)
- fix links to URLs (some filesystems are case-sensitive)
- fix the HTML in the `description` tag

like always, I've tried to separate all the changes into multiple commits, so if you do not agree with a specific change, just cherry-pick whatever you want :-)