### PR TITLE
Fix empty bank file after failed startup

### DIFF
--- a/src/Misc/Bank.h
+++ b/src/Misc/Bank.h
@@ -175,6 +175,7 @@ class Bank
         size_t generateSingleRoot(string const& newRoot, bool clear = true);
 
         uint getVersion() {return version; }
+        bool isEmpty()    {return roots.empty(); }
 
     private:
         uint version;

--- a/src/Misc/SynthEngine.cpp
+++ b/src/Misc/SynthEngine.cpp
@@ -2666,6 +2666,9 @@ bool SynthEngine::installBanks()
 
 bool SynthEngine::saveBanks()
 {
+    if (bank.isEmpty())
+        return true;
+
     string name = file::configDir() + '/' + YOSHIMI;
     string bankname = name + ".banks";
 

--- a/src/MusicIO/MusicClient.cpp
+++ b/src/MusicIO/MusicClient.cpp
@@ -85,6 +85,7 @@ void MusicClient::createEngines(audio_driver useAudio, midi_driver useMidi)
 #endif /*ALSA*/
 #endif /*LV2*/
         default:
+            audioIO.reset();
             break;
     }
 
@@ -107,6 +108,7 @@ void MusicClient::createEngines(audio_driver useAudio, midi_driver useMidi)
 #endif /*ALSA*/
 #endif /*LV2*/
         default:
+            midiIO.reset();
             break;
     }
 


### PR DESCRIPTION
This problem seems to have been caused by an interplay of various recent changes

- changes to the start-up sequence done two years ago (for the `GuiDataExchange`)
- changes to the configuration and start-up / shutdown to reliably persist the banks
- changes in preparation for MXML 4 : the new XMLStore is always initialised with headers and can thus be persisted even without adding data.

The first problem was stale state in MusicClient, after unsuccessfully probing an IO backend. This caused the "null backend" erroneously to fail. The second problem was that the bank file could be saved before the SynthEngine was fully initialised, whenever "Yoshimi staged a strategic retreat"