### PR TITLE
Fix start phase bug for frequency LFOs.

### DIFF
--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -79,8 +79,11 @@ LFO::LFO(LFOParams *_lfopars, float _basefreq, SynthEngine *_synth):
     incrnd = nextincrnd = 1.0f;
 
     Recompute();
-    if (lfopars->fel == 0) // this is a Frequency LFO
+    if (lfopars->fel == 0) { // this is a Frequency LFO
         x -= 0.25f; // change the starting phase
+        if (x < 0.0f)
+            x += 1.0f;
+    }
     amp1 = (1 - lfornd) + lfornd * synth->numRandom();
     amp2 = (1 - lfornd) + lfornd * synth->numRandom();
     computenextincrnd(); // twice because I want incrnd & nextincrnd to be random


### PR DESCRIPTION
A bit surprising that this bug hasn't been reported before. It requires setting a start phase which happens to end up in the lower quarter of the phase cycle. In this case the frequency would be less than zero, which the rest of the code is not prepared to handle. This would result in the negative magnitude of the response being too strong (meaning note would be too low pitched), before suddenly jumping back once it is corrected by the phase wrapping code. Easier to hear with a slow LFO.