### PR TITLE
Add new Kit Mode: "Crossfade (volume)".

### DIFF
--- a/src/CLI/CmdInterpreter.cpp
+++ b/src/CLI/CmdInterpreter.cpp
@@ -323,11 +323,17 @@ string CmdInterpreter::buildPartStatus(bool showPartDetails)
                 else
                     result += "S";
                 break;
-            case PART::kitType::CrossFade:
+            case PART::kitType::CrossFadeVel:
                 if (justPart)
-                    result += (front + "Crossfade" + back);
+                    result += (front + "Crossfade vel" + back);
                 else
                     result += "C";
+                break;
+            case PART::kitType::CrossFadeVol:
+                if (justPart)
+                    result += (front + "Crossfade vol" + back);
+                else
+                    result += "V";
                 break;
             default:
                 break;
@@ -2794,8 +2800,11 @@ void CmdInterpreter::listCurrentParts(Parser& input, list<string>& msg_buf)
                     case PART::kitType::Single:
                         name += "Single";
                         break;
-                    case PART::kitType::CrossFade:
-                        name += "Crossfade";
+                    case PART::kitType::CrossFadeVel:
+                        name += "Crossfade vel";
+                        break;
+                    case PART::kitType::CrossFadeVol:
+                        name += "Crossfade vol";
                         break;
                 }
             }
@@ -5631,8 +5640,10 @@ int CmdInterpreter::commandPart(Parser& input, unsigned char controlType)
         tmp = PART::kitType::Multi;
     else if (input.matchnMove(2, "single"))
         tmp = PART::kitType::Single;
-    else if (input.matchnMove(2, "crossfade"))
-        tmp = PART::kitType::CrossFade;
+    else if (input.matchnMove(2, "crossfade vel"))
+        tmp = PART::kitType::CrossFadeVel;
+    else if (input.matchnMove(2, "crossfade vol"))
+        tmp = PART::kitType::CrossFadeVol;
     else if (input.matchnMove(3, "kit"))
     {
         if (kitMode == PART::kitType::Off)

--- a/src/Interface/Data2Text.cpp
+++ b/src/Interface/Data2Text.cpp
@@ -1645,7 +1645,10 @@ string DataText::resolvePart(CommandBlock& cmd, bool addValue)
                         contstr += "single";
                         break;
                     case 3:
-                        contstr += "crossfade";
+                        contstr += "crossfade vel";
+                        break;
+                    case 4:
+                        contstr += "crossfade vol";
                         break;
                 }
             }

--- a/src/Interface/InterChange.cpp
+++ b/src/Interface/InterChange.cpp
@@ -4279,23 +4279,44 @@ void InterChange::commandPart(CommandBlock& cmd)
         case PART::control::kitMode:
             if (write)
             {
-                if (value_int == 3) // crossfade
+                switch (value_int)
                 {
+                case 3: // velocity based crossfade
                     part.Pkitmode = 1; // normal kit mode (multiple kit items playing)
                     part.PkitfadeType = 1;
                     value = 1; // just to be sure
-                }
-                else
-                {
+                    break;
+                case 4: // volume based crossfade
+                    part.Pkitmode = 1; // normal kit mode (multiple kit items playing)
+                    part.PkitfadeType = 2;
+                    value = 1; // just to be sure
+                    break;
+                default:
                     part.PkitfadeType = 0;
                     part.Pkitmode = value_int;
+                    break;
                 }
             }
             else
             {
                 value = part.Pkitmode;
-                if (value == 1 && part.PkitfadeType == 1)
-                    value = 3; // encode crossfade velocity mode
+                if (value == 1)
+                {
+                    // encode crossfade mode
+                    switch (part.PkitfadeType)
+                    {
+                    case 1:
+                        value = 3; // velocity based
+                        break;
+                    case 2:
+                        value = 4; // volume based
+                        break;
+                    case 0:
+                    default:
+                        // No change.
+                        break;
+                    }
+                }
             }
             break;
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -146,7 +146,7 @@ class Part
         uchar  Pvelsns;        // velocity sensing (amplitude velocity scale)
         uchar  Pveloffs;       // velocity offset
         uchar  Pkitmode;       // Part uses kit mode: 0 == off, 1 == on, 2 == "Single": only first applicable kit item can play
-        uchar  PkitfadeType;   // type of cross fade, 0 off (multi)
+        uchar  PkitfadeType;   // type of cross fade, 0 = off (multi), 1 = velocity based, 2 = volume based
         uchar  Pdrummode;      // if all keys are mapped and the system is 12tET (used for drums)
         uchar  Pkeymode;       // 0 = poly, 1 = mono, > 1 = legato;
         uint   PchannelATchoice;
