### PR TITLE
Config: inconsistencies when disabling GUI

### DIFF
--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -3049,21 +3049,21 @@ void InterChange::commandConfig(CommandBlock& cmd)
             if (write)
             {
                 synth.getRuntime().storedGui = value_bool;
-                synth.getRuntime().showGui = value_bool;
+                synth.getRuntime().showGui  |= value_bool;
                 synth.getRuntime().updateConfig(control, value);
             }
             else
-                value = synth.getRuntime().showGui;
+                value = synth.getRuntime().storedGui;
             break;
         case CONFIG::control::enableCLI:
             if (write)
             {
                 synth.getRuntime().storedCli = value_bool;
-                synth.getRuntime().showCli = value_bool;
+                synth.getRuntime().showCli  |= value_bool;
                 synth.getRuntime().updateConfig(control, value);
             }
             else
-                value = synth.getRuntime().showCli;
+                value = synth.getRuntime().storedCli;
             break;
         case CONFIG::control::showSplash:
             if (write)

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -835,15 +835,18 @@ bool Config::extractBaseParameters(XMLStore& xml)
         return false;
     }
 
+    // the following two settings are special, since
+    // - it is possible to override them from the cmdline (but not persistently)
+    // - it is dangerous to disable them from the running instance (leaves half broken, running GUI)
+    // thus we keep the persistent setting in separate state flags (storedGui, storedCli)
     storedGui  = basePars.getPar_bool("enable_gui", showGui);
     if (not guiChanged)
         showGui = storedGui;
-
-    showSplash = basePars.getPar_bool("enable_splash", showSplash);
-
     storedCli  = basePars.getPar_bool("enable_CLI", showCli);
     if (not cliChanged)
         showCli = storedCli;
+
+    showSplash = basePars.getPar_bool("enable_splash", showSplash);
     showCLIcontext  = basePars.getPar_int("show_CLI_context", 1, 0, 2);
 
     singlePath   = basePars.getPar_bool("enable_single_master", singlePath);

--- a/src/UI/ConfigUI.fl
+++ b/src/UI/ConfigUI.fl
@@ -351,7 +351,7 @@ fillThemes();
                         else
                             o->value(1);}
             tooltip {Enable starting with this graphical interface} xywh {190 160 27 25} down_box DOWN_BOX selection_color 64 labelsize 12 labelcolor 64 align 4
-            code0 {o->value(synth->getRuntime().showGui);}
+            code0 {o->value(synth->getRuntime().storedGui);}
             code1 {if (current_ID != 0) o->hide(); else if (isLV2()) o->deactivate();}
             class Fl_Check_Button2
           }
@@ -360,7 +360,7 @@ fillThemes();
             callback {//
                         send_data(0, CONFIG::control::enableCLI, o->value(), TOPLEVEL::type::Integer);}
             tooltip {Enable starting with interactive command line interface} xywh {190 180 27 25} down_box DOWN_BOX selection_color 64 labelsize 12 labelcolor 64 align 4
-            code0 {o->value(synth->getRuntime().showCli);}
+            code0 {o->value(synth->getRuntime().storedCli);}
             code1 {if (current_ID != 0) o->hide(); else if (isLV2()) o->deactivate();}
             class Fl_Check_Button2
           }
@@ -2076,8 +2076,8 @@ send_data (0, CONFIG::control::alsaMidiType, o->value(), TOPLEVEL::type::Integer
                     logTimes->value(synth->getRuntime().showTimes);
                     logXML->value(synth->getRuntime().logXMLheaders);
                     saveAllXML->value(synth->getRuntime().xmlmax);
-                    enableGUI->value(synth->getRuntime().showGui);
-                    enableCLI->value(synth->getRuntime().showCli);
+                    enableGUI->value(synth->getRuntime().storedGui);
+                    enableCLI->value(synth->getRuntime().storedCli);
                     break;
     }} {}
   }


### PR DESCRIPTION
Related to enabling / disabling the GUI and CLI, some inconsistencies in Yoshimi's config handling were discussed. The following points could be identified:

- the `gzip_compression` setting is applied to all XML files, including config. Prior to my extended refactoring with [Pull-request #226](https://github.com/Yoshimi/yoshimi/pull/226), special handling was employed for the base-config. Hereby I reintroduce that special treatment and propose to extend it to all config.
- it is possible to deactivate the GUI through the GUI, but then there is no way to revert this change persistently using the GUI.
- furthermore, when said enabling/disabling is overridden by command line toggles (`-i`, `-I`, `-c`, `-C`), the resulting mixture of state is not handled consistently.

This kind of inconsistencies is not simple to resolve, since there is only one set of settings present as `Config` object. Once the `Config::showGui` is set to `false`, further communication with the UI will be severed, since the core will no longer service the ringbuffer connection to the UI. As a remedy, the changes proposed in this pull request attempt to keep the state in the _current instance_ separate from the persisted state, by using a second pair of state flags for the latter.