@@ -199,7 +199,7 @@ class Part
         void ReleaseNotePos(int pos);
         void monoNoteHistoryRecall();
 
-        void startNewNotes        (int pos, size_t item, size_t currItem, Note, bool portamento);
+        void startNewNotes        (int pos, size_t item, size_t currItem, Note, bool portamento, float volumeAdjustment);
         void startLegato          (int pos, size_t item, size_t currItem, Note);
         void startLegatoPortamento(int pos, size_t item, size_t currItem, Note);
         float computeKitItemCrossfade(size_t item, int midiNote);

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -57,6 +57,7 @@ ADnote::ADnoteGlobal::ADnoteGlobal()
     , freqEnvelope{}
     , freqLFO{}
     , volume{0.0f}
+    , volumeAdjustment{1.0f}
     , randpanL{0.0f}
     , randpanR{0.0f}
     , fadeinAdjustment{0.0f}
@@ -74,6 +75,7 @@ ADnote::ADnoteGlobal::ADnoteGlobal(ADnoteGlobal const& o)
     , freqEnvelope{}
     , freqLFO{}
     , volume{o.volume}
+    , volumeAdjustment{o.volumeAdjustment}
     , randpanL{o.randpanL}
     , randpanR{o.randpanR}
     , fadeinAdjustment{o.fadeinAdjustment}
@@ -651,6 +653,7 @@ void ADnote::construct(size_t unison_total_size)
     initSubVoices(unison_total_size);
 
     globalnewamplitude = noteGlobal.volume
+                         * noteGlobal.volumeAdjustment
                          * noteGlobal.ampEnvelope->envout_dB()
                          * noteGlobal.ampLFO->amplfoout();
 }
@@ -1511,6 +1514,7 @@ void ADnote::computeWorkingParameters()
                        + noteGlobal.freqLFO->lfoout() * ctl.modwheel.relmod);
     globaloldamplitude = globalnewamplitude;
     globalnewamplitude = noteGlobal.volume
+                         * noteGlobal.volumeAdjustment
                          * noteGlobal.ampEnvelope->envout_dB()
                          * noteGlobal.ampLFO->amplfoout();
     float globalfilterpitch = noteGlobal.filterEnvelope->envout()

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -149,6 +149,7 @@ class ADnote
         void performPortamento(Note);
         void legatoFadeIn(Note);
         void legatoFadeOut();
+        void setVolumeAdjustment(float val) { noteGlobal.volumeAdjustment = val; }
 
     private:
         void construct(size_t unison_total_size);
@@ -228,6 +229,7 @@ class ADnote
             // AMPLITUDE GLOBAL PARAMETERS
             //****************************
             float volume;   // [ 0 .. 1 ]
+            float volumeAdjustment;
             float randpanL; // [ 0 .. 1 ]
             float randpanR;
             float fadeinAdjustment;

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -146,9 +146,10 @@ PADnote::PADnote(const PADnote &orig)
     auto& gpar = noteGlobal;
     auto& opar = orig.noteGlobal;
 
-    gpar.detune  = opar.detune;
-    gpar.volume  = opar.volume;
-    gpar.panning = opar.panning;
+    gpar.detune           = opar.detune;
+    gpar.volume           = opar.volume;
+    gpar.volumeAdjustment = opar.volumeAdjustment;
+    gpar.panning          = opar.panning;
 
     gpar.fadeinAdjustment = opar.fadeinAdjustment;
     gpar.punch = opar.punch;
@@ -349,6 +350,7 @@ void PADnote::computecurrentparameters()
         + noteGlobal.freqLFO->lfoout() * ctl.modwheel.relmod + noteGlobal.detune);
     globaloldamplitude = globalnewamplitude;
     globalnewamplitude = noteGlobal.volume
+        * noteGlobal.volumeAdjustment
         * noteGlobal.ampEnvelope->envout_dB()
         * noteGlobal.ampLFO->amplfoout();
 

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -57,6 +57,7 @@ class PADnote
         void performPortamento(Note);
         void legatoFadeIn(Note);
         void legatoFadeOut();
+        void setVolumeAdjustment(float val) { noteGlobal.volumeAdjustment = val; }
 
         void noteout(float* outl, float* outr);
         bool finished() const { return noteStatus == NOTE_DISABLED; }
@@ -112,6 +113,7 @@ class PADnote
             // AMPLITUDE GLOBAL PARAMETERS
             //****************************
             float volume;  // [ 0 .. 1 ]
+            float volumeAdjustment {1.0f};
             float panning; // [ 0 .. 1 ]
             float fadeinAdjustment;
 

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -74,6 +74,7 @@ SUBnote::SUBnote(SUBnoteParameters& parameters, Controller& ctl_, Note note_, bo
     , globalFilterR{}
     , noteStatus{NOTE_ENABLED}
     , firsttick{1}
+    , volumeAdjustment{1.0f}
     , lfilter{}
     , rfilter{}
     , tmpsmp{synth.getRuntime().genTmp1}
@@ -127,6 +128,7 @@ SUBnote::SUBnote(SUBnote const& orig)
     , noteStatus{orig.noteStatus}
     , firsttick{orig.firsttick}
     , volume{orig.volume}
+    , volumeAdjustment{orig.volumeAdjustment}
     , oldamplitude{orig.oldamplitude}
     , newamplitude{orig.newamplitude}
     , lfilter{}
@@ -604,7 +606,10 @@ void SUBnote::computecurrentparameters()
         computeallfiltercoefs();
 
     // Envelope
-    newamplitude = volume * ampEnvelope->envout_dB() * ampLFO->amplfoout();
+    newamplitude = volume
+        * volumeAdjustment
+        * ampEnvelope->envout_dB()
+        * ampLFO->amplfoout();
 
     // Filter
     if (globalFilterL != NULL)

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -59,6 +59,7 @@ class SUBnote
         void performPortamento(Note);
         void legatoFadeIn(Note);
         void legatoFadeOut();
+        void setVolumeAdjustment(float val) { volumeAdjustment = val; }
 
         void noteout(float* outl, float* outr);
         void releasekey();
@@ -110,6 +111,7 @@ class SUBnote
 
         int firsttick;
         float volume;
+        float volumeAdjustment;
         float oldamplitude;
         float newamplitude;
 

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -674,9 +674,9 @@ class PartUI {: {public Fl_Group, PartUI_}
             kitlist->deactivate();
 
         send_data(0, PART::control::kitMode, tmp, TOPLEVEL::type::Integer, npart);}
-        tooltip {Single = only 1st item in defined note range sounds} xywh {41 348 88 19} down_box BORDER_BOX labelsize 11 labelcolor 64 textfont 1 textsize 11 textcolor 64
-        code0 {o->add("Off");o->add("Multi");o->add("Single");o->add("Crossfade");}
-        code1 {if (part->PkitfadeType == 1) {o->value(3);} else {o->value(part->Pkitmode);}}
+        tooltip {Single = only 1st item in defined note range sounds} xywh {41 348 148 19} down_box BORDER_BOX labelsize 11 labelcolor 64 textfont 1 textsize 11 textcolor 64
+        code0 {o->add("Off");o->add("Multi");o->add("Single");o->add("Crossfade (velocity)");o->add("Crossfade (volume)");}
+        code1 {if (part->PkitfadeType == 1) {o->value(3);} else if (part->PkitfadeType == 2) {o->value(4);} else {o->value(part->Pkitmode);}}
         code2 {partKitOn = o->value() > 0;}
         code3 {if (!partKitOn) kitlist->deactivate();}
       } {}
@@ -1522,13 +1522,17 @@ class PartUI {: {public Fl_Group, PartUI_}
             break;
 
         case PART::control::kitMode:
-            if (part->PkitfadeType == 1)
+            switch (part->PkitfadeType)
             {
+            case 1:
                 kitMode->value(3);
-            }
-            else
-            {
+                break;
+            case 2:
+                kitMode->value(4);
+                break;
+            default:
                 kitMode->value(valInt);
+                break;
             }
             partKitOn =  (kitMode->value() > 0);
             if (partKitOn > 0)
@@ -1926,13 +1930,17 @@ class PartUI {: {public Fl_Group, PartUI_}
     code {//
         instrumentkitlist->copy_label(textMsgBuffer.fetch(collect_readData(synth, textMsgBuffer.push("Kit List"), npart, TOPLEVEL::windowTitle)).c_str());
         drumMode->value(part->Pdrummode);
-            if (part->PkitfadeType == 1)
+            switch (part->PkitfadeType)
             {
+            case 1:
                 kitMode->value(3);
-            }
-            else
-            {
+                break;
+            case 2:
+                kitMode->value(4);
+                break;
+            default:
                 kitMode->value(part->Pkitmode);
+                break;
             }
         if (kitMode->value())
         {

--- a/src/globals.h
+++ b/src/globals.h
@@ -724,7 +724,8 @@ namespace PART // usage PART::control::volume
         Off = 0,
         Multi,
         Single,
-        CrossFade
+        CrossFadeVel,
+        CrossFadeVol,
     };
 
     enum engine : uchar {


### PR DESCRIPTION
We also rename the existing crossfade to "Crossfade (velocity)". This is useful for crossfaded instruments where either the velocity has audible properties besides volume, such as modulation strength, or the instrument doesn't respond to velocity. Crossfading by volume will in most such cases provide a better result